### PR TITLE
Allow `Target` to override `Arch`'s target description

### DIFF
--- a/src/target/ext/base/description.rs
+++ b/src/target/ext/base/description.rs
@@ -1,0 +1,15 @@
+use crate::arch::Arch;
+use crate::target::Target;
+
+/// Basic operation to return an XML-formatted target description string
+/// to the GDB client.
+pub trait TargetDescription: Target {
+    /// Returns an optional XML description for the target to GDB.
+    fn target_description_xml(&self) -> &'static str {
+        <Self::Arch as Arch>::target_description_xml().unwrap()
+    }
+}
+
+/// See [`TargetDescription`]
+pub type TargetDescriptionOps<'a, T> =
+    &'a mut dyn TargetDescription<Arch = <T as Target>::Arch, Error = <T as Target>::Error>;

--- a/src/target/ext/base/mod.rs
+++ b/src/target/ext/base/mod.rs
@@ -7,6 +7,11 @@
 pub mod multithread;
 pub mod singlethread;
 
+mod description;
+
+pub use description::TargetDescription;
+pub use description::TargetDescriptionOps;
+
 /// Base operations for single/multi threaded targets.
 pub enum BaseOps<'a, A, E> {
     /// Single-threaded target

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -239,6 +239,11 @@ pub trait Target {
     fn section_offsets(&mut self) -> Option<ext::section_offsets::SectionOffsetsOps<Self>> {
         None
     }
+
+    /// Handle requests for the target's XML description for GDB.
+    fn target_description(&mut self) -> Option<ext::base::TargetDescriptionOps<Self>> {
+        None
+    }
 }
 
 macro_rules! impl_dyn_target {


### PR DESCRIPTION
Continued from #31. Related to #12.
Currently we can only report a single and static target description to GDB that gets determined at compile-time.
This however does not work for systems that determine the running architecture at runtime (e.g. for virtualization).

As such, we can add a new function to `Target` that can return any arbitrary `String` description (and by default it will use the old static method).

Something worth debating is whether or not we should return a `&'static str` or a `String` from `Target::description_xml()`.
The former doesn't require an extra copy or allocation, while the latter allows a `Target` to build a custom XML description string.