### PR TITLE
Add (partial) support for RISC-V

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -12,6 +12,7 @@
 pub mod arm;
 pub mod mips;
 pub mod msp430;
+pub mod riscv;
 mod traits;
 pub mod x86;
 

--- a/src/arch/riscv/mod.rs
+++ b/src/arch/riscv/mod.rs
@@ -1,0 +1,33 @@
+//! Support for the [RISC-V](https://riscv.org/) architecture.
+//!
+//! *Note*: currently only supports integer version of the ISA
+
+use crate::arch::Arch;
+
+pub mod reg;
+
+/// Implements `Arch` for 32-bit RISC-V.
+#[derive(Eq, PartialEq)]
+pub struct Riscv32;
+
+/// Implements `Arch` for 64-bit RISC-V.
+#[derive(Eq, PartialEq)]
+pub struct Riscv64;
+
+impl Arch for Riscv32 {
+    type Usize = u32;
+    type Registers = reg::RiscvCoreRegs<u32>;
+
+    fn target_description_xml() -> Option<&'static str> {
+        Some(r#"<target version="1.0"><architecture>riscv</architecture></target>"#)
+    }
+}
+
+impl Arch for Riscv64 {
+    type Usize = u64;
+    type Registers = reg::RiscvCoreRegs<u64>;
+
+    fn target_description_xml() -> Option<&'static str> {
+        Some(r#"<target version="1.0"><architecture>riscv64</architecture></target>"#)
+    }
+}

--- a/src/arch/riscv/mod.rs
+++ b/src/arch/riscv/mod.rs
@@ -1,6 +1,6 @@
 //! Support for the [RISC-V](https://riscv.org/) architecture.
 //!
-//! *Note*: currently only supports integer version of the ISA
+//! *Note*: currently only supports integer versions of the ISA.
 
 use crate::arch::Arch;
 

--- a/src/arch/riscv/reg/mod.rs
+++ b/src/arch/riscv/reg/mod.rs
@@ -1,0 +1,5 @@
+//! `GdbRegister` structs for RISC-V architectures.
+
+mod riscv;
+
+pub use riscv::RiscvCoreRegs;

--- a/src/arch/riscv/reg/riscv.rs
+++ b/src/arch/riscv/reg/riscv.rs
@@ -1,19 +1,18 @@
-//! RISC-V Register Definitions.
-//!
-//! Useful links:
-//!     - [GNU binutils-gdb XML Descriptions](https://github.com/bminor/binutils-gdb/blob/master/gdb/features/riscv)
-//!     - [riscv-tdep.h](https://github.com/bminor/binutils-gdb/blob/master/gdb/riscv-tdep.h)
 use crate::arch::Registers;
 use crate::internal::LeBytes;
 use num_traits::PrimInt;
 
-/// RISC-V Integer registers
+/// RISC-V Integer registers.
 ///
 /// The register width is set to `u32` or `u64` based on the `<U>` type.
+///
+/// Useful links:
+/// * [GNU binutils-gdb XML descriptions](https://github.com/bminor/binutils-gdb/blob/master/gdb/features/riscv)
+/// * [riscv-tdep.h](https://github.com/bminor/binutils-gdb/blob/master/gdb/riscv-tdep.h)
 #[derive(Default)]
 pub struct RiscvCoreRegs<U> {
     /// General purpose registers (x0-x31)
-    pub r: [U; 32],
+    pub x: [U; 32],
     /// Program counter
     pub pc: U,
 }
@@ -36,7 +35,7 @@ where
         }
 
         // Write GPRs
-        for reg in self.r.iter() {
+        for reg in self.x.iter() {
             write_le_bytes!(reg);
         }
 
@@ -57,7 +56,7 @@ where
             .map(|c| U::from_le_bytes(c).unwrap());
 
         // Read GPRs
-        for reg in self.r.iter_mut() {
+        for reg in self.x.iter_mut() {
             *reg = regs.next().ok_or(())?
         }
         self.pc = regs.next().ok_or(())?;
@@ -65,6 +64,7 @@ where
         if regs.next().is_some() {
             return Err(());
         }
+
         Ok(())
     }
 }

--- a/src/arch/riscv/reg/riscv.rs
+++ b/src/arch/riscv/reg/riscv.rs
@@ -1,0 +1,70 @@
+//! RISC-V Register Definitions.
+//!
+//! Useful links:
+//!     - [GNU binutils-gdb XML Descriptions](https://github.com/bminor/binutils-gdb/blob/master/gdb/features/riscv)
+//!     - [riscv-tdep.h](https://github.com/bminor/binutils-gdb/blob/master/gdb/riscv-tdep.h)
+use crate::arch::Registers;
+use crate::internal::LeBytes;
+use num_traits::PrimInt;
+
+/// RISC-V Integer registers
+///
+/// The register width is set to `u32` or `u64` based on the `<U>` type.
+#[derive(Default)]
+pub struct RiscvCoreRegs<U> {
+    /// General purpose registers (x0-x31)
+    pub r: [U; 32],
+    /// Program counter
+    pub pc: U,
+}
+
+impl<U> Registers for RiscvCoreRegs<U>
+where
+    U: PrimInt + LeBytes + Default,
+{
+    fn gdb_serialize(&self, mut write_byte: impl FnMut(Option<u8>)) {
+        macro_rules! write_le_bytes {
+            ($value:expr) => {
+                let mut buf = [0; 16];
+                // infallible (unless digit is a >128 bit number)
+                let len = $value.to_le_bytes(&mut buf).unwrap();
+                let buf = &buf[..len];
+                for b in buf {
+                    write_byte(Some(*b));
+                }
+            };
+        }
+
+        // Write GPRs
+        for reg in self.r.iter() {
+            write_le_bytes!(reg);
+        }
+
+        // Program Counter is regnum 33
+        write_le_bytes!(&self.pc);
+    }
+
+    fn gdb_deserialize(&mut self, bytes: &[u8]) -> Result<(), ()> {
+        let ptrsize = core::mem::size_of::<U>();
+
+        // ensure bytes.chunks_exact(ptrsize) won't panic
+        if bytes.len() % ptrsize != 0 {
+            return Err(());
+        }
+
+        let mut regs = bytes
+            .chunks_exact(ptrsize)
+            .map(|c| U::from_le_bytes(c).unwrap());
+
+        // Read GPRs
+        for reg in self.r.iter_mut() {
+            *reg = regs.next().ok_or(())?
+        }
+        self.pc = regs.next().ok_or(())?;
+
+        if regs.next().is_some() {
+            return Err(());
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Hey,

This PR contains two commits:
- A first that implements the `Arch` trait for RISC-V 32/64 bit
- A second one that add support for the "Read register command" of the RSP protocol ('p' command), this is actually needed for debuging RISC-V programs. GDB is querying some specific CSR registers through this command (mstatus, mpriv, ...).

Currently I have a RISC-V softfp toolchain for testing. I will try to add support for floating-point RISC-V 32 and 64 as well soon.
Let me know if the commits need some rework.

Thanks for your awesome `gdbstub` crate, it works like a charm on my emulator !
Thomas.