### PR TITLE
Reverse execution

### DIFF
--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -2,7 +2,10 @@ use core::convert::TryInto;
 
 use armv4t_emu::{reg, Memory};
 use gdbstub::target;
-use gdbstub::target::ext::base::singlethread::{ResumeAction, SingleThreadOps, StopReason};
+use gdbstub::target::ext::base::singlethread::{
+    ResumeAction, SingleThreadOps, SingleThreadReverseContOps, SingleThreadReverseStepOps,
+    StopReason,
+};
 use gdbstub::target::ext::breakpoints::WatchKind;
 use gdbstub::target::{Target, TargetError, TargetResult};
 use gdbstub_arch::arm::reg::id::ArmCoreRegId;
@@ -157,6 +160,14 @@ impl SingleThreadOps for Emu {
         Some(self)
     }
 
+    fn support_reverse_cont(&mut self) -> Option<SingleThreadReverseContOps<Self>> {
+        Some(self)
+    }
+
+    fn support_reverse_step(&mut self) -> Option<SingleThreadReverseStepOps<Self>> {
+        Some(self)
+    }
+
     fn support_resume_range_step(
         &mut self,
     ) -> Option<target::ext::base::singlethread::SingleThreadRangeSteppingOps<Self>> {
@@ -196,6 +207,32 @@ impl target::ext::base::SingleRegisterAccess<()> for Emu {
         } else {
             Err(().into())
         }
+    }
+}
+
+impl target::ext::base::singlethread::SingleThreadReverseCont for Emu {
+    fn reverse_cont(
+        &mut self,
+        check_gdb_interrupt: &mut dyn FnMut() -> bool,
+    ) -> Result<StopReason<u32>, Self::Error> {
+        // FIXME: actually implement reverse step
+        eprintln!(
+            "FIXME: Not actually reverse-continuing. Performing forwards continue instead..."
+        );
+        self.resume(ResumeAction::Continue, check_gdb_interrupt)
+    }
+}
+
+impl target::ext::base::singlethread::SingleThreadReverseStep for Emu {
+    fn reverse_step(
+        &mut self,
+        check_gdb_interrupt: &mut dyn FnMut() -> bool,
+    ) -> Result<StopReason<u32>, Self::Error> {
+        // FIXME: actually implement reverse step
+        eprintln!(
+            "FIXME: Not actually reverse-stepping. Performing single forwards step instead..."
+        );
+        self.resume(ResumeAction::Step, check_gdb_interrupt)
     }
 }
 

--- a/src/gdbstub_impl/ext/mod.rs
+++ b/src/gdbstub_impl/ext/mod.rs
@@ -15,5 +15,6 @@ mod base;
 mod breakpoints;
 mod extended_mode;
 mod monitor_cmd;
+mod reverse_exec;
 mod section_offsets;
 mod single_register_access;

