### PR TITLE
Fix trait terminology

### DIFF
--- a/src/target/ext/mod.rs
+++ b/src/target/ext/mod.rs
@@ -101,7 +101,7 @@
 //!
 //! - (library) Define a `trait OptExt: Target { ... }` with all the optional
 //!   methods:
-//!    - Making `OptExt` a supertrait of `Target` enables using `Target`'s
+//!    - Making `OptExt` a subtrait of `Target` enables using `Target`'s
 //!      associated types.
 //!
 //! ```rust,ignore


### PR DESCRIPTION
OptExt is a subtrait of Target, not the opposite. See https://doc.rust-lang.org/reference/items/traits.html#supertraits

Also thanks for the read 😄 