### PR TITLE
Dynamic `RegId` Support

### DIFF
--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -6,6 +6,7 @@ use gdbstub::target::ext::base::singlethread::{
     GdbInterrupt, ResumeAction, SingleThreadOps, SingleThreadReverseContOps,
     SingleThreadReverseStepOps, StopReason,
 };
+use gdbstub::target::ext::base::SendRegisterOutput;
 use gdbstub::target::ext::breakpoints::WatchKind;
 use gdbstub::target::{Target, TargetError, TargetResult};
 use gdbstub_arch::arm::reg::id::ArmCoreRegId;
@@ -212,11 +213,11 @@ impl target::ext::base::SingleRegisterAccess<()> for Emu {
         &mut self,
         _tid: (),
         reg_id: gdbstub_arch::arm::reg::id::ArmCoreRegId,
-        output: &mut dyn FnMut(&[u8]),
+        mut output: SendRegisterOutput,
     ) -> TargetResult<(), Self> {
         if let Some(i) = cpu_reg_id(reg_id) {
             let w = self.cpu.reg_get(self.cpu.mode(), i);
-            output(&w.to_le_bytes());
+            output.write(&w.to_le_bytes());
             Ok(())
         } else {
             Err(().into())

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -212,11 +212,11 @@ impl target::ext::base::SingleRegisterAccess<()> for Emu {
         &mut self,
         _tid: (),
         reg_id: gdbstub_arch::arm::reg::id::ArmCoreRegId,
-        dst: &mut [u8],
+        output: &mut dyn FnMut(&[u8]),
     ) -> TargetResult<(), Self> {
         if let Some(i) = cpu_reg_id(reg_id) {
             let w = self.cpu.reg_get(self.cpu.mode(), i);
-            dst.copy_from_slice(&w.to_le_bytes());
+            output(&w.to_le_bytes());
             Ok(())
         } else {
             Err(().into())

--- a/gdbstub_arch/src/arm/reg/id.rs
+++ b/gdbstub_arch/src/arm/reg/id.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroUsize;
+
 use gdbstub::arch::RegId;
 
 /// 32-bit ARM core register identifier.
@@ -21,7 +23,7 @@ pub enum ArmCoreRegId {
 }
 
 impl RegId for ArmCoreRegId {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         let reg = match id {
             0..=12 => Self::Gpr(id as u8),
             13 => Self::Sp,
@@ -31,6 +33,6 @@ impl RegId for ArmCoreRegId {
             25 => Self::Cpsr,
             _ => return None,
         };
-        Some((reg, 4))
+        Some((reg, Some(NonZeroUsize::new(4).unwrap())))
     }
 }

--- a/gdbstub_arch/src/arm/reg/id.rs
+++ b/gdbstub_arch/src/arm/reg/id.rs
@@ -33,6 +33,6 @@ impl RegId for ArmCoreRegId {
             25 => Self::Cpsr,
             _ => return None,
         };
-        Some((reg, Some(NonZeroUsize::new(4).unwrap())))
+        Some((reg, Some(NonZeroUsize::new(4)?)))
     }
 }

--- a/gdbstub_arch/src/mips/reg/id.rs
+++ b/gdbstub_arch/src/mips/reg/id.rs
@@ -65,13 +65,13 @@ fn from_raw_id<U>(id: usize) -> Option<(MipsRegId<U>, Option<NonZeroUsize>)> {
         76 => MipsRegId::Hi3,
         77 => MipsRegId::Lo3,
         // `MipsRegId::Dspctl` is the only register that will always be 4 bytes wide
-        78 => return Some((MipsRegId::Dspctl, Some(NonZeroUsize::new(4).unwrap()))),
+        78 => return Some((MipsRegId::Dspctl, Some(NonZeroUsize::new(4)?))),
         79 => MipsRegId::Restart,
         _ => return None,
     };
 
     let ptrsize = core::mem::size_of::<U>();
-    Some((reg, Some(NonZeroUsize::new(ptrsize).unwrap())))
+    Some((reg, Some(NonZeroUsize::new(ptrsize)?)))
 }
 
 impl RegId for MipsRegId<u32> {

--- a/gdbstub_arch/src/msp430/reg/id.rs
+++ b/gdbstub_arch/src/msp430/reg/id.rs
@@ -31,7 +31,7 @@ impl RegId for Msp430RegId {
             4..=15 => Self::Gpr((id as u8) - 4),
             _ => return None,
         };
-        Some((reg, Some(NonZeroUsize::new(2).unwrap())))
+        Some((reg, Some(NonZeroUsize::new(2)?)))
     }
 }
 

