### PR TITLE
Add support for memory maps

### DIFF
--- a/examples/armv4t/gdb/memory_map.rs
+++ b/examples/armv4t/gdb/memory_map.rs
@@ -1,0 +1,17 @@
+use gdbstub::target;
+
+use crate::emu::Emu;
+
+impl target::ext::memory_map::MemoryMap for Emu {
+    fn memory_map_xml(&self) -> &str {
+        // Sample memory map, with RAM coverying the whole
+        // memory space.
+        r#"<?xml version="1.0"?>
+<!DOCTYPE memory-map
+    PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN"
+            "http://sourceware.org/gdb/gdb-memory-map.dtd">
+<memory-map>
+    <memory type="ram" start="0x0" length="0x100000000"/>
+</memory-map>"#
+    }
+}

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -16,6 +16,7 @@ use crate::emu::{Emu, Event};
 
 mod breakpoints;
 mod extended_mode;
+mod memory_map;
 mod monitor_cmd;
 mod section_offsets;
 mod target_description_xml_override;
@@ -71,6 +72,11 @@ impl Target for Emu {
         &mut self,
     ) -> Option<target::ext::target_description_xml_override::TargetDescriptionXmlOverrideOps<Self>>
     {
+        Some(self)
+    }
+
+    #[inline(always)]
+    fn memory_map(&mut self) -> Option<target::ext::memory_map::MemoryMapOps<Self>> {
         Some(self)
     }
 }

--- a/src/gdbstub_impl/ext/base.rs
+++ b/src/gdbstub_impl/ext/base.rs
@@ -147,30 +147,6 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 }
                 HandlerStatus::Handled
             }
-            Base::qXferMemoryMapRead(cmd) => {
-                match target.memory_map().map(|ops| ops.memory_map_xml()) {
-                    Some(xml) => {
-                        let xml = xml.trim();
-                        if cmd.offset >= xml.len() {
-                            // no more data
-                            res.write_str("l")?;
-                        } else if cmd.offset + cmd.len >= xml.len() {
-                            // last little bit of data
-                            res.write_str("l")?;
-                            res.write_binary(&xml.as_bytes()[cmd.offset..])?
-                        } else {
-                            // still more data
-                            res.write_str("m")?;
-                            res.write_binary(&xml.as_bytes()[cmd.offset..(cmd.offset + cmd.len)])?
-                        }
-                    }
-                    None => return Err(Error::PacketUnexpected),
-                }
-                // If the target hasn't provided a memory map, then the initial response to
-                // "qSupported" wouldn't have included  "qXfer:features:memory-map", and gdb wouldn't
-                // send this packet unless it was explicitly marked as supported.
-                HandlerStatus::Handled
-            }
 
             // -------------------- "Core" Functionality -------------------- //
             // TODO: Improve the '?' response based on last-sent stop reason.

--- a/src/gdbstub_impl/ext/memory_map.rs
+++ b/src/gdbstub_impl/ext/memory_map.rs
@@ -1,0 +1,40 @@
+use super::prelude::*;
+use crate::protocol::commands::ext::MemoryMap;
+
+impl<T: Target, C: Connection> GdbStubImpl<T, C> {
+    pub(crate) fn handle_memory_map(
+        &mut self,
+        res: &mut ResponseWriter<C>,
+        target: &mut T,
+        command: MemoryMap,
+    ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
+        let ops = match target.memory_map() {
+            Some(ops) => ops,
+            None => return Ok(HandlerStatus::Handled),
+        };
+
+        crate::__dead_code_marker!("memory_map", "impl");
+
+        let handler_status = match command {
+            MemoryMap::qXferMemoryMapRead(cmd) => {
+                let xml = ops.memory_map_xml().trim();
+                if cmd.offset >= xml.len() {
+                    // no more data
+                    res.write_str("l")?;
+                } else if cmd.offset + cmd.len >= xml.len() {
+                    // last little bit of data
+                    res.write_str("l")?;
+                    res.write_binary(&xml.as_bytes()[cmd.offset..])?
+                } else {
+                    // still more data
+                    res.write_str("m")?;
+                    res.write_binary(&xml.as_bytes()[cmd.offset..(cmd.offset + cmd.len)])?
+                }
+
+                HandlerStatus::Handled
+            }
+        };
+
+        Ok(handler_status)
+    }
+}

