### PR TITLE
fix RiscvRegId's from_raw_id for RISCV64

### DIFF
--- a/src/arch/riscv/mod.rs
+++ b/src/arch/riscv/mod.rs
@@ -15,7 +15,7 @@ pub enum Riscv64 {}
 impl Arch for Riscv32 {
     type Usize = u32;
     type Registers = reg::RiscvCoreRegs<u32>;
-    type RegId = reg::id::RiscvRegId;
+    type RegId = reg::id::RiscvRegId<u32>;
     type BreakpointKind = usize;
 
     fn target_description_xml() -> Option<&'static str> {
@@ -26,7 +26,7 @@ impl Arch for Riscv32 {
 impl Arch for Riscv64 {
     type Usize = u64;
     type Registers = reg::RiscvCoreRegs<u64>;
-    type RegId = reg::id::RiscvRegId;
+    type RegId = reg::id::RiscvRegId<u64>;
     type BreakpointKind = usize;
 
     fn target_description_xml() -> Option<&'static str> {

--- a/src/arch/riscv/reg/id.rs
+++ b/src/arch/riscv/reg/id.rs
@@ -3,7 +3,7 @@ use crate::arch::RegId;
 /// RISC-V Register identifier.
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
-pub enum RiscvRegId {
+pub enum RiscvRegId<U> {
     /// General Purpose Register (x0-x31).
     Gpr(u8),
     /// Floating Point Register (f0-f31).
@@ -14,18 +14,30 @@ pub enum RiscvRegId {
     Csr(u16),
     /// Privilege level.
     Priv,
+
+    #[doc(hidden)]
+    _Marker(core::marker::PhantomData<U>),
 }
 
-impl RegId for RiscvRegId {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
-        let reg_size = match id {
-            0..=31 => (Self::Gpr(id as u8), 4),
-            32 => (Self::Pc, 4),
-            33..=64 => (Self::Fpr((id - 33) as u8), 4),
-            65..=4160 => (Self::Csr((id - 65) as u16), 4),
-            4161 => (Self::Priv, 1),
-            _ => return None,
-        };
-        Some(reg_size)
-    }
+macro_rules! impl_riscv_reg_id {
+    ($usize:ty) => {
+        impl RegId for RiscvRegId<$usize> {
+            fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+                const USIZE: usize = core::mem::size_of::<$usize>();
+
+                let reg_size = match id {
+                    0..=31 => (Self::Gpr(id as u8), USIZE),
+                    32 => (Self::Pc, USIZE),
+                    33..=64 => (Self::Fpr((id - 33) as u8), USIZE),
+                    65..=4160 => (Self::Csr((id - 65) as u16), USIZE),
+                    4161 => (Self::Priv, 1),
+                    _ => return None,
+                };
+                Some(reg_size)
+            }
+        }
+    };
 }
+
+impl_riscv_reg_id!(u32);
+impl_riscv_reg_id!(u64);


### PR DESCRIPTION
Hello. For RISC-V 64, the size of Csr and Gpr is 64bit. However, the RiscvRegId's `from_raw_id` returns 4 bytes for both RV32 and RV64. Thus I create a new type for RV64 and re-implement `from_raw_id`. Now, the `RegId::from_raw_id()` works correctly on RV64 architecture.

I am new Rust. I think my implementation is a little ugly but I have no idea how to implement this elegantly. The `RiscvRegId64` and `RiscvRegId` have same definition. I define this new type only for override `from_raw_id`. I have tried to define something like `RiscvRegId<U>`. But the compiler complains that `U` is an unused parameter.