--- a/src/gdbstub_impl/ext/reverse_exec.rs
+++ b/src/gdbstub_impl/ext/reverse_exec.rs
@@ -1,0 +1,141 @@
+use super::prelude::*;
+use crate::protocol::commands::ext::{ReverseCont, ReverseStep};
+
+use crate::arch::Arch;
+use crate::protocol::SpecificIdKind;
+use crate::target::ext::base::multithread::{MultiThreadReverseCont, MultiThreadReverseStep};
+use crate::target::ext::base::singlethread::{SingleThreadReverseCont, SingleThreadReverseStep};
+use crate::target::ext::base::BaseOps;
+
+enum ReverseContOps<'a, A: Arch, E> {
+    SingleThread(&'a mut dyn SingleThreadReverseCont<Arch = A, Error = E>),
+    MultiThread(&'a mut dyn MultiThreadReverseCont<Arch = A, Error = E>),
+}
+
+enum ReverseStepOps<'a, A: Arch, E> {
+    SingleThread(&'a mut dyn SingleThreadReverseStep<Arch = A, Error = E>),
+    MultiThread(&'a mut dyn MultiThreadReverseStep<Arch = A, Error = E>),
+}
+
+impl<T: Target, C: Connection> GdbStubImpl<T, C> {
+    pub(crate) fn handle_reverse_cont(
+        &mut self,
+        res: &mut ResponseWriter<C>,
+        target: &mut T,
+        command: ReverseCont,
+    ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
+        // Resolve the reverse-continue operations. Error out if the target does not
+        // support it.
+        let ops = match target.base_ops() {
+            BaseOps::MultiThread(ops) => match ops.support_reverse_cont() {
+                Some(ops) => ReverseContOps::MultiThread(ops),
+                None => return Ok(HandlerStatus::Handled),
+            },
+            BaseOps::SingleThread(ops) => match ops.support_reverse_cont() {
+                Some(ops) => ReverseContOps::SingleThread(ops),
+                None => return Ok(HandlerStatus::Handled),
+            },
+        };
+
+        let handler_status = match command {
+            ReverseCont::bc(_) => {
+                // FIXME: look into why this isn't being optimized out.
+                crate::__dead_code_marker!("bc", "impl");
+
+                // FIXME: This block is duplicated from the vCont code.
+                let mut err = Ok(());
+                let mut check_gdb_interrupt = || match res.as_conn().peek() {
+                    Ok(Some(0x03)) => true, // 0x03 is the interrupt byte
+                    Ok(Some(_)) => false,   // it's nothing that can't wait...
+                    Ok(None) => false,
+                    Err(e) => {
+                        err = Err(Error::ConnectionRead(e));
+                        true // break ASAP if a connection error occurred
+                    }
+                };
+
+                let stop_reason = match ops {
+                    ReverseContOps::MultiThread(ops) => ops
+                        .reverse_cont(&mut check_gdb_interrupt)
+                        .map_err(Error::TargetError)?,
+                    ReverseContOps::SingleThread(ops) => ops
+                        .reverse_cont(&mut check_gdb_interrupt)
+                        .map_err(Error::TargetError)?
+                        .into(),
+                };
+
+                err?;
+
+                // FIXME: properly handle None case
+                self.finish_exec(res, target, stop_reason)?
+                    .ok_or(Error::PacketUnexpected)?
+            }
+        };
+
+        Ok(handler_status)
+    }
+
+    // FIXME: De-duplicate with above code?
+    pub(crate) fn handle_reverse_step(
+        &mut self,
+        res: &mut ResponseWriter<C>,
+        target: &mut T,
+        command: ReverseStep,
+    ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
+        // Resolve the reverse-step operations. Error out if the target does not
+        // support it.
+        let ops = match target.base_ops() {
+            BaseOps::MultiThread(ops) => match ops.support_reverse_step() {
+                Some(ops) => ReverseStepOps::MultiThread(ops),
+                None => return Ok(HandlerStatus::Handled),
+            },
+            BaseOps::SingleThread(ops) => match ops.support_reverse_step() {
+                Some(ops) => ReverseStepOps::SingleThread(ops),
+                None => return Ok(HandlerStatus::Handled),
+            },
+        };
+
+        let handler_status = match command {
+            ReverseStep::bs(_) => {
+                // FIXME: look into why this isn't being optimized out.
+                crate::__dead_code_marker!("bs", "impl");
+
+                let tid = match self.current_resume_tid {
+                    // NOTE: Can't single-step all cores.
+                    SpecificIdKind::All => return Err(Error::PacketUnexpected),
+                    SpecificIdKind::WithId(tid) => tid,
+                };
+
+                // FIXME: This block is duplicated from the vCont code.
+                let mut err = Ok(());
+                let mut check_gdb_interrupt = || match res.as_conn().peek() {
+                    Ok(Some(0x03)) => true, // 0x03 is the interrupt byte
+                    Ok(Some(_)) => false,   // it's nothing that can't wait...
+                    Ok(None) => false,
+                    Err(e) => {
+                        err = Err(Error::ConnectionRead(e));
+                        true // break ASAP if a connection error occurred
+                    }
+                };
+
+                let stop_reason = match ops {
+                    ReverseStepOps::MultiThread(ops) => ops
+                        .reverse_step(tid, &mut check_gdb_interrupt)
+                        .map_err(Error::TargetError)?,
+                    ReverseStepOps::SingleThread(ops) => ops
+                        .reverse_step(&mut check_gdb_interrupt)
+                        .map_err(Error::TargetError)?
+                        .into(),
+                };
+
+                err?;
+
+                // FIXME: properly handle None case
+                self.finish_exec(res, target, stop_reason)?
+                    .ok_or(Error::PacketUnexpected)?
+            }
+        };
+
+        Ok(handler_status)
+    }
+}

--- a/src/gdbstub_impl/mod.rs
+++ b/src/gdbstub_impl/mod.rs
@@ -234,6 +234,8 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Command::ExtendedMode(cmd) => self.handle_extended_mode(res, target, cmd),
             Command::MonitorCmd(cmd) => self.handle_monitor_cmd(res, target, cmd),
             Command::SectionOffsets(cmd) => self.handle_section_offsets(res, target, cmd),
+            Command::ReverseCont(cmd) => self.handle_reverse_cont(res, target, cmd),
+            Command::ReverseStep(cmd) => self.handle_reverse_step(res, target, cmd),
         }
     }
 }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -79,6 +79,8 @@ macro_rules! commands {
                 trait Hack {
                     fn base(&mut self) -> Option<()>;
                     fn single_register_access(&mut self) -> Option<()>;
+                    fn reverse_step(&mut self) -> Option<()>;
+                    fn reverse_cont(&mut self) -> Option<()>;
                 }
 
                 impl<T: Target> Hack for T {
@@ -91,6 +93,22 @@ macro_rules! commands {
                         match self.base_ops() {
                             BaseOps::SingleThread(ops) => ops.single_register_access().map(drop),
                             BaseOps::MultiThread(ops) => ops.single_register_access().map(drop),
+                        }
+                    }
+
+                    fn reverse_step(&mut self) -> Option<()> {
+                        use crate::target::ext::base::BaseOps;
+                        match self.base_ops() {
+                            BaseOps::SingleThread(ops) => ops.support_reverse_step().map(drop),
+                            BaseOps::MultiThread(ops) => ops.support_reverse_step().map(drop),
+                        }
+                    }
+
+                    fn reverse_cont(&mut self) -> Option<()> {
+                        use crate::target::ext::base::BaseOps;
+                        match self.base_ops() {
+                            BaseOps::SingleThread(ops) => ops.support_reverse_cont().map(drop),
+                            BaseOps::MultiThread(ops) => ops.support_reverse_cont().map(drop),
                         }
                     }
                 }
@@ -189,5 +207,13 @@ commands! {
 
     section_offsets {
         "qOffsets" => _qOffsets::qOffsets,
+    }
+
+    reverse_cont {
+        "bc" => _bc::bc,
+    }
+
+    reverse_step {
+        "bs" => _bs::bs,
     }
 }

--- a/src/protocol/commands/_bc.rs
+++ b/src/protocol/commands/_bc.rs
@@ -1,0 +1,13 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct bc;
+
+impl<'a> ParseCommand<'a> for bc {
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        if !buf.into_body().is_empty() {
+            return None;
+        }
+        Some(bc)
+    }
+}

--- a/src/protocol/commands/_bs.rs
+++ b/src/protocol/commands/_bs.rs
@@ -1,0 +1,13 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct bs;
+
+impl<'a> ParseCommand<'a> for bs {
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        if !buf.into_body().is_empty() {
+            return None;
+        }
+        Some(bs)
+    }
+}

--- a/src/target/ext/base/mod.rs
+++ b/src/target/ext/base/mod.rs
@@ -41,3 +41,13 @@ pub enum ResumeAction {
     /// Step with signal.
     StepWithSignal(u8),
 }
+
+/// Describes the point reached in a replay log for the corresponding stop
+/// reason.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReplayLogPosition {
+    /// Reached the beginning of the replay log.
+    Begin,
+    /// Reached the end of the replay log.
+    End,
+}


### PR DESCRIPTION
This is a pull request for reverse continue/step support for gdbstub.
This corresponds to the `bc` / `bs` packets, or the `rs` / `rc` commands in GDB.