### PR TITLE
Unify the way of writing a range of data

### DIFF
--- a/src/gdbstub_impl/ext/base.rs
+++ b/src/gdbstub_impl/ext/base.rs
@@ -131,16 +131,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 match xml {
                     Some(xml) => {
                         let xml = xml.trim().as_bytes();
-                        if cmd.offset < xml.len() {
-                            // still more data
-                            res.write_str("m")?;
-                            res.write_binary(
-                                &xml[cmd.offset..][..cmd.len.min(xml.len() - cmd.offset)],
-                            )?
-                        } else {
-                            // no more data
-                            res.write_str("l")?;
-                        }
+                        res.write_binary_range(xml, cmd.offset, cmd.len)?;
                     }
                     // If the target hasn't provided their own XML, then the initial response to
                     // "qSupported" wouldn't have included "qXfer:features:read", and gdb wouldn't

--- a/src/gdbstub_impl/ext/memory_map.rs
+++ b/src/gdbstub_impl/ext/memory_map.rs
@@ -17,20 +17,8 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
         let handler_status = match command {
             MemoryMap::qXferMemoryMapRead(cmd) => {
-                let xml = ops.memory_map_xml().trim();
-                if cmd.offset >= xml.len() {
-                    // no more data
-                    res.write_str("l")?;
-                } else if cmd.offset + cmd.len >= xml.len() {
-                    // last little bit of data
-                    res.write_str("l")?;
-                    res.write_binary(&xml.as_bytes()[cmd.offset..])?
-                } else {
-                    // still more data
-                    res.write_str("m")?;
-                    res.write_binary(&xml.as_bytes()[cmd.offset..(cmd.offset + cmd.len)])?
-                }
-
+                let xml = ops.memory_map_xml().trim().as_bytes();
+                res.write_binary_range(xml, cmd.offset, cmd.len)?;
                 HandlerStatus::Handled
             }
         };

--- a/src/protocol/response_writer.rs
+++ b/src/protocol/response_writer.rs
@@ -193,6 +193,25 @@ impl<'a, C: Connection + 'a> ResponseWriter<'a, C> {
         Ok(())
     }
 
+    /// Write a range of data specified by offset and len.
+    /// Used by qXfer:_object_:read commands.
+    pub fn write_binary_range(
+        &mut self,
+        data: &[u8],
+        offset: usize,
+        len: usize,
+    ) -> Result<(), Error<C::Error>> {
+        if offset < data.len() {
+            // still more data
+            self.write_str("m")?;
+            self.write_binary(&data[offset..][..len.min(data.len() - offset)])?
+        } else {
+            // no more data
+            self.write_str("l")?;
+        }
+        Ok(())
+    }
+
     /// Write a number as a big-endian hex string using the most compact
     /// representation possible (i.e: trimming leading zeros).
     pub fn write_num<D: BeBytes + PrimInt>(&mut self, digit: D) -> Result<(), Error<C::Error>> {


### PR DESCRIPTION
### Description

<!-- Please include a brief description of what is being added/changed -->

Unify the way of writing a range of data

### API Stability

- [x] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
- Documentation
  - [x] rustdoc + approprate inline code comments
  - [ ] Updated CHANGELOG.md
  - [ ] (if appropriate) Added feature to "Debugging Features" in README.md
- _If implementing a new protocol extension IDET_
  - [ ] Included a basic sample implementation in `examples/armv4t`
  - [ ] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [ ] Confirmed that IDET can be optimized away (using `./scripts/test_dead_code_elim.sh` and/or `./example_no_std/check_size.sh`)
  - [ ] **OR** Implementation requires adding non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [ ] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- If you are implementing `gdbstub` in an open-source project, consider updating the README.md's "Real World Examples" section to link back to your project! -->
