### PR TITLE
Allow stop packets with arbitary signal codes

### DIFF
--- a/src/gdbstub_impl/mod.rs
+++ b/src/gdbstub_impl/mod.rs
@@ -567,6 +567,11 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 res.write_str("S05")?;
                 Ok(None)
             }
+            StopReason::Signal(code) => {
+                res.write_str("S")?;
+                res.write_num(code)?;
+                Ok(None)
+            }
             StopReason::Halted => {
                 res.write_str("W00")?;
                 Ok(Some(DisconnectReason::TargetHalted))

--- a/src/target.rs
+++ b/src/target.rs
@@ -321,6 +321,8 @@ pub enum StopReason<U> {
         /// Address of watched memory
         addr: U,
     },
+    /// The program received a signal
+    Signal(u8),
 }
 
 /// Describes how the target should resume the specified thread.


### PR DESCRIPTION
Currently `gdbstub` only allows SIGTRAP signals to be used in stop reply packets, however there are other signals that are useful to report (in particular I want to report SIGSEGV).

This PR partially issue report with _a possible_ way of allowing this. However, maybe you want to have explicit enum variants for all reasonable stop reasons, and this technically a breaking change, so may need to wait to the next non-patch release.