--- a/gdbstub_arch/src/msp430/reg/id.rs
+++ b/gdbstub_arch/src/msp430/reg/id.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroUsize;
+
 use gdbstub::arch::RegId;
 
 /// TI-MSP430 register identifier.
@@ -20,7 +22,7 @@ pub enum Msp430RegId {
 }
 
 impl RegId for Msp430RegId {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         let reg = match id {
             0 => Self::Pc,
             1 => Self::Sp,
@@ -29,7 +31,7 @@ impl RegId for Msp430RegId {
             4..=15 => Self::Gpr((id as u8) - 4),
             _ => return None,
         };
-        Some((reg, 2))
+        Some((reg, Some(NonZeroUsize::new(2).unwrap())))
     }
 }
 
@@ -57,7 +59,7 @@ mod tests {
         let mut i = 0;
         let mut sum_reg_sizes = 0;
         while let Some((_, size)) = RId::from_raw_id(i) {
-            sum_reg_sizes += size;
+            sum_reg_sizes += size.unwrap().get();
             i += 1;
         }
 

--- a/gdbstub_arch/src/riscv/reg/id.rs
+++ b/gdbstub_arch/src/riscv/reg/id.rs
@@ -36,7 +36,7 @@ macro_rules! impl_riscv_reg_id {
                     _ => return None,
                 };
 
-                Some((id, Some(NonZeroUsize::new(size).unwrap())))
+                Some((id, Some(NonZeroUsize::new(size)?)))
             }
         }
     };

--- a/gdbstub_arch/src/riscv/reg/id.rs
+++ b/gdbstub_arch/src/riscv/reg/id.rs
@@ -27,21 +27,16 @@ macro_rules! impl_riscv_reg_id {
             fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
                 const USIZE: usize = core::mem::size_of::<$usize>();
 
-                let reg_size = match id {
-                    0..=31 => (Self::Gpr(id as u8), Some(NonZeroUsize::new(USIZE).unwrap())),
-                    32 => (Self::Pc, Some(NonZeroUsize::new(USIZE).unwrap())),
-                    33..=64 => (
-                        Self::Fpr((id - 33) as u8),
-                        Some(NonZeroUsize::new(USIZE).unwrap()),
-                    ),
-                    65..=4160 => (
-                        Self::Csr((id - 65) as u16),
-                        Some(NonZeroUsize::new(USIZE).unwrap()),
-                    ),
-                    4161 => (Self::Priv, Some(NonZeroUsize::new(1).unwrap())),
+                let (id, size) = match id {
+                    0..=31 => (Self::Gpr(id as u8), USIZE),
+                    32 => (Self::Pc, USIZE),
+                    33..=64 => (Self::Fpr((id - 33) as u8), USIZE),
+                    65..=4160 => (Self::Csr((id - 65) as u16), USIZE),
+                    4161 => (Self::Priv, 1),
                     _ => return None,
                 };
-                Some(reg_size)
+
+                Some((id, Some(NonZeroUsize::new(size).unwrap())))
             }
         }
     };

--- a/gdbstub_arch/src/riscv/reg/id.rs
+++ b/gdbstub_arch/src/riscv/reg/id.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroUsize;
+
 use gdbstub::arch::RegId;
 
 /// RISC-V Register identifier.
