### PR TITLE
Msp430 fixes

### DIFF
--- a/gdbstub_arch/src/msp430/mod.rs
+++ b/gdbstub_arch/src/msp430/mod.rs
@@ -1,23 +1,16 @@
 //! Implementations for the TI-MSP430 family of MCUs.
 
 use gdbstub::arch::Arch;
-use gdbstub::arch::RegId;
 
 pub mod reg;
 
 /// Implements `Arch` for standard 16-bit TI-MSP430 MCUs.
-///
-/// Check out the [module level docs](gdbstub::arch#whats-with-regidimpl) for
-/// more info about the `RegIdImpl` type parameter.
-pub enum Msp430<RegIdImpl: RegId = reg::id::Msp430RegId<u16>> {
-    #[doc(hidden)]
-    _Marker(core::marker::PhantomData<RegIdImpl>),
-}
+pub struct Msp430 {}
 
-impl<RegIdImpl: RegId> Arch for Msp430<RegIdImpl> {
+impl Arch for Msp430 {
     type Usize = u16;
     type Registers = reg::Msp430Regs<u16>;
-    type RegId = RegIdImpl;
+    type RegId = reg::id::Msp430RegId<u16>;
     type BreakpointKind = usize;
 
     fn target_description_xml() -> Option<&'static str> {
@@ -26,18 +19,12 @@ impl<RegIdImpl: RegId> Arch for Msp430<RegIdImpl> {
 }
 
 /// Implements `Arch` for 20-bit TI-MSP430 MCUs (CPUX).
-///
-/// Check out the [module level docs](gdbstub::arch#whats-with-regidimpl) for
-/// more info about the `RegIdImpl` type parameter.
-pub enum Msp430X<RegIdImpl: RegId = reg::id::Msp430RegId<u32>> {
-    #[doc(hidden)]
-    _Marker(core::marker::PhantomData<RegIdImpl>),
-}
+pub struct Msp430X {}
 
-impl<RegIdImpl: RegId> Arch for Msp430X<RegIdImpl> {
+impl Arch for Msp430X {
     type Usize = u32;
     type Registers = reg::Msp430Regs<u32>;
-    type RegId = RegIdImpl;
+    type RegId = reg::id::Msp430RegId<u32>;
     type BreakpointKind = usize;
 
     fn target_description_xml() -> Option<&'static str> {

--- a/gdbstub_arch/src/msp430/mod.rs
+++ b/gdbstub_arch/src/msp430/mod.rs
@@ -25,7 +25,7 @@ impl<RegIdImpl: RegId> Arch for Msp430<RegIdImpl> {
     }
 }
 
-/// Implements `Arch` for CPUX 20-bit TI-MSP430 MCUs.
+/// Implements `Arch` for 20-bit TI-MSP430 MCUs (CPUX).
 ///
 /// Check out the [module level docs](gdbstub::arch#whats-with-regidimpl) for
 /// more info about the `RegIdImpl` type parameter.

--- a/gdbstub_arch/src/msp430/mod.rs
+++ b/gdbstub_arch/src/msp430/mod.rs
@@ -9,18 +9,38 @@ pub mod reg;
 ///
 /// Check out the [module level docs](gdbstub::arch#whats-with-regidimpl) for
 /// more info about the `RegIdImpl` type parameter.
-pub enum Msp430<RegIdImpl: RegId = reg::id::Msp430RegId> {
+pub enum Msp430<RegIdImpl: RegId = reg::id::Msp430RegId<u16>> {
     #[doc(hidden)]
     _Marker(core::marker::PhantomData<RegIdImpl>),
 }
 
 impl<RegIdImpl: RegId> Arch for Msp430<RegIdImpl> {
     type Usize = u16;
-    type Registers = reg::Msp430Regs;
+    type Registers = reg::Msp430Regs<u16>;
     type RegId = RegIdImpl;
     type BreakpointKind = usize;
 
     fn target_description_xml() -> Option<&'static str> {
         Some(r#"<target version="1.0"><architecture>msp430</architecture></target>"#)
+    }
+}
+
+/// Implements `Arch` for CPUX 20-bit TI-MSP430 MCUs.
+///
+/// Check out the [module level docs](gdbstub::arch#whats-with-regidimpl) for
+/// more info about the `RegIdImpl` type parameter.
+pub enum Msp430X<RegIdImpl: RegId = reg::id::Msp430RegId<u32>> {
+    #[doc(hidden)]
+    _Marker(core::marker::PhantomData<RegIdImpl>),
+}
+
+impl<RegIdImpl: RegId> Arch for Msp430X<RegIdImpl> {
+    type Usize = u32;
+    type Registers = reg::Msp430Regs<u32>;
+    type RegId = RegIdImpl;
+    type BreakpointKind = usize;
+
+    fn target_description_xml() -> Option<&'static str> {
+        Some(r#"<target version="1.0"><architecture>msp430x</architecture></target>"#)
     }
 }

--- a/gdbstub_arch/src/msp430/reg/id.rs
+++ b/gdbstub_arch/src/msp430/reg/id.rs
@@ -6,7 +6,7 @@ use gdbstub::arch::RegId;
 /// The best file to reference is [msp430-tdep.c](https://github.com/bminor/binutils-gdb/blob/master/gdb/msp430-tdep.c).
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
-pub enum Msp430RegId {
+pub enum Msp430RegId<U> {
     /// Program Counter (R0)
     Pc,
     /// Stack Pointer (R1)
@@ -17,19 +17,33 @@ pub enum Msp430RegId {
     Cg,
     /// General Purpose Registers (R4-R15)
     Gpr(u8),
+    #[doc(hidden)]
+    _Size(U),
 }
 
-impl RegId for Msp430RegId {
+fn from_raw_id<U>(id: usize) -> Option<(Msp430RegId<U>, usize)> {
+    let reg = match id {
+        0 => Msp430RegId::Pc,
+        1 => Msp430RegId::Sp,
+        2 => Msp430RegId::Sr,
+        3 => Msp430RegId::Cg,
+        4..=15 => Msp430RegId::Gpr((id as u8) - 4),
+        _ => return None,
+    };
+
+    let ptrsize = core::mem::size_of::<U>();
+    Some((reg, ptrsize))
+}
+
+impl RegId for Msp430RegId<u16> {
     fn from_raw_id(id: usize) -> Option<(Self, usize)> {
-        let reg = match id {
-            0 => Self::Pc,
-            1 => Self::Sp,
-            2 => Self::Sr,
-            3 => Self::Cg,
-            4..=15 => Self::Gpr((id as u8) - 4),
-            _ => return None,
-        };
-        Some((reg, 2))
+        from_raw_id::<u16>(id)
+    }
+}
+
+impl RegId for Msp430RegId<u32> {
+    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+        from_raw_id::<u32>(id)
     }
 }
 

--- a/gdbstub_arch/src/msp430/reg/id.rs
+++ b/gdbstub_arch/src/msp430/reg/id.rs
@@ -65,7 +65,7 @@ mod tests {
 
         // The `Msp430Regs` implementation does not increment the size for
         // the CG register since it will always be the constant zero.
-        serialized_data_len += 4;
+        serialized_data_len += RId::from_raw_id(3).unwrap().1;
 
         // Accumulate register sizes returned by `from_raw_id`.
         let mut i = 0;
@@ -80,6 +80,11 @@ mod tests {
 
     #[test]
     fn test_msp430() {
-        test::<crate::msp430::reg::Msp430Regs, crate::msp430::reg::id::Msp430RegId>()
+        test::<crate::msp430::reg::Msp430Regs<u16>, crate::msp430::reg::id::Msp430RegId<u16>>()
+    }
+
+    #[test]
+    fn test_msp430x() {
+        test::<crate::msp430::reg::Msp430Regs<u32>, crate::msp430::reg::id::Msp430RegId<u32>>()
     }
 }

--- a/gdbstub_arch/src/msp430/reg/msp430.rs
+++ b/gdbstub_arch/src/msp430/reg/msp430.rs
@@ -5,8 +5,8 @@ use gdbstub::internal::LeBytes;
 
 /// TI-MSP430 registers.
 ///
-/// The register width `<U>` should be set to `u16` for 16-bit MSP430 CPUs and
-/// to `u32` for 20-bit MSP430 CPUs (CPUX).
+/// The register width is set based on the `<U>` type. For 16-bit MSP430 CPUs
+/// this should be `u16` and for 20-bit MSP430 CPUs (CPUX) this should be `u32`.
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Msp430Regs<U> {
     /// Program Counter (R0)

--- a/gdbstub_arch/src/msp430/reg/msp430.rs
+++ b/gdbstub_arch/src/msp430/reg/msp430.rs
@@ -1,60 +1,74 @@
-use gdbstub::arch::Registers;
+use num_traits::PrimInt;
 
-/// 16-bit TI-MSP430 registers.
+use gdbstub::arch::Registers;
+use gdbstub::internal::LeBytes;
+
+/// TI-MSP430 registers.
+///
+/// The register width `<U>` should be set to `u16` for 16-bit MSP430 CPUs and
+/// to `u32` for 20-bit MSP430 CPUs (CPUX).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
-pub struct Msp430Regs {
+pub struct Msp430Regs<U> {
     /// Program Counter (R0)
-    pub pc: u16,
+    pub pc: U,
     /// Stack Pointer (R1)
-    pub sp: u16,
+    pub sp: U,
     /// Status Register (R2)
-    pub sr: u16,
+    pub sr: U,
     /// General Purpose Registers (R4-R15)
-    pub r: [u16; 11],
+    pub r: [U; 12],
 }
 
-impl Registers for Msp430Regs {
-    type ProgramCounter = u16;
+impl<U> Registers for Msp430Regs<U>
+where
+    U: PrimInt + LeBytes + Default + core::fmt::Debug,
+{
+    type ProgramCounter = U;
 
     fn pc(&self) -> Self::ProgramCounter {
         self.pc
     }
 
     fn gdb_serialize(&self, mut write_byte: impl FnMut(Option<u8>)) {
-        macro_rules! write_bytes {
-            ($bytes:expr) => {
-                for b in $bytes {
-                    write_byte(Some(*b))
+        macro_rules! write_le_bytes {
+            ($value:expr) => {
+                let mut buf = [0; 4];
+                // infallible (register size a maximum of 32-bits)
+                let len = $value.to_le_bytes(&mut buf).unwrap();
+                let buf = &buf[..len];
+                for b in buf {
+                    write_byte(Some(*b));
                 }
             };
         }
 
-        write_bytes!(&self.pc.to_le_bytes());
-        write_bytes!(&self.sp.to_le_bytes());
-        write_bytes!(&self.sr.to_le_bytes());
-        (0..4).for_each(|_| write_byte(None)); // Constant Generator (CG/R3)
+        write_le_bytes!(&self.pc);
+        write_le_bytes!(&self.sp);
+        write_le_bytes!(&self.sr);
+        (0..core::mem::size_of::<U>()).for_each(|_| write_byte(None)); // Constant Generator (CG/R3)
         for reg in self.r.iter() {
-            write_bytes!(&reg.to_le_bytes());
+            write_le_bytes!(&reg);
         }
     }
 
     fn gdb_deserialize(&mut self, bytes: &[u8]) -> Result<(), ()> {
-        // ensure bytes.chunks_exact(2) won't panic
-        if bytes.len() % 2 != 0 {
+        let ptrsize = core::mem::size_of::<U>();
+
+        // Ensure bytes contains enough data for all 16 registers
+        if bytes.len() < ptrsize * 16 {
             return Err(());
         }
 
-        use core::convert::TryInto;
         let mut regs = bytes
-            .chunks_exact(2)
-            .map(|c| u16::from_le_bytes(c.try_into().unwrap()));
+            .chunks_exact(ptrsize)
+            .map(|c| U::from_le_bytes(c).unwrap());
 
         self.pc = regs.next().ok_or(())?;
         self.sp = regs.next().ok_or(())?;
         self.sr = regs.next().ok_or(())?;
 
         // Constant Generator (CG/R3) should always be 0
-        if regs.next().ok_or(())? != 0 {
+        if regs.next().ok_or(())? != U::zero() {
             return Err(());
         }
 


### PR DESCRIPTION
### Description

The previous MSP430 register definition in `gdbstub_arch` was missing a GPR.

This PR adds the missing register as well as adding support for 20-bit MSP430 variant (CPUX) using the paramaterization strategy from the MIPS implementation, note that gdb treats the 20-bit registers as 32-bit registers internally.

I tested both the 16-bit variant and the 20-bit variant with my emulator, and things seemed to work. Backtraces seem to be broken but I don't think that is related gdbstub (The TI compiler was used to compile the binary I was testing, I think it could be an upstream GDB issue with the TI calling convention).

Technically this is breaking API change, however, since the previous implementation would have resulted in R15 being dropped, it seems unlikely it is being used.

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
- Documentation
  - [x] rustdoc + appropriate inline code comments
  - [ ] Updated CHANGELOG.md

### Debug output

<details>
<summary>Gdb output</summary>

```
Remote debugging using :9999
warning: Can not parse XML target description; XML support was disabled at compile time
_c_int00_noargs () at boot.c:134
134     boot.c: No such file or directory.
(gdb) break main
Breakpoint 1 at 0x10bc4: file ../main.c, line 72.
(gdb) c
Continuing.

Breakpoint 1, main () at ../main.c:72
72      {
(gdb) info r
pc             0x10bc4  0x10bc4 <main>
sp             0x43fc   17404
sr             0x3      3
cg             <unavailable>
r4             0x0      0
r5             0x0      0
r6             0x0      0
r7             0x0      0
r8             0x0      0
r9             0x0      0
r10            0x0      0
r11            0xfff    4095
r12            0x0      0
r13            0x24f7   9463
r14            0x0      0
r15            0x0      0
(gdb) bt
#0  main () at ../main.c:72
(gdb) q
A debugging session is active.

        Inferior 1 [process 1] will be detached.

Quit anyway? (y or n) y
Detaching from program: D:\src\fuzzing\sysroots\msp430\H3_EchoToHost.out, process 1
Ending remote debugging.
```
</details>

<details>
<summary>Protocol output</summary>

```
w +$qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;no-resumed+#df
r +$PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;ReverseStep+;swbreak+;qXfer:features:read+#db
w +$vMustReplyEmpty#3a
r +$#00
w +$QStartNoAckMode#b0
r +$OK#9a
w +$Hgp0.0#ad
r $OK#9a
w $qXfer:features:read:target.xml:0,ffb#79
r $l<target version="1.0"><architecture>msp430x</architecture></target>#5b
w $qTStatus#49
r $#00
w $?#3f
r $S05#b8
w $qfThreadInfo#bb
r $mp01.01#cd
w $qsThreadInfo#c8
r $l#6c
w $qAttached:1#fa
r $1#31
w $Hc-1#09
r $OK#9a
w $qC#b4
r $#00
w $qOffsets#4b
r $#00
w $g#67
r $5c450*0x*$0*|#27
w $qfThreadInfo#bb
r $mp01.01#cd
w $qsThreadInfo#c8
r $l#6c
w $qSymbol::#5b
r $#00
c break main
w $m10bc4,1#24
r $f1#97
w $m10bc5,1#25
r $03#63
w $m10bc4,1#24
r $f1#97
w $m10bc5,1#25
r $03#63
w $m10bc4,2#25
r $f103#fa
c c
w $Z0,10bc4,2#6e
r $OK#9a
w $vCont?#49
r $vCont;c;C;s;S#62
w $vCont;c:p1.-1#0f
r <Timeout: 0 seconds>$S05#b8
w $g#67
r $c40b0100fc430*!300*!x*$0*Tff0f0*(f7240*0#58
w $qfThreadInfo#bb
r $mp01.01#cd
w $qsThreadInfo#c8
r $l#6c
w $z0,10bc4,2#8e
r $OK#9a
c info r
c bt
c q
w $D;1#b0
r $OK#9a
End of log
```
</details>