### PR TITLE
Add `TargetDescriptionXmlOverride` extension

### DIFF
--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -15,6 +15,7 @@ use crate::emu::{Emu, Event};
 mod extended_mode;
 mod monitor_cmd;
 mod section_offsets;
+mod target_description_xml_override;
 
 /// Turn a `ArmCoreRegId` into an internal register number of `armv4t_emu`.
 fn cpu_reg_id(id: ArmCoreRegId) -> Option<u8> {
@@ -53,6 +54,13 @@ impl Target for Emu {
     }
 
     fn section_offsets(&mut self) -> Option<target::ext::section_offsets::SectionOffsetsOps<Self>> {
+        Some(self)
+    }
+
+    fn target_xml_override(
+        &mut self,
+    ) -> Option<target::ext::target_description_xml_override::TargetDescriptionXmlOverrideOps<Self>>
+    {
         Some(self)
     }
 }

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -57,7 +57,7 @@ impl Target for Emu {
         Some(self)
     }
 
-    fn target_xml_override(
+    fn target_description_xml_override(
         &mut self,
     ) -> Option<target::ext::target_description_xml_override::TargetDescriptionXmlOverrideOps<Self>>
     {

--- a/examples/armv4t/gdb/target_description_xml_override.rs
+++ b/examples/armv4t/gdb/target_description_xml_override.rs
@@ -1,0 +1,9 @@
+use gdbstub::target;
+
+use crate::emu::Emu;
+
+impl target::ext::target_description_xml_override::TargetDescriptionXmlOverride for Emu {
+    fn target_description_xml(&self) -> &str {
+        r#"<target version="1.0"><!-- custom override string --><architecture>armv4t</architecture></target>"#
+    }
+}

--- a/src/arch/traits.rs
+++ b/src/arch/traits.rs
@@ -63,18 +63,17 @@ pub trait Arch {
     /// separate from the main `Registers` structure.
     type RegId: RegId;
 
-    /// (optional) Return the platform's `features.xml` file.
+    /// (optional) Return the target's description XML file (`target.xml`).
     ///
-    /// Implementing this method enables `gdb` to automatically detect the
+    /// Implementing this method enables GDB to automatically detect the
     /// target's architecture, saving the hassle of having to run `set
     /// architecture <arch>` when starting a debugging session.
     ///
     /// These descriptions can be quite succinct. For example, the target
-    /// description for an `armv4t` platform can be as simple as:
+    /// description for an `armv4t` target can be as simple as:
     ///
     /// ```
-    /// r#"<target version="1.0"><architecture>armv4t</architecture></target>"#
-    /// # ;
+    /// r#"<target version="1.0"><architecture>armv4t</architecture></target>"#;
     /// ```
     ///
     /// See the [GDB docs](https://sourceware.org/gdb/current/onlinedocs/gdb/Target-Description-Format.html)

--- a/src/gdbstub_impl/mod.rs
+++ b/src/gdbstub_impl/mod.rs
@@ -304,7 +304,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 // res.write_str("ConditionalBreakpoints+;")?;
 
                 if T::Arch::target_description_xml().is_some()
-                    || target.target_xml_override().is_some()
+                    || target.target_description_xml_override().is_some()
                 {
                     res.write_str(";qXfer:features:read+")?;
                 }
@@ -318,7 +318,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             ext::Base::qXferFeaturesRead(cmd) => {
                 #[allow(clippy::redundant_closure)]
                 let xml = target
-                    .target_xml_override()
+                    .target_description_xml_override()
                     .map(|ops| ops.target_description_xml())
                     .or_else(|| T::Arch::target_description_xml());
 

--- a/src/target/ext/mod.rs
+++ b/src/target/ext/mod.rs
@@ -250,3 +250,4 @@ pub mod breakpoints;
 pub mod extended_mode;
 pub mod monitor_cmd;
 pub mod section_offsets;
+pub mod target_description_xml_override;

--- a/src/target/ext/target_description_xml_override.rs
+++ b/src/target/ext/target_description_xml_override.rs
@@ -10,19 +10,9 @@ use crate::target::Target;
 pub trait TargetDescriptionXmlOverride: Target {
     /// Return the target's description XML file (`target.xml`).
     ///
-    /// Implementing this method enables GDB to automatically detect the
-    /// target's architecture, saving the hassle of having to run `set
-    /// architecture <arch>` when starting a debugging session.
-    ///
-    /// These descriptions can be quite succinct. For example, the target
-    /// description for an `armv4t` target can be as simple as:
-    ///
-    /// ```
-    /// r#"<target version="1.0"><architecture>armv4t</architecture></target>"#;
-    /// ```
-    ///
-    /// See the [GDB docs](https://sourceware.org/gdb/current/onlinedocs/gdb/Target-Description-Format.html)
-    /// for details on the target description XML format.
+    /// Refer to the
+    /// [target_description_xml](crate::arch::Arch::target_description_xml)
+    /// docs for more info.
     fn target_description_xml(&self) -> &str;
 }
 

--- a/src/target/ext/target_description_xml_override.rs
+++ b/src/target/ext/target_description_xml_override.rs
@@ -1,0 +1,32 @@
+//! Override the target description XML specified by `Target::Arch`.
+use crate::target::Target;
+
+/// Target Extension - Override the target description XML specified by
+/// `Target::Arch`.
+///
+/// _Note:_ Unless you're working with a particularly dynamic,
+/// runtime-configurable target, it's unlikely that you'll need to implement
+/// this extension.
+pub trait TargetDescriptionXmlOverride: Target {
+    /// Return the target's description XML file (`target.xml`).
+    ///
+    /// Implementing this method enables GDB to automatically detect the
+    /// target's architecture, saving the hassle of having to run `set
+    /// architecture <arch>` when starting a debugging session.
+    ///
+    /// These descriptions can be quite succinct. For example, the target
+    /// description for an `armv4t` target can be as simple as:
+    ///
+    /// ```
+    /// r#"<target version="1.0"><architecture>armv4t</architecture></target>"#;
+    /// ```
+    ///
+    /// See the [GDB docs](https://sourceware.org/gdb/current/onlinedocs/gdb/Target-Description-Format.html)
+    /// for details on the target description XML format.
+    fn target_description_xml(&self) -> &str;
+}
+
+define_ext!(
+    TargetDescriptionXmlOverrideOps,
+    TargetDescriptionXmlOverride
+);

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -239,6 +239,13 @@ pub trait Target {
     fn section_offsets(&mut self) -> Option<ext::section_offsets::SectionOffsetsOps<Self>> {
         None
     }
+
+    /// Override the target description XML specified by `Target::Arch`.
+    fn target_xml_override(
+        &mut self,
+    ) -> Option<ext::target_description_xml_override::TargetDescriptionXmlOverrideOps<Self>> {
+        None
+    }
 }
 
 macro_rules! impl_dyn_target {
@@ -277,6 +284,13 @@ macro_rules! impl_dyn_target {
 
             fn section_offsets(&mut self) -> Option<ext::section_offsets::SectionOffsetsOps<Self>> {
                 (**self).section_offsets()
+            }
+
+            fn target_xml_override(
+                &mut self,
+            ) -> Option<ext::target_description_xml_override::TargetDescriptionXmlOverrideOps<Self>>
+            {
+                (**self).target_xml_override()
             }
         }
     };

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -241,7 +241,7 @@ pub trait Target {
     }
 
     /// Override the target description XML specified by `Target::Arch`.
-    fn target_xml_override(
+    fn target_description_xml_override(
         &mut self,
     ) -> Option<ext::target_description_xml_override::TargetDescriptionXmlOverrideOps<Self>> {
         None
@@ -286,11 +286,11 @@ macro_rules! impl_dyn_target {
                 (**self).section_offsets()
             }
 
-            fn target_xml_override(
+            fn target_description_xml_override(
                 &mut self,
             ) -> Option<ext::target_description_xml_override::TargetDescriptionXmlOverrideOps<Self>>
             {
-                (**self).target_xml_override()
+                (**self).target_description_xml_override()
             }
         }
     };


### PR DESCRIPTION
Building off of @DrChat's work in #42 (closes #42)

Remember how [I said](https://github.com/daniel5151/gdbstub/pull/42#issuecomment-802329081) I'd try and tackle #12 as part of this PR as well? Well... after refreshing myself on the details of the underlying `qXfer:features:read` API, I realized that my idea wouldn't actually work. The changes will require a bit more thought and effort, and aren't something I'd be able to hack out in an afternoon. 

As such, I've kept this PR's scope limited to just allowing target-dependent target description XML files.