@@ -22,15 +24,21 @@ pub enum RiscvRegId<U> {
 macro_rules! impl_riscv_reg_id {
     ($usize:ty) => {
         impl RegId for RiscvRegId<$usize> {
-            fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+            fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
                 const USIZE: usize = core::mem::size_of::<$usize>();
 
                 let reg_size = match id {
-                    0..=31 => (Self::Gpr(id as u8), USIZE),
-                    32 => (Self::Pc, USIZE),
-                    33..=64 => (Self::Fpr((id - 33) as u8), USIZE),
-                    65..=4160 => (Self::Csr((id - 65) as u16), USIZE),
-                    4161 => (Self::Priv, 1),
+                    0..=31 => (Self::Gpr(id as u8), Some(NonZeroUsize::new(USIZE).unwrap())),
+                    32 => (Self::Pc, Some(NonZeroUsize::new(USIZE).unwrap())),
+                    33..=64 => (
+                        Self::Fpr((id - 33) as u8),
+                        Some(NonZeroUsize::new(USIZE).unwrap()),
+                    ),
+                    65..=4160 => (
+                        Self::Csr((id - 65) as u16),
+                        Some(NonZeroUsize::new(USIZE).unwrap()),
+                    ),
+                    4161 => (Self::Priv, Some(NonZeroUsize::new(1).unwrap())),
                     _ => return None,
                 };
                 Some(reg_size)

--- a/gdbstub_arch/src/x86/reg/id.rs
+++ b/gdbstub_arch/src/x86/reg/id.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroUsize;
+
 use gdbstub::arch::RegId;
 
 /// FPU register identifier.
@@ -115,25 +117,31 @@ pub enum X86CoreRegId {
 }
 
 impl RegId for X86CoreRegId {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         use self::X86CoreRegId::*;
 
         let r = match id {
-            0 => (Eax, 4),
-            1 => (Ecx, 4),
-            2 => (Edx, 4),
-            3 => (Ebx, 4),
-            4 => (Esp, 4),
-            5 => (Ebp, 4),
-            6 => (Esi, 4),
-            7 => (Edi, 4),
-            8 => (Eip, 4),
-            9 => (Eflags, 4),
-            10..=15 => (Segment(X86SegmentRegId::from_u8(id as u8 - 10)?), 4),
-            16..=23 => (St(id as u8 - 16), 10),
-            24..=31 => (Fpu(X87FpuInternalRegId::from_u8(id as u8 - 24)?), 4),
-            32..=39 => (Xmm(id as u8 - 32), 16),
-            40 => (Mxcsr, 4),
+            0 => (Eax, Some(NonZeroUsize::new(4).unwrap())),
+            1 => (Ecx, Some(NonZeroUsize::new(4).unwrap())),
+            2 => (Edx, Some(NonZeroUsize::new(4).unwrap())),
+            3 => (Ebx, Some(NonZeroUsize::new(4).unwrap())),
+            4 => (Esp, Some(NonZeroUsize::new(4).unwrap())),
+            5 => (Ebp, Some(NonZeroUsize::new(4).unwrap())),
+            6 => (Esi, Some(NonZeroUsize::new(4).unwrap())),
+            7 => (Edi, Some(NonZeroUsize::new(4).unwrap())),
+            8 => (Eip, Some(NonZeroUsize::new(4).unwrap())),
+            9 => (Eflags, Some(NonZeroUsize::new(4).unwrap())),
+            10..=15 => (
+                Segment(X86SegmentRegId::from_u8(id as u8 - 10)?),
+                Some(NonZeroUsize::new(4).unwrap()),
+            ),
+            16..=23 => (St(id as u8 - 16), Some(NonZeroUsize::new(10).unwrap())),
+            24..=31 => (
+                Fpu(X87FpuInternalRegId::from_u8(id as u8 - 24)?),
+                Some(NonZeroUsize::new(4).unwrap()),
+            ),
+            32..=39 => (Xmm(id as u8 - 32), Some(NonZeroUsize::new(16).unwrap())),
+            40 => (Mxcsr, Some(NonZeroUsize::new(4).unwrap())),
             _ => return None,
         };
         Some(r)
@@ -167,18 +175,24 @@ pub enum X86_64CoreRegId {
 }
 
 impl RegId for X86_64CoreRegId {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         use self::X86_64CoreRegId::*;
 
         let r = match id {
-            0..=15 => (Gpr(id as u8), 8),
-            16 => (Rip, 4),
-            17 => (Eflags, 8),
-            18..=23 => (Segment(X86SegmentRegId::from_u8(id as u8 - 18)?), 4),
-            24..=31 => (St(id as u8 - 24), 10),
-            32..=39 => (Fpu(X87FpuInternalRegId::from_u8(id as u8 - 32)?), 4),
-            40..=55 => (Xmm(id as u8 - 40), 16),
-            56 => (Mxcsr, 4),
+            0..=15 => (Gpr(id as u8), Some(NonZeroUsize::new(8).unwrap())),
+            16 => (Rip, Some(NonZeroUsize::new(4).unwrap())),
+            17 => (Eflags, Some(NonZeroUsize::new(8).unwrap())),
+            18..=23 => (
+                Segment(X86SegmentRegId::from_u8(id as u8 - 18)?),
+                Some(NonZeroUsize::new(4).unwrap()),
+            ),
+            24..=31 => (St(id as u8 - 24), Some(NonZeroUsize::new(10).unwrap())),
+            32..=39 => (
+                Fpu(X87FpuInternalRegId::from_u8(id as u8 - 32)?),
+                Some(NonZeroUsize::new(4).unwrap()),
+            ),
+            40..=55 => (Xmm(id as u8 - 40), Some(NonZeroUsize::new(16).unwrap())),
+            56 => (Mxcsr, Some(NonZeroUsize::new(4).unwrap())),
             _ => return None,
         };
         Some(r)
@@ -208,7 +222,7 @@ mod tests {
         let mut i = 0;
         let mut sum_reg_sizes = 0;
         while let Some((_, size)) = RId::from_raw_id(i) {
-            sum_reg_sizes += size;
+            sum_reg_sizes += size.unwrap().get();
             i += 1;
         }
 

--- a/gdbstub_arch/src/x86/reg/id.rs
+++ b/gdbstub_arch/src/x86/reg/id.rs
@@ -120,31 +120,26 @@ impl RegId for X86CoreRegId {
     fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         use self::X86CoreRegId::*;
 
-        let r = match id {
-            0 => (Eax, Some(NonZeroUsize::new(4).unwrap())),
-            1 => (Ecx, Some(NonZeroUsize::new(4).unwrap())),
-            2 => (Edx, Some(NonZeroUsize::new(4).unwrap())),
-            3 => (Ebx, Some(NonZeroUsize::new(4).unwrap())),
-            4 => (Esp, Some(NonZeroUsize::new(4).unwrap())),
-            5 => (Ebp, Some(NonZeroUsize::new(4).unwrap())),
-            6 => (Esi, Some(NonZeroUsize::new(4).unwrap())),
-            7 => (Edi, Some(NonZeroUsize::new(4).unwrap())),
-            8 => (Eip, Some(NonZeroUsize::new(4).unwrap())),
-            9 => (Eflags, Some(NonZeroUsize::new(4).unwrap())),
-            10..=15 => (
-                Segment(X86SegmentRegId::from_u8(id as u8 - 10)?),
-                Some(NonZeroUsize::new(4).unwrap()),
-            ),
-            16..=23 => (St(id as u8 - 16), Some(NonZeroUsize::new(10).unwrap())),
-            24..=31 => (
-                Fpu(X87FpuInternalRegId::from_u8(id as u8 - 24)?),
-                Some(NonZeroUsize::new(4).unwrap()),
-            ),
-            32..=39 => (Xmm(id as u8 - 32), Some(NonZeroUsize::new(16).unwrap())),
-            40 => (Mxcsr, Some(NonZeroUsize::new(4).unwrap())),
+        let (r, sz): (X86CoreRegId, usize) = match id {
+            0 => (Eax, 4),
+            1 => (Ecx, 4),
+            2 => (Edx, 4),
+            3 => (Ebx, 4),
+            4 => (Esp, 4),
+            5 => (Ebp, 4),
+            6 => (Esi, 4),
+            7 => (Edi, 4),
+            8 => (Eip, 4),
+            9 => (Eflags, 4),
+            10..=15 => (Segment(X86SegmentRegId::from_u8(id as u8 - 10)?), 4),
+            16..=23 => (St(id as u8 - 16), 10),
+            24..=31 => (Fpu(X87FpuInternalRegId::from_u8(id as u8 - 24)?), 4),
+            32..=39 => (Xmm(id as u8 - 32), 16),
+            40 => (Mxcsr, 4),
             _ => return None,
         };
-        Some(r)
+
+        Some((r, Some(NonZeroUsize::new(sz).unwrap())))
     }
 }
 
@@ -178,24 +173,19 @@ impl RegId for X86_64CoreRegId {
     fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         use self::X86_64CoreRegId::*;
 
-        let r = match id {
-            0..=15 => (Gpr(id as u8), Some(NonZeroUsize::new(8).unwrap())),
-            16 => (Rip, Some(NonZeroUsize::new(4).unwrap())),
-            17 => (Eflags, Some(NonZeroUsize::new(8).unwrap())),
-            18..=23 => (
-                Segment(X86SegmentRegId::from_u8(id as u8 - 18)?),
-                Some(NonZeroUsize::new(4).unwrap()),
-            ),
-            24..=31 => (St(id as u8 - 24), Some(NonZeroUsize::new(10).unwrap())),
-            32..=39 => (
-                Fpu(X87FpuInternalRegId::from_u8(id as u8 - 32)?),
-                Some(NonZeroUsize::new(4).unwrap()),
-            ),
-            40..=55 => (Xmm(id as u8 - 40), Some(NonZeroUsize::new(16).unwrap())),
-            56 => (Mxcsr, Some(NonZeroUsize::new(4).unwrap())),
+        let (r, sz): (X86_64CoreRegId, usize) = match id {
+            0..=15 => (Gpr(id as u8), 8),
+            16 => (Rip, 4),
+            17 => (Eflags, 8),
+            18..=23 => (Segment(X86SegmentRegId::from_u8(id as u8 - 18)?), 4),
+            24..=31 => (St(id as u8 - 24), 10),
+            32..=39 => (Fpu(X87FpuInternalRegId::from_u8(id as u8 - 32)?), 4),
+            40..=55 => (Xmm(id as u8 - 40), 16),
+            56 => (Mxcsr, 4),
             _ => return None,
         };
-        Some(r)
+
+        Some((r, Some(NonZeroUsize::new(sz).unwrap())))
     }
 }
 

--- a/gdbstub_arch/src/x86/reg/id.rs
+++ b/gdbstub_arch/src/x86/reg/id.rs
@@ -139,7 +139,7 @@ impl RegId for X86CoreRegId {
             _ => return None,
         };
 
-        Some((r, Some(NonZeroUsize::new(sz).unwrap())))
+        Some((r, Some(NonZeroUsize::new(sz)?)))
     }
 }
 
@@ -185,7 +185,7 @@ impl RegId for X86_64CoreRegId {
             _ => return None,
         };
 
-        Some((r, Some(NonZeroUsize::new(sz).unwrap())))
+        Some((r, Some(NonZeroUsize::new(sz)?)))
     }
 }
 

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -15,7 +15,7 @@
 //! > Having community-created `Arch` implementations distributed in a separate
 //! crate helps minimize any unnecessary "version churn" in `gdbstub` core.
 
-use core::fmt::Debug;
+use core::{fmt::Debug, num::NonZeroUsize};
 
 use num_traits::{FromPrimitive, PrimInt, Unsigned};
 
@@ -31,12 +31,12 @@ pub trait RegId: Sized + Debug {
     /// Map raw GDB register number corresponding `RegId` and register size.
     ///
     /// Returns `None` if the register is not available.
-    fn from_raw_id(id: usize) -> Option<(Self, usize)>;
+    fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)>;
 }
 
 /// Stub implementation -- Returns `None` for all raw IDs.
 impl RegId for () {
-    fn from_raw_id(_id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(_id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         None
     }
 }

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -28,7 +28,12 @@ use crate::internal::{BeBytes, LeBytes};
 ///
 /// [single register accesses]: crate::target::ext::base::SingleRegisterAccess
 pub trait RegId: Sized + Debug {
-    /// Map raw GDB register number corresponding `RegId` and register size.
+    /// Map raw GDB register number to a corresponding `RegId` and optional
+    /// register size.
+    ///
+    /// If the register size is specified here, no more than that amount of
+    /// bytes will be permitted to be transferred on the wire for that
+    /// register.
     ///
     /// Returns `None` if the register is not available.
     fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)>;

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -31,9 +31,9 @@ pub trait RegId: Sized + Debug {
     /// Map raw GDB register number to a corresponding `RegId` and optional
     /// register size.
     ///
-    /// If the register size is specified here, no more than that amount of
-    /// bytes will be permitted to be transferred on the wire for that
-    /// register.
+    /// If the register size is specified here, gdbstub will include a runtime
+    /// check that ensures target implementations do not send back more
+    /// bytes than the register allows
     ///
     /// Returns `None` if the register is not available.
     fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)>;

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -33,7 +33,7 @@ pub trait RegId: Sized + Debug {
     ///
     /// If the register size is specified here, gdbstub will include a runtime
     /// check that ensures target implementations do not send back more
-    /// bytes than the register allows
+    /// bytes than the register allows.
     ///
     /// Returns `None` if the register is not available.
     fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)>;

--- a/src/gdbstub_impl/ext/single_register_access.rs
+++ b/src/gdbstub_impl/ext/single_register_access.rs
@@ -13,17 +13,25 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
         let handler_status = match command {
             SingleRegisterAccess::p(p) => {
-                let mut dst = [0u8; 32]; // enough for 256-bit registers
                 let reg = <T::Arch as Arch>::RegId::from_raw_id(p.reg_id);
-                let (reg_id, reg_size) = match reg {
+                let (reg_id, _reg_size) = match reg {
                     // empty packet indicates unrecognized query
                     None => return Ok(HandlerStatus::Handled),
                     Some(v) => v,
                 };
-                let dst = &mut dst[0..reg_size];
-                ops.read_register(id, reg_id, dst).handle_error()?;
 
-                res.write_hex_buf(dst)?;
+                // TODO: Limit the number of bytes transferred on the wire to the register size
+                // (if specified). Maybe pad the register if the callee does not
+                // send enough data?
+                let mut err = Ok(());
+                ops.read_register(id, reg_id, &mut |buf| match res.write_hex_buf(buf) {
+                    Ok(_) => {}
+                    Err(e) => err = Err(e),
+                })
+                .handle_error()?;
+
+                err?;
+
                 HandlerStatus::Handled
             }
             SingleRegisterAccess::P(p) => {

--- a/src/gdbstub_impl/ext/single_register_access.rs
+++ b/src/gdbstub_impl/ext/single_register_access.rs
@@ -33,7 +33,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                             // error out and stop sending data.
                             if let Some(size) = reg_size {
                                 n += buf.len();
-                                
+
                                 if n > size.get() {
                                     err = Err(Error::TargetMismatch);
                                     return;

--- a/src/gdbstub_impl/ext/single_register_access.rs
+++ b/src/gdbstub_impl/ext/single_register_access.rs
@@ -31,8 +31,9 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                             // If the register has a known size and read_register attempts
                             // to send more bytes than are present in the register,
                             // error out and stop sending data.
-                            n += buf.len();
                             if let Some(size) = reg_size {
+                                n += buf.len();
+                                
                                 if n > size.get() {
                                     err = Err(Error::TargetMismatch);
                                     return;

--- a/src/target/ext/base/mod.rs
+++ b/src/target/ext/base/mod.rs
@@ -10,7 +10,9 @@ pub mod singlethread;
 
 mod single_register_access;
 
-pub use single_register_access::{SingleRegisterAccess, SingleRegisterAccessOps};
+pub use single_register_access::{
+    SendRegisterOutput, SingleRegisterAccess, SingleRegisterAccessOps,
+};
 
 /// Base operations for single/multi threaded targets.
 pub enum BaseOps<'a, A, E> {

--- a/src/target/ext/base/single_register_access.rs
+++ b/src/target/ext/base/single_register_access.rs
@@ -35,7 +35,7 @@ pub trait SingleRegisterAccess<Id>: Target {
         &mut self,
         tid: Id,
         reg_id: <Self::Arch as Arch>::RegId,
-        dst: &mut [u8],
+        output: &mut dyn FnMut(&[u8]),
     ) -> TargetResult<(), Self>;
 
     /// Write from a single register on the target.

--- a/src/target/ext/base/single_register_access.rs
+++ b/src/target/ext/base/single_register_access.rs
@@ -22,7 +22,7 @@ pub trait SingleRegisterAccess<Id>: Target {
     /// On single threaded targets, `tid` is set to `()` and can be ignored.
     ///
     /// Implementations should write the value of the register using target's
-    /// native byte order in the buffer `dst`.
+    /// native byte order when writing via `output`.
     ///
     /// If the requested register could not be accessed, an appropriate
     /// non-fatal error should be returned.


### PR DESCRIPTION
### Description
As per a discussion in #53, ([comment](https://github.com/daniel5151/gdbstub/issues/53#issuecomment-849766528)), `gdbstub`'s `RegId` abstraction does not have a way to support dynamic register files due to the register size field returned from `RegId::from_raw_id`.

As suggested by @daniel5151, we can make the register size an optional hint, and enforce register sizing based on that.

This changeset also removes the array allocated in the single register access handler, and instead passes the target a closure that behaves in a similar manner to the one passed to `Registers::gdb_serialize`.

### API Stability

This will break SemVer compatibility, though for a good reason.

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
- Documentation
  - [ ] rustdoc + approprate inline code comments
  - [ ] Updated CHANGELOG.md
  - [ ] (if appropriate) Added feature to "Debugging Features" in README.md

### Validation

TODO...
P.S: How do I query a single register using a GDB client?

<!-- example output, from https://github.com/daniel5151/gdbstub/pull/54 -->

<details>
<summary>GDB output</summary>

```
TODO...
```

</details>

<details>
<summary>armv4t output</summary>

```
TODO...
```
</details>