--- a/src/gdbstub_impl/ext/mod.rs
+++ b/src/gdbstub_impl/ext/mod.rs
@@ -14,6 +14,7 @@ mod prelude {
 mod base;
 mod breakpoints;
 mod extended_mode;
+mod memory_map;
 mod monitor_cmd;
 mod reverse_exec;
 mod section_offsets;

--- a/src/gdbstub_impl/mod.rs
+++ b/src/gdbstub_impl/mod.rs
@@ -225,6 +225,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Command::SectionOffsets(cmd) => self.handle_section_offsets(res, target, cmd),
             Command::ReverseCont(cmd) => self.handle_reverse_cont(res, target, cmd),
             Command::ReverseStep(cmd) => self.handle_reverse_step(res, target, cmd),
+            Command::MemoryMap(cmd) => self.handle_memory_map(res, target, cmd),
         }
     }
 }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -177,6 +177,7 @@ commands! {
         "qsThreadInfo" => _qsThreadInfo::qsThreadInfo,
         "qSupported" => _qSupported::qSupported<'a>,
         "qXfer:features:read" => _qXfer_features_read::qXferFeaturesRead,
+        "qXfer:memory-map:read" => _qXfer_memory_map::qXferMemoryMapRead,
         "s" => _s::s<'a>,
         "T" => _t_upcase::T,
         "vCont" => _vCont::vCont<'a>,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -177,7 +177,6 @@ commands! {
         "qsThreadInfo" => _qsThreadInfo::qsThreadInfo,
         "qSupported" => _qSupported::qSupported<'a>,
         "qXfer:features:read" => _qXfer_features_read::qXferFeaturesRead,
-        "qXfer:memory-map:read" => _qXfer_memory_map::qXferMemoryMapRead,
         "s" => _s::s<'a>,
         "T" => _t_upcase::T,
         "vCont" => _vCont::vCont<'a>,
@@ -216,5 +215,9 @@ commands! {
 
     reverse_step {
         "bs" => _bs::bs,
+    }
+
+    memory_map {
+        "qXfer:memory-map:read" => _qXfer_memory_map::qXferMemoryMapRead,
     }
 }

--- a/src/protocol/commands/_qXfer_memory_map.rs
+++ b/src/protocol/commands/_qXfer_memory_map.rs
@@ -1,0 +1,29 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct qXferMemoryMapRead {
+    pub offset: usize,
+    pub len: usize,
+}
+
+impl<'a> ParseCommand<'a> for qXferMemoryMapRead {
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let body = buf.into_body();
+
+        if body.is_empty() {
+            return None;
+        }
+
+        let mut body = body.split(|b| *b == b':').skip(1);
+        let annex = body.next()?;
+        if annex != b"" {
+            return None;
+        }
+
+        let mut body = body.next()?.split(|b| *b == b',');
+        let offset = decode_hex(body.next()?).ok()?;
+        let len = decode_hex(body.next()?).ok()?;
+
+        Some(qXferMemoryMapRead { offset, len })
+    }
+}

--- a/src/target/ext/memory_map.rs
+++ b/src/target/ext/memory_map.rs
@@ -8,7 +8,7 @@ pub trait MemoryMap: Target {
     /// See the [GDB Documentation] for a description of the format.
     ///
     /// [GDB Documentation]: https://sourceware.org/gdb/onlinedocs/gdb/Memory-Map-Format.html
-    fn memory_map_xml(&self) -> String;
+    fn memory_map_xml(&self) -> &str;
 }
 
 define_ext!(MemoryMapOps, MemoryMap);

--- a/src/target/ext/memory_map.rs
+++ b/src/target/ext/memory_map.rs
@@ -1,0 +1,14 @@
+//! Provide a memory map for the target.
+use crate::target::Target;
+
+/// Target Extension - Provide a target memory map.
+pub trait MemoryMap: Target {
+    /// Return the target memory map XML file.
+    ///
+    /// See the [GDB Documentation] for a description of the format.
+    ///
+    /// [GDB Documentation]: https://sourceware.org/gdb/onlinedocs/gdb/Memory-Map-Format.html
+    fn memory_map_xml(&self) -> String;
+}
+
+define_ext!(MemoryMapOps, MemoryMap);

--- a/src/target/ext/mod.rs
+++ b/src/target/ext/mod.rs
@@ -256,6 +256,7 @@ macro_rules! define_ext {
 pub mod base;
 pub mod breakpoints;
 pub mod extended_mode;
+pub mod memory_map;
 pub mod monitor_cmd;
 pub mod section_offsets;
 pub mod target_description_xml_override;

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -239,6 +239,12 @@ pub trait Target {
     ) -> Option<ext::target_description_xml_override::TargetDescriptionXmlOverrideOps<Self>> {
         None
     }
+
+    /// Prove a target memory map.
+    #[inline(always)]
+    fn memory_map(&mut self) -> Option<ext::memory_map::MemoryMapOps<Self>> {
+        None
+    }
 }
 
 macro_rules! impl_dyn_target {

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -240,7 +240,7 @@ pub trait Target {
         None
     }
 
-    /// Prove a target memory map.
+    /// Provide a target memory map.
     #[inline(always)]
     fn memory_map(&mut self) -> Option<ext::memory_map::MemoryMapOps<Self>> {
         None


### PR DESCRIPTION
For embedded targets, we need to be able to configure the memory map, as described in the [GDB Docs].
Otherwise, GDB will try to use software breakpoints for code running from flash, which doesn't work.

This PR adds an extension trait based on the `target_description_xml_override` extension to support memory maps.

[GDB Docs]: https://sourceware.org/gdb/onlinedocs/gdb/Memory-Map-Format.html#Memory-Map-Format