### PR TITLE
specify cfg-if 0.1.10 or later

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["gdb", "emulation", "no_std", "debugging"]
 categories = ["development-tools::debugging", "embedded", "emulators", "network-programming", "no-std"]
 
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "0.1.10"
 log = "0.4"
 managed = { version = "0.8", default-features = false }
 num-traits = { version = "0.2", default-features = false }


### PR DESCRIPTION
`cargo build` fails if cfg-if is 0.1.9 or older.

It seems that [this change](https://github.com/alexcrichton/cfg-if/pull/28) is needed to compile [this part](https://github.com/daniel5151/gdbstub/blob/da716bdd7b/src/protocol/console_output.rs#L43-L48).