### PR TITLE
Support Host I/O operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools::debugging", "embedded", "emulators", "network-
 exclude = ["examples/**/*.elf", "examples/**/*.o"]
 
 [dependencies]
-bitflags = "1.2.1"
+bitflags = "1.3"
 cfg-if = "0.1.10"
 log = "0.4"
 managed = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools::debugging", "embedded", "emulators", "network-
 exclude = ["examples/**/*.elf", "examples/**/*.o"]
 
 [dependencies]
+bitflags = "1.2.1"
 cfg-if = "0.1.10"
 log = "0.4"
 managed = { version = "0.8", default-features = false }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Of course, most use-cases will want to support additional debugging features as 
     -   Get section/segment relocation offsets from the target
 -   Custom `monitor` Commands
     -   Extend the GDB protocol with custom debug commands using GDB's `monitor` command
+-   Get target memory map
+-   Perform Host I/O operations
 
 _Note:_ GDB features are implemented on an as-needed basis by `gdbstub`'s contributors. If there's a missing GDB feature that you'd like `gdbstub` to implement, please file an issue and/or open a PR!
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ If you happen to stumble across this crate and end up using it to debug some bar
 
 -   When the `paranoid_unsafe` feature is enabled, the following `unsafe` code is _removed_:
     -   `src/protocol/packet.rs`: Swaps a couple slice-index methods in `PacketBuf` to use `get_unchecked_mut`. The public API of struct ensures that the bounds used to index into the array remain in-bounds.
-    -   `src/protocol/common/hex`: Use an alternate implementation of `decode_hex_buf` which uses unsafe slice indexing.
+    -   `src/protocol/common/hex`: Use an alternate implementation of `decode_hex_buf`/`decode_bin_buf` which uses unsafe slice indexing.
 
 -   When the `std` feature is enabled:
     -   `src/connection/impls/unixstream.rs`: An implementation of `UnixStream::peek` which uses `libc::recv`. This manual implementation will be removed once [rust-lang/rust#76923](https://github.com/rust-lang/rust/issues/76923) is stabilized.

--- a/examples/armv4t/emu.rs
+++ b/examples/armv4t/emu.rs
@@ -4,6 +4,7 @@ use crate::mem_sniffer::{AccessKind, MemSniffer};
 use crate::DynResult;
 
 const HLE_RETURN_ADDR: u32 = 0x12345678;
+pub const FD_MAX: u32 = 256;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Event {
@@ -25,10 +26,12 @@ pub struct Emu {
 
     pub(crate) watchpoints: Vec<u32>,
     pub(crate) breakpoints: Vec<u32>,
+    pub(crate) files: [Option<std::fs::File>; FD_MAX as usize],
 }
 
 impl Emu {
     pub fn new(program_elf: &[u8]) -> DynResult<Emu> {
+        const FILE_INIT: Option<std::fs::File> = None;
         // set up emulated system
         let mut cpu = Cpu::new();
         let mut mem = ExampleMem::new();
@@ -72,6 +75,7 @@ impl Emu {
 
             watchpoints: Vec::new(),
             breakpoints: Vec::new(),
+            files: [FILE_INIT; FD_MAX as usize],
         })
     }
 

--- a/examples/armv4t/emu.rs
+++ b/examples/armv4t/emu.rs
@@ -4,7 +4,6 @@ use crate::mem_sniffer::{AccessKind, MemSniffer};
 use crate::DynResult;
 
 const HLE_RETURN_ADDR: u32 = 0x12345678;
-pub const FD_MAX: u32 = 256;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Event {
@@ -26,12 +25,11 @@ pub struct Emu {
 
     pub(crate) watchpoints: Vec<u32>,
     pub(crate) breakpoints: Vec<u32>,
-    pub(crate) files: [Option<std::fs::File>; FD_MAX as usize],
+    pub(crate) files: Vec<Option<std::fs::File>>,
 }
 
 impl Emu {
     pub fn new(program_elf: &[u8]) -> DynResult<Emu> {
-        const FILE_INIT: Option<std::fs::File> = None;
         // set up emulated system
         let mut cpu = Cpu::new();
         let mut mem = ExampleMem::new();
@@ -75,7 +73,7 @@ impl Emu {
 
             watchpoints: Vec::new(),
             breakpoints: Vec::new(),
-            files: [FILE_INIT; FD_MAX as usize],
+            files: Vec::new(),
         })
     }
 

--- a/examples/armv4t/gdb/host_io.rs
+++ b/examples/armv4t/gdb/host_io.rs
@@ -1,0 +1,35 @@
+use gdbstub::target;
+
+use crate::emu::Emu;
+
+impl target::ext::host_io::HostIo for Emu {
+    fn open(&self, filename: &[u8], _flags: u64, _mode: u64) -> i64 {
+        if filename == b"/proc/1/maps" {
+            1
+        } else {
+            -1
+        }
+    }
+
+    fn pread(&self, fd: usize, count: usize, offset: usize) -> &[u8] {
+        if fd == 1 {
+            let maps = b"0x55550000-0x55550078 r-x 0 0 0\n";
+            let len = maps.len();
+            &maps[offset.min(len)..(offset + count).min(len)]
+        } else {
+            b""
+        }
+    }
+
+    fn close(&self, fd: usize) -> i64 {
+        if fd == 1 {
+            0
+        } else {
+            -1
+        }
+    }
+
+    fn setfs(&self, _fd: usize) -> i64 {
+        0
+    }
+}

--- a/examples/armv4t/gdb/host_io.rs
+++ b/examples/armv4t/gdb/host_io.rs
@@ -3,7 +3,8 @@ use gdbstub::target;
 use crate::emu::Emu;
 
 use gdbstub::target::ext::host_io::{
-    HostIoErrno, HostIoError, HostIoMode, HostIoOpenFlags, HostIoResult, PreadOutput, PreadToken,
+    HostIoErrno, HostIoError, HostIoOpenFlags, HostIoOpenMode, HostIoOutput, HostIoResult,
+    HostIoToken,
 };
 
 impl target::ext::host_io::HostIo for Emu {
@@ -28,7 +29,7 @@ impl target::ext::host_io::HostIoOpen for Emu {
         &mut self,
         filename: &[u8],
         _flags: HostIoOpenFlags,
-        _mode: HostIoMode,
+        _mode: HostIoOpenMode,
     ) -> HostIoResult<u32, Self> {
         // Support `info proc mappings` command
         if filename == b"/proc/1/maps" {
@@ -42,11 +43,11 @@ impl target::ext::host_io::HostIoOpen for Emu {
 impl target::ext::host_io::HostIoPread for Emu {
     fn pread<'a>(
         &mut self,
-        fd: i32,
+        fd: u32,
         count: u32,
         offset: u32,
-        output: PreadOutput<'a>,
-    ) -> HostIoResult<PreadToken<'a>, Self> {
+        output: HostIoOutput<'a>,
+    ) -> HostIoResult<HostIoToken<'a>, Self> {
         if fd == 1 {
             let maps = b"0x55550000-0x55550078 r-x 0 0 0\n";
             let len = maps.len();
@@ -60,7 +61,7 @@ impl target::ext::host_io::HostIoPread for Emu {
 }
 
 impl target::ext::host_io::HostIoClose for Emu {
-    fn close(&mut self, fd: i32) -> HostIoResult<u32, Self> {
+    fn close(&mut self, fd: u32) -> HostIoResult<u32, Self> {
         if fd == 1 {
             Ok(0)
         } else {

--- a/examples/armv4t/gdb/host_io.rs
+++ b/examples/armv4t/gdb/host_io.rs
@@ -1,10 +1,11 @@
 use gdbstub::target;
+use std::io::{Read, Seek, Write};
 
-use crate::emu::Emu;
+use crate::emu::{Emu, FD_MAX};
 
 use gdbstub::target::ext::host_io::{
     HostIoErrno, HostIoError, HostIoOpenFlags, HostIoOpenMode, HostIoOutput, HostIoResult,
-    HostIoToken,
+    HostIoStat, HostIoToken,
 };
 
 impl target::ext::host_io::HostIo for Emu {
@@ -14,12 +15,27 @@ impl target::ext::host_io::HostIo for Emu {
     }
 
     #[inline(always)]
+    fn enable_close(&mut self) -> Option<target::ext::host_io::HostIoCloseOps<Self>> {
+        Some(self)
+    }
+
+    #[inline(always)]
     fn enable_pread(&mut self) -> Option<target::ext::host_io::HostIoPreadOps<Self>> {
         Some(self)
     }
 
     #[inline(always)]
-    fn enable_close(&mut self) -> Option<target::ext::host_io::HostIoCloseOps<Self>> {
+    fn enable_pwrite(&mut self) -> Option<target::ext::host_io::HostIoPwriteOps<Self>> {
+        Some(self)
+    }
+
+    #[inline(always)]
+    fn enable_unlink(&mut self) -> Option<target::ext::host_io::HostIoUnlinkOps<Self>> {
+        Some(self)
+    }
+
+    #[inline(always)]
+    fn enable_readlink(&mut self) -> Option<target::ext::host_io::HostIoReadlinkOps<Self>> {
         Some(self)
     }
 }
@@ -28,14 +44,55 @@ impl target::ext::host_io::HostIoOpen for Emu {
     fn open(
         &mut self,
         filename: &[u8],
-        _flags: HostIoOpenFlags,
-        _mode: HostIoOpenMode,
+        flags: HostIoOpenFlags,
+        mode: HostIoOpenMode,
     ) -> HostIoResult<u32, Self> {
         // Support `info proc mappings` command
         if filename == b"/proc/1/maps" {
-            Ok(1)
+            Ok(FD_MAX + 1)
         } else {
-            Err(HostIoError::Errno(HostIoErrno::EPERM))
+            let path = match std::str::from_utf8(filename) {
+                Ok(v) => v,
+                Err(_) => return Err(HostIoError::Errno(HostIoErrno::ENOENT)),
+            };
+            let file;
+            if flags
+                == HostIoOpenFlags::O_WRONLY | HostIoOpenFlags::O_CREAT | HostIoOpenFlags::O_TRUNC
+                && mode
+                    == HostIoOpenMode::S_IRUSR | HostIoOpenMode::S_IWUSR | HostIoOpenMode::S_IXUSR
+            {
+                file = std::fs::File::create(path)?;
+            } else if flags == HostIoOpenFlags::O_RDONLY {
+                file = std::fs::File::open(path)?;
+            } else {
+                return Err(HostIoError::Errno(HostIoErrno::EINVAL));
+            }
+            let n = 0;
+            for n in 0..FD_MAX {
+                if self.files[n as usize].is_none() {
+                    break;
+                }
+            }
+            if n == FD_MAX {
+                return Err(HostIoError::Errno(HostIoErrno::ENFILE));
+            }
+            self.files[n as usize] = Some(file);
+            Ok(n)
+        }
+    }
+}
+
+impl target::ext::host_io::HostIoClose for Emu {
+    fn close(&mut self, fd: u32) -> HostIoResult<(), Self> {
+        if fd == FD_MAX + 1 {
+            Ok(())
+        } else if fd < FD_MAX {
+            self.files[fd as usize]
+                .take()
+                .ok_or(HostIoError::Errno(HostIoErrno::EBADF))?;
+            Ok(())
+        } else {
+            Err(HostIoError::Errno(HostIoErrno::EBADF))
         }
     }
 }
@@ -48,24 +105,115 @@ impl target::ext::host_io::HostIoPread for Emu {
         offset: u32,
         output: HostIoOutput<'a>,
     ) -> HostIoResult<HostIoToken<'a>, Self> {
-        if fd == 1 {
+        if fd == FD_MAX + 1 {
             let maps = b"0x55550000-0x55550078 r-x 0 0 0\n";
             let len = maps.len();
             let count: usize = count as usize;
             let offset: usize = offset as usize;
             Ok(output.write(&maps[offset.min(len)..(offset + count).min(len)]))
+        } else if fd < FD_MAX {
+            if let Some(ref mut file) = self.files[fd as usize] {
+                let mut buffer = vec![0; count as usize];
+                file.seek(std::io::SeekFrom::Start(offset as u64))?;
+                let n = file.read(&mut buffer)?;
+                Ok(output.write(&buffer[..n]))
+            } else {
+                Err(HostIoError::Errno(HostIoErrno::EBADF))
+            }
         } else {
-            Err(HostIoError::Errno(HostIoErrno::EPERM))
+            Err(HostIoError::Errno(HostIoErrno::EBADF))
         }
     }
 }
 
-impl target::ext::host_io::HostIoClose for Emu {
-    fn close(&mut self, fd: u32) -> HostIoResult<u32, Self> {
-        if fd == 1 {
-            Ok(0)
+impl target::ext::host_io::HostIoPwrite for Emu {
+    fn pwrite(&mut self, fd: u32, offset: u32, data: &[u8]) -> HostIoResult<u32, Self> {
+        if fd < FD_MAX {
+            if let Some(ref mut file) = self.files[fd as usize] {
+                file.seek(std::io::SeekFrom::Start(offset as u64))?;
+                let n = file.write(data)?;
+                Ok(n as u32)
+            } else {
+                Err(HostIoError::Errno(HostIoErrno::EBADF))
+            }
         } else {
-            Err(HostIoError::Errno(HostIoErrno::EPERM))
+            Err(HostIoError::Errno(HostIoErrno::EBADF))
         }
+    }
+}
+
+impl target::ext::host_io::HostIoFstat for Emu {
+    fn fstat(&mut self, fd: u32) -> HostIoResult<HostIoStat, Self> {
+        if fd < FD_MAX {
+            if let Some(ref mut file) = self.files[fd as usize] {
+                let metadata = file.metadata()?;
+                let mtime = metadata
+                    .modified()
+                    .map_err(|_| HostIoError::Errno(HostIoErrno::EACCES))?;
+                let duration = mtime
+                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .map_err(|_| HostIoError::Errno(HostIoErrno::EACCES))?;
+                let secs = duration.as_secs() as u32;
+                Ok(HostIoStat {
+                    st_dev: 0,
+                    st_ino: 0,
+                    st_mode: HostIoOpenMode::S_IRUSR
+                        | HostIoOpenMode::S_IWUSR
+                        | HostIoOpenMode::S_IXUSR,
+                    st_nlink: 0,
+                    st_uid: 0,
+                    st_gid: 0,
+                    st_rdev: 0,
+                    st_size: metadata.len(),
+                    st_blksize: 0,
+                    st_blocks: 0,
+                    st_atime: 0,
+                    st_mtime: secs,
+                    st_ctime: 0,
+                })
+            } else {
+                Err(HostIoError::Errno(HostIoErrno::EBADF))
+            }
+        } else {
+            Err(HostIoError::Errno(HostIoErrno::EBADF))
+        }
+    }
+}
+
+impl target::ext::host_io::HostIoUnlink for Emu {
+    fn unlink(&mut self, filename: &[u8]) -> HostIoResult<(), Self> {
+        let path = match std::str::from_utf8(filename) {
+            Ok(v) => v,
+            Err(_) => return Err(HostIoError::Errno(HostIoErrno::ENOENT)),
+        };
+        std::fs::remove_file(path)?;
+        Ok(())
+    }
+}
+
+impl target::ext::host_io::HostIoReadlink for Emu {
+    fn readlink<'a>(
+        &mut self,
+        filename: &[u8],
+        output: HostIoOutput<'a>,
+    ) -> HostIoResult<HostIoToken<'a>, Self> {
+        if filename == b"/proc/1/exe" {
+            // Support `info proc exe` command
+            return Ok(output.write(b"/test.elf"));
+        } else if filename == b"/proc/1/cwd" {
+            // Support `info proc cwd` command
+            return Ok(output.write(b"/"));
+        }
+
+        let path = match std::str::from_utf8(filename) {
+            Ok(v) => v,
+            Err(_) => return Err(HostIoError::Errno(HostIoErrno::ENOENT)),
+        };
+        Ok(output.write(
+            std::fs::read_link(path)?
+                .to_str()
+                .ok_or(HostIoError::Errno(HostIoErrno::ENOENT))?
+                .as_bytes(),
+        ))
     }
 }

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -17,6 +17,7 @@ use crate::emu::{Emu, Event};
 mod breakpoints;
 mod catch_syscalls;
 mod extended_mode;
+mod host_io;
 mod memory_map;
 mod monitor_cmd;
 mod section_offsets;
@@ -92,6 +93,11 @@ impl Target for Emu {
 
     #[inline(always)]
     fn catch_syscalls(&mut self) -> Option<target::ext::catch_syscalls::CatchSyscallsOps<Self>> {
+        Some(self)
+    }
+
+    #[inline(always)]
+    fn host_io(&mut self) -> Option<target::ext::host_io::HostIoOps<Self>> {
         Some(self)
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,59 +1,7 @@
 //! Common types and definitions.
 
-use bitflags::bitflags;
-
 /// Thread ID
 pub type Tid = core::num::NonZeroUsize;
 
 /// Process ID
 pub type Pid = core::num::NonZeroUsize;
-
-bitflags! {
-    // The read/write flags below may look a little weird, but that is the way
-    // they are defined in the protocol.
-    /// Host flags for opening files.
-    pub struct HostOpenFlags: u32 {
-        /// A read-only file.
-        const O_RDONLY = 0x0;
-        /// A write-only file.
-        const O_WRONLY = 0x1;
-        /// A read-write file.
-        const O_RDWR = 0x2;
-        /// Append to an existing file.
-        const O_APPEND = 0x8;
-        /// Create a non-existent file.
-        const O_CREAT = 0x200;
-        /// Truncate an existing file.
-        const O_TRUNC = 0x400;
-        /// Exclusive access.
-        const O_EXCL = 0x800;
-    }
-}
-
-bitflags! {
-    /// Host file permissions.
-    pub struct HostMode: u32 {
-        /// A regular file.
-        const S_IFREG = 0o100000;
-        /// A directory.
-        const S_IFDIR = 0o40000;
-        /// User read permissions.
-        const S_IRUSR = 0o400;
-        /// User write permissions.
-        const S_IWUSR = 0o200;
-        /// User execute permissions.
-        const S_IXUSR = 0o100;
-        /// Group read permissions.
-        const S_IRGRP = 0o40;
-        /// Group write permissions
-        const S_IWGRP = 0o20;
-        /// Group execute permissions.
-        const S_IXGRP = 0o10;
-        /// World read permissions.
-        const S_IROTH = 0o4;
-        /// World write permissions
-        const S_IWOTH = 0o2;
-        /// World execute permissions.
-        const S_IXOTH = 0o1;
-    }
-}

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,59 @@
 //! Common types and definitions.
 
+use bitflags::bitflags;
+
 /// Thread ID
 pub type Tid = core::num::NonZeroUsize;
 
 /// Process ID
 pub type Pid = core::num::NonZeroUsize;
+
+bitflags! {
+    // The read/write flags below may look a little weird, but that is the way
+    // they are defined in the protocol.
+    /// Host flags for opening files.
+    pub struct HostOpenFlags: u32 {
+        /// A read-only file.
+        const O_RDONLY = 0x0;
+        /// A write-only file.
+        const O_WRONLY = 0x1;
+        /// A read-write file.
+        const O_RDWR = 0x2;
+        /// Append to an existing file.
+        const O_APPEND = 0x8;
+        /// Create a non-existent file.
+        const O_CREAT = 0x200;
+        /// Truncate an existing file.
+        const O_TRUNC = 0x400;
+        /// Exclusive access.
+        const O_EXCL = 0x800;
+    }
+}
+
+bitflags! {
+    /// Host file permissions.
+    pub struct HostMode: u32 {
+        /// A regular file.
+        const S_IFREG = 0o100000;
+        /// A directory.
+        const S_IFDIR = 0o40000;
+        /// User read permissions.
+        const S_IRUSR = 0o400;
+        /// User write permissions.
+        const S_IWUSR = 0o200;
+        /// User execute permissions.
+        const S_IXUSR = 0o100;
+        /// Group read permissions.
+        const S_IRGRP = 0o40;
+        /// Group write permissions
+        const S_IWGRP = 0o20;
+        /// Group execute permissions.
+        const S_IXGRP = 0o10;
+        /// World read permissions.
+        const S_IROTH = 0o4;
+        /// World write permissions
+        const S_IWOTH = 0o2;
+        /// World execute permissions.
+        const S_IXOTH = 0o1;
+    }
+}

--- a/src/gdbstub_impl/ext/host_io.rs
+++ b/src/gdbstub_impl/ext/host_io.rs
@@ -1,21 +1,8 @@
 use super::prelude::*;
 use crate::arch::Arch;
 use crate::protocol::commands::ext::HostIo;
-use crate::target::ext::host_io::{HostIoError, HostStat, PreadOutput};
+use crate::target::ext::host_io::{HostIoError, HostIoOutput, HostIoStat};
 use crate::GdbStubError;
-
-macro_rules! handle_hostio_result {
-    ( $ret:ident, $res:ident, $callback:expr) => {{
-        match $ret {
-            Ok(fd) => $callback(fd)?,
-            Err(HostIoError::Errno(errno)) => {
-                $res.write_str("F-1,")?;
-                $res.write_num(errno as i32)?;
-            }
-            Err(HostIoError::Fatal(e)) => return Err(GdbStubError::TargetError(e)),
-        }
-    }};
-}
 
 impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     pub(crate) fn handle_host_io(
@@ -31,25 +18,38 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
         crate::__dead_code_marker!("host_io", "impl");
 
+        macro_rules! handle_hostio_result {
+            ( if let Ok($val:pat) = $ret:expr => $callback:block ) => {{
+                match $ret {
+                    Ok($val) => $callback,
+                    Err(HostIoError::Errno(errno)) => {
+                        res.write_str("F-1,")?;
+                        res.write_num(errno as i32)?;
+                    }
+                    Err(HostIoError::Fatal(e)) => return Err(GdbStubError::TargetError(e)),
+                }
+            }};
+        }
+
         let handler_status = match command {
             HostIo::vFileOpen(cmd) if ops.enable_open().is_some() => {
                 let ops = ops.enable_open().unwrap();
-                let result = ops.open(cmd.filename, cmd.flags, cmd.mode);
-                handle_hostio_result!(result, res, |fd| -> Result<_, Error<T::Error, C::Error>> {
-                    res.write_str("F")?;
-                    res.write_num(fd)?;
-                    Ok(())
-                });
+                handle_hostio_result! {
+                if let Ok(fd) = ops.open(cmd.filename, cmd.flags, cmd.mode) => {
+                        res.write_str("F")?;
+                        res.write_num(fd)?;
+                    }
+                }
                 HandlerStatus::Handled
             }
             HostIo::vFileClose(cmd) if ops.enable_close().is_some() => {
                 let ops = ops.enable_close().unwrap();
-                let result = ops.close(cmd.fd);
-                handle_hostio_result!(result, res, |ret| -> Result<_, Error<T::Error, C::Error>> {
-                    res.write_str("F")?;
-                    res.write_num(ret)?;
-                    Ok(())
-                });
+                handle_hostio_result! {
+                    if let Ok(ret) = ops.close(cmd.fd) => {
+                        res.write_str("F")?;
+                        res.write_num(ret)?;
+                    }
+                }
                 HandlerStatus::Handled
             }
             HostIo::vFilePread(cmd) if ops.enable_pread().is_some() => {
@@ -73,10 +73,9 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 };
 
                 let ops = ops.enable_pread().unwrap();
-                let result = ops.pread(cmd.fd, count, offset, PreadOutput::new(&mut callback));
-                handle_hostio_result!(result, res, |_| -> Result<_, Error<T::Error, C::Error>> {
-                    Ok(())
-                });
+                handle_hostio_result! {
+                    if let Ok(_) = ops.pread(cmd.fd, count, offset, HostIoOutput::new(&mut callback)) => {}
+                };
                 err?;
 
                 HandlerStatus::Handled
@@ -85,22 +84,19 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 let offset = <T::Arch as Arch>::Usize::from_be_bytes(cmd.offset)
                     .ok_or(Error::TargetMismatch)?;
                 let ops = ops.enable_pwrite().unwrap();
-                let result = ops.pwrite(cmd.fd, offset, cmd.data);
-                handle_hostio_result!(result, res, |ret| -> Result<_, Error<T::Error, C::Error>> {
-                    res.write_str("F")?;
-                    res.write_num(ret)?;
-                    Ok(())
-                });
+                handle_hostio_result! {
+                    if let Ok(ret) = ops.pwrite(cmd.fd, offset, cmd.data) => {
+                        res.write_str("F")?;
+                        res.write_num(ret)?;
+                    }
+                };
                 HandlerStatus::Handled
             }
             HostIo::vFileFstat(cmd) if ops.enable_fstat().is_some() => {
                 let ops = ops.enable_fstat().unwrap();
-                let result = ops.fstat(cmd.fd);
-                handle_hostio_result!(
-                    result,
-                    res,
-                    |stat: HostStat| -> Result<_, Error<T::Error, C::Error>> {
-                        let size = core::mem::size_of::<HostStat>();
+                handle_hostio_result! {
+                    if let Ok(stat) = ops.fstat(cmd.fd) => {
+                        let size = core::mem::size_of::<HostIoStat>();
                         res.write_str("F")?;
                         res.write_num(size)?;
                         res.write_str(";")?;
@@ -117,37 +113,52 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                         res.write_binary(&stat.st_atime.to_le_bytes())?;
                         res.write_binary(&stat.st_mtime.to_le_bytes())?;
                         res.write_binary(&stat.st_ctime.to_le_bytes())?;
-                        Ok(())
                     }
-                );
+                };
                 HandlerStatus::Handled
             }
             HostIo::vFileUnlink(cmd) if ops.enable_unlink().is_some() => {
                 let ops = ops.enable_unlink().unwrap();
-                let result = ops.unlink(cmd.filename);
-                handle_hostio_result!(result, res, |ret| -> Result<_, Error<T::Error, C::Error>> {
-                    res.write_str("F")?;
-                    res.write_num(ret)?;
-                    Ok(())
-                });
+                handle_hostio_result! {
+                    if let Ok(ret) = ops.unlink(cmd.filename) => {
+                        res.write_str("F")?;
+                        res.write_num(ret)?;
+                    }
+                };
                 HandlerStatus::Handled
             }
             HostIo::vFileReadlink(cmd) if ops.enable_readlink().is_some() => {
+                let mut err: Result<_, Error<T::Error, C::Error>> = Ok(());
+                let mut callback = |data: &[u8]| {
+                    let e = (|| {
+                        res.write_str("F")?;
+                        res.write_num(data.len())?;
+                        res.write_str(";")?;
+                        res.write_binary(data)?;
+                        Ok(())
+                    })();
+
+                    if let Err(e) = e {
+                        err = Err(e)
+                    }
+                };
+
                 let ops = ops.enable_readlink().unwrap();
-                let result = ops.readlink(cmd.filename);
-                handle_hostio_result!(result, res, |ret| -> Result<_, Error<T::Error, C::Error>> {
-                    res.write_str("F")?;
-                    res.write_num(ret)?;
-                    Ok(())
-                });
+                handle_hostio_result! {
+                    if let Ok(_) = ops.readlink(cmd.filename, HostIoOutput::new(&mut callback)) => {}
+                };
+                err?;
+
                 HandlerStatus::Handled
             }
             HostIo::vFileSetfs(cmd) if ops.enable_setfs().is_some() => {
                 let ops = ops.enable_setfs().unwrap();
-                let result = ops.setfs(cmd.fs);
-                handle_hostio_result!(result, res, |_| -> Result<_, Error<T::Error, C::Error>> {
-                    Ok(())
-                });
+                handle_hostio_result! {
+                    if let Ok(ret) = ops.setfs(cmd.fs) => {
+                        res.write_str("F")?;
+                        res.write_num(ret)?;
+                    }
+                };
                 HandlerStatus::Handled
             }
             _ => HandlerStatus::Handled,

--- a/src/gdbstub_impl/ext/host_io.rs
+++ b/src/gdbstub_impl/ext/host_io.rs
@@ -1,7 +1,21 @@
 use super::prelude::*;
 use crate::arch::Arch;
 use crate::protocol::commands::ext::HostIo;
-use crate::target::ext::host_io::{HostStat, PreadOutput};
+use crate::target::ext::host_io::{HostIoError, HostStat, PreadOutput};
+use crate::GdbStubError;
+
+macro_rules! handle_hostio_result {
+    ( $ret:ident, $res:ident, $callback:expr) => {{
+        match $ret {
+            Ok(fd) => $callback(fd)?,
+            Err(HostIoError::Errno(errno)) => {
+                $res.write_str("F-1,")?;
+                $res.write_num(errno as i32)?;
+            }
+            Err(HostIoError::Fatal(e)) => return Err(GdbStubError::TargetError(e)),
+        }
+    }};
+}
 
 impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     pub(crate) fn handle_host_io(
@@ -20,16 +34,22 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
         let handler_status = match command {
             HostIo::vFileOpen(cmd) if ops.enable_open().is_some() => {
                 let ops = ops.enable_open().unwrap();
-                let ret = ops.open(cmd.filename, cmd.flags, cmd.mode).handle_error()?;
-                res.write_str("F")?;
-                res.write_num(ret)?;
+                let result = ops.open(cmd.filename, cmd.flags, cmd.mode);
+                handle_hostio_result!(result, res, |fd| -> Result<_, Error<T::Error, C::Error>> {
+                    res.write_str("F")?;
+                    res.write_num(fd)?;
+                    Ok(())
+                });
                 HandlerStatus::Handled
             }
             HostIo::vFileClose(cmd) if ops.enable_close().is_some() => {
                 let ops = ops.enable_close().unwrap();
-                let ret = ops.close(cmd.fd).handle_error()?;
-                res.write_str("F")?;
-                res.write_num(ret)?;
+                let result = ops.close(cmd.fd);
+                handle_hostio_result!(result, res, |ret| -> Result<_, Error<T::Error, C::Error>> {
+                    res.write_str("F")?;
+                    res.write_num(ret)?;
+                    Ok(())
+                });
                 HandlerStatus::Handled
             }
             HostIo::vFilePread(cmd) if ops.enable_pread().is_some() => {
@@ -53,8 +73,10 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 };
 
                 let ops = ops.enable_pread().unwrap();
-                ops.pread(cmd.fd, count, offset, PreadOutput::new(&mut callback))
-                    .handle_error()?;
+                let result = ops.pread(cmd.fd, count, offset, PreadOutput::new(&mut callback));
+                handle_hostio_result!(result, res, |_| -> Result<_, Error<T::Error, C::Error>> {
+                    Ok(())
+                });
                 err?;
 
                 HandlerStatus::Handled
@@ -63,40 +85,69 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 let offset = <T::Arch as Arch>::Usize::from_be_bytes(cmd.offset)
                     .ok_or(Error::TargetMismatch)?;
                 let ops = ops.enable_pwrite().unwrap();
-                let ret = ops.pwrite(cmd.fd, offset, cmd.data).handle_error()?;
-                res.write_str("F")?;
-                res.write_num(ret)?;
+                let result = ops.pwrite(cmd.fd, offset, cmd.data);
+                handle_hostio_result!(result, res, |ret| -> Result<_, Error<T::Error, C::Error>> {
+                    res.write_str("F")?;
+                    res.write_num(ret)?;
+                    Ok(())
+                });
                 HandlerStatus::Handled
             }
             HostIo::vFileFstat(cmd) if ops.enable_fstat().is_some() => {
                 let ops = ops.enable_fstat().unwrap();
-                let stat = ops.fstat(cmd.fd).handle_error()?;
-                let size = core::mem::size_of_val(&stat);
-                let p: *const HostStat = &stat;
-                let p: *const u8 = p as *const u8;
-                res.write_str("F")?;
-                res.write_num(size)?;
-                res.write_str(";")?;
-                res.write_binary(unsafe { core::slice::from_raw_parts(p, size) })?;
+                let result = ops.fstat(cmd.fd);
+                handle_hostio_result!(
+                    result,
+                    res,
+                    |stat: HostStat| -> Result<_, Error<T::Error, C::Error>> {
+                        let size = core::mem::size_of::<HostStat>();
+                        res.write_str("F")?;
+                        res.write_num(size)?;
+                        res.write_str(";")?;
+                        res.write_binary(&stat.st_dev.to_le_bytes())?;
+                        res.write_binary(&stat.st_ino.to_le_bytes())?;
+                        res.write_binary(&(stat.st_mode.bits()).to_le_bytes())?;
+                        res.write_binary(&stat.st_nlink.to_le_bytes())?;
+                        res.write_binary(&stat.st_uid.to_le_bytes())?;
+                        res.write_binary(&stat.st_gid.to_le_bytes())?;
+                        res.write_binary(&stat.st_rdev.to_le_bytes())?;
+                        res.write_binary(&stat.st_size.to_le_bytes())?;
+                        res.write_binary(&stat.st_blksize.to_le_bytes())?;
+                        res.write_binary(&stat.st_blocks.to_le_bytes())?;
+                        res.write_binary(&stat.st_atime.to_le_bytes())?;
+                        res.write_binary(&stat.st_mtime.to_le_bytes())?;
+                        res.write_binary(&stat.st_ctime.to_le_bytes())?;
+                        Ok(())
+                    }
+                );
                 HandlerStatus::Handled
             }
             HostIo::vFileUnlink(cmd) if ops.enable_unlink().is_some() => {
                 let ops = ops.enable_unlink().unwrap();
-                let ret = ops.unlink(cmd.filename).handle_error()?;
-                res.write_str("F")?;
-                res.write_num(ret)?;
+                let result = ops.unlink(cmd.filename);
+                handle_hostio_result!(result, res, |ret| -> Result<_, Error<T::Error, C::Error>> {
+                    res.write_str("F")?;
+                    res.write_num(ret)?;
+                    Ok(())
+                });
                 HandlerStatus::Handled
             }
             HostIo::vFileReadlink(cmd) if ops.enable_readlink().is_some() => {
                 let ops = ops.enable_readlink().unwrap();
-                let ret = ops.readlink(cmd.filename).handle_error()?;
-                res.write_str("F")?;
-                res.write_num(ret)?;
+                let result = ops.readlink(cmd.filename);
+                handle_hostio_result!(result, res, |ret| -> Result<_, Error<T::Error, C::Error>> {
+                    res.write_str("F")?;
+                    res.write_num(ret)?;
+                    Ok(())
+                });
                 HandlerStatus::Handled
             }
             HostIo::vFileSetfs(cmd) if ops.enable_setfs().is_some() => {
                 let ops = ops.enable_setfs().unwrap();
-                ops.setfs(cmd.fs).handle_error()?;
+                let result = ops.setfs(cmd.fs);
+                handle_hostio_result!(result, res, |_| -> Result<_, Error<T::Error, C::Error>> {
+                    Ok(())
+                });
                 HandlerStatus::Handled
             }
             _ => HandlerStatus::Handled,

--- a/src/gdbstub_impl/ext/host_io.rs
+++ b/src/gdbstub_impl/ext/host_io.rs
@@ -3,7 +3,6 @@ use crate::protocol::commands::ext::HostIo;
 
 use crate::arch::Arch;
 use crate::target::ext::host_io::{HostIoError, HostIoOutput, HostIoStat};
-use crate::GdbStubError;
 
 impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     pub(crate) fn handle_host_io(
@@ -27,7 +26,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                         res.write_str("F-1,")?;
                         res.write_num(errno as u32)?;
                     }
-                    Err(HostIoError::Fatal(e)) => return Err(GdbStubError::TargetError(e)),
+                    Err(HostIoError::Fatal(e)) => return Err(Error::TargetError(e)),
                 }
             }};
         }

--- a/src/gdbstub_impl/ext/host_io.rs
+++ b/src/gdbstub_impl/ext/host_io.rs
@@ -24,7 +24,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     Ok($val) => $callback,
                     Err(HostIoError::Errno(errno)) => {
                         res.write_str("F-1,")?;
-                        res.write_num(errno as i32)?;
+                        res.write_num(errno as u32)?;
                     }
                     Err(HostIoError::Fatal(e)) => return Err(GdbStubError::TargetError(e)),
                 }

--- a/src/gdbstub_impl/ext/host_io.rs
+++ b/src/gdbstub_impl/ext/host_io.rs
@@ -1,0 +1,49 @@
+use super::prelude::*;
+use crate::protocol::commands::ext::HostIo;
+
+impl<T: Target, C: Connection> GdbStubImpl<T, C> {
+    pub(crate) fn handle_host_io(
+        &mut self,
+        res: &mut ResponseWriter<C>,
+        target: &mut T,
+        command: HostIo,
+    ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
+        let ops = match target.host_io() {
+            Some(ops) => ops,
+            None => return Ok(HandlerStatus::Handled),
+        };
+
+        crate::__dead_code_marker!("host_io", "impl");
+
+        let handler_status = match command {
+            HostIo::vFileOpen(cmd) => {
+                let ret = ops.open(cmd.filename, cmd.flags, cmd.mode);
+                res.write_str("F")?;
+                res.write_num(ret)?;
+                HandlerStatus::Handled
+            }
+            HostIo::vFileClose(cmd) => {
+                let ret = ops.close(cmd.fd);
+                res.write_str("F")?;
+                res.write_num(ret)?;
+                HandlerStatus::Handled
+            }
+            HostIo::vFilePread(cmd) => {
+                let data = ops.pread(cmd.fd, cmd.count, cmd.offset);
+                res.write_str("F")?;
+                res.write_num(data.len())?;
+                res.write_str(";")?;
+                res.write_binary(data)?;
+                HandlerStatus::Handled
+            }
+            HostIo::vFileSetfs(cmd) => {
+                let ret = ops.setfs(cmd.fd);
+                res.write_str("F")?;
+                res.write_num(ret)?;
+                HandlerStatus::Handled
+            }
+        };
+
+        Ok(handler_status)
+    }
+}

--- a/src/gdbstub_impl/ext/host_io.rs
+++ b/src/gdbstub_impl/ext/host_io.rs
@@ -35,7 +35,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             HostIo::vFileOpen(cmd) if ops.enable_open().is_some() => {
                 let ops = ops.enable_open().unwrap();
                 handle_hostio_result! {
-                if let Ok(fd) = ops.open(cmd.filename, cmd.flags, cmd.mode) => {
+                    if let Ok(fd) = ops.open(cmd.filename, cmd.flags, cmd.mode) => {
                         res.write_str("F")?;
                         res.write_num(fd)?;
                     }
@@ -45,9 +45,8 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             HostIo::vFileClose(cmd) if ops.enable_close().is_some() => {
                 let ops = ops.enable_close().unwrap();
                 handle_hostio_result! {
-                    if let Ok(ret) = ops.close(cmd.fd) => {
-                        res.write_str("F")?;
-                        res.write_num(ret)?;
+                    if let Ok(()) = ops.close(cmd.fd) => {
+                        res.write_str("F0")?;
                     }
                 }
                 HandlerStatus::Handled
@@ -120,9 +119,8 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             HostIo::vFileUnlink(cmd) if ops.enable_unlink().is_some() => {
                 let ops = ops.enable_unlink().unwrap();
                 handle_hostio_result! {
-                    if let Ok(ret) = ops.unlink(cmd.filename) => {
-                        res.write_str("F")?;
-                        res.write_num(ret)?;
+                    if let Ok(()) = ops.unlink(cmd.filename) => {
+                        res.write_str("F0")?;
                     }
                 };
                 HandlerStatus::Handled
@@ -154,9 +152,8 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             HostIo::vFileSetfs(cmd) if ops.enable_setfs().is_some() => {
                 let ops = ops.enable_setfs().unwrap();
                 handle_hostio_result! {
-                    if let Ok(ret) = ops.setfs(cmd.fs) => {
-                        res.write_str("F")?;
-                        res.write_num(ret)?;
+                    if let Ok(()) = ops.setfs(cmd.fs) => {
+                        res.write_str("F0")?;
                     }
                 };
                 HandlerStatus::Handled

--- a/src/gdbstub_impl/ext/host_io.rs
+++ b/src/gdbstub_impl/ext/host_io.rs
@@ -1,6 +1,7 @@
 use super::prelude::*;
-use crate::arch::Arch;
 use crate::protocol::commands::ext::HostIo;
+
+use crate::arch::Arch;
 use crate::target::ext::host_io::{HostIoError, HostIoOutput, HostIoStat};
 use crate::GdbStubError;
 
@@ -99,19 +100,19 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                         res.write_str("F")?;
                         res.write_num(size)?;
                         res.write_str(";")?;
-                        res.write_binary(&stat.st_dev.to_le_bytes())?;
-                        res.write_binary(&stat.st_ino.to_le_bytes())?;
-                        res.write_binary(&(stat.st_mode.bits()).to_le_bytes())?;
-                        res.write_binary(&stat.st_nlink.to_le_bytes())?;
-                        res.write_binary(&stat.st_uid.to_le_bytes())?;
-                        res.write_binary(&stat.st_gid.to_le_bytes())?;
-                        res.write_binary(&stat.st_rdev.to_le_bytes())?;
-                        res.write_binary(&stat.st_size.to_le_bytes())?;
-                        res.write_binary(&stat.st_blksize.to_le_bytes())?;
-                        res.write_binary(&stat.st_blocks.to_le_bytes())?;
-                        res.write_binary(&stat.st_atime.to_le_bytes())?;
-                        res.write_binary(&stat.st_mtime.to_le_bytes())?;
-                        res.write_binary(&stat.st_ctime.to_le_bytes())?;
+                        res.write_binary(&stat.st_dev.to_be_bytes())?;
+                        res.write_binary(&stat.st_ino.to_be_bytes())?;
+                        res.write_binary(&(stat.st_mode.bits()).to_be_bytes())?;
+                        res.write_binary(&stat.st_nlink.to_be_bytes())?;
+                        res.write_binary(&stat.st_uid.to_be_bytes())?;
+                        res.write_binary(&stat.st_gid.to_be_bytes())?;
+                        res.write_binary(&stat.st_rdev.to_be_bytes())?;
+                        res.write_binary(&stat.st_size.to_be_bytes())?;
+                        res.write_binary(&stat.st_blksize.to_be_bytes())?;
+                        res.write_binary(&stat.st_blocks.to_be_bytes())?;
+                        res.write_binary(&stat.st_atime.to_be_bytes())?;
+                        res.write_binary(&stat.st_mtime.to_be_bytes())?;
+                        res.write_binary(&stat.st_ctime.to_be_bytes())?;
                     }
                 };
                 HandlerStatus::Handled

--- a/src/gdbstub_impl/ext/mod.rs
+++ b/src/gdbstub_impl/ext/mod.rs
@@ -15,6 +15,7 @@ mod base;
 mod breakpoints;
 mod catch_syscalls;
 mod extended_mode;
+mod host_io;
 mod memory_map;
 mod monitor_cmd;
 mod reverse_exec;

--- a/src/gdbstub_impl/mod.rs
+++ b/src/gdbstub_impl/mod.rs
@@ -579,6 +579,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Command::ReverseCont(cmd) => self.handle_reverse_cont(res, target, cmd),
             Command::ReverseStep(cmd) => self.handle_reverse_step(res, target, cmd),
             Command::MemoryMap(cmd) => self.handle_memory_map(res, target, cmd),
+            Command::HostIo(cmd) => self.handle_host_io(res, target, cmd),
         }
     }
 }

--- a/src/gdbstub_impl/mod.rs
+++ b/src/gdbstub_impl/mod.rs
@@ -561,9 +561,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
         match cmd {
             Command::Unknown(cmd) => {
-                // cmd must be ASCII, as the slice originated from a PacketBuf, which checks for
-                // ASCII as part of the initial validation.
-                info!("Unknown command: {}", core::str::from_utf8(cmd).unwrap());
+                info!("Unknown command: {:?}", core::str::from_utf8(cmd));
                 Ok(HandlerStatus::Handled)
             }
             // `handle_X` methods are defined in the `ext` module

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -6,7 +6,9 @@ use crate::target::Target;
 pub(self) mod prelude {
     pub use super::ParseCommand;
     pub use crate::common::*;
-    pub use crate::protocol::common::hex::{decode_hex, decode_hex_buf, is_hex, HexString};
+    pub use crate::protocol::common::hex::{
+        decode_bin_buf, decode_hex, decode_hex_buf, is_hex, HexString,
+    };
     pub use crate::protocol::common::lists;
     pub use crate::protocol::common::thread_id::{
         IdKind, SpecificIdKind, SpecificThreadId, ThreadId,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -223,6 +223,13 @@ commands! {
         "qXfer:memory-map:read" => _qXfer_memory_map::qXferMemoryMapRead,
     }
 
+    host_io use 'a{
+        "vFile:open" => _vFile_open::vFileOpen<'a>,
+        "vFile:close" => _vFile_close::vFileClose,
+        "vFile:pread" => _vFile_pread::vFilePread,
+        "vFile:setfs" => _vFile_setfs::vFileSetfs,
+    }
+
     catch_syscalls use 'a {
         "QCatchSyscalls" => _QCatchSyscalls::QCatchSyscalls<'a>,
     }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -223,10 +223,10 @@ commands! {
         "qXfer:memory-map:read" => _qXfer_memory_map::qXferMemoryMapRead,
     }
 
-    host_io use 'a{
+    host_io use 'a {
         "vFile:open" => _vFile_open::vFileOpen<'a>,
         "vFile:close" => _vFile_close::vFileClose,
-        "vFile:pread" => _vFile_pread::vFilePread,
+        "vFile:pread" => _vFile_pread::vFilePread<'a>,
         "vFile:setfs" => _vFile_setfs::vFileSetfs,
     }
 

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -227,6 +227,10 @@ commands! {
         "vFile:open" => _vFile_open::vFileOpen<'a>,
         "vFile:close" => _vFile_close::vFileClose,
         "vFile:pread" => _vFile_pread::vFilePread<'a>,
+        "vFile:pwrite" => _vFile_pwrite::vFilePwrite<'a>,
+        "vFile:fstat" => _vFile_fstat::vFileFstat,
+        "vFile:unlink" => _vFile_unlink::vFileUnlink<'a>,
+        "vFile:readlink" => _vFile_readlink::vFileReadlink<'a>,
         "vFile:setfs" => _vFile_setfs::vFileSetfs,
     }
 

--- a/src/protocol/commands/_vFile_close.rs
+++ b/src/protocol/commands/_vFile_close.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 
 #[derive(Debug)]
 pub struct vFileClose {
-    pub fd: i32,
+    pub fd: u32,
 }
 
 impl<'a> ParseCommand<'a> for vFileClose {

--- a/src/protocol/commands/_vFile_close.rs
+++ b/src/protocol/commands/_vFile_close.rs
@@ -1,0 +1,23 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct vFileClose {
+    pub fd: usize,
+}
+
+impl<'a> ParseCommand<'a> for vFileClose {
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let body = buf.into_body();
+        if body.is_empty() {
+            return None;
+        }
+
+        match body {
+            [b':', body @ ..] => {
+                let fd = decode_hex(body).ok()?;
+                Some(vFileClose{fd})
+            },
+            _ => None,
+        }
+    }
+}

--- a/src/protocol/commands/_vFile_close.rs
+++ b/src/protocol/commands/_vFile_close.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 
 #[derive(Debug)]
 pub struct vFileClose {
-    pub fd: usize,
+    pub fd: i32,
 }
 
 impl<'a> ParseCommand<'a> for vFileClose {

--- a/src/protocol/commands/_vFile_fstat.rs
+++ b/src/protocol/commands/_vFile_fstat.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 
 #[derive(Debug)]
 pub struct vFileFstat {
-    pub fd: i32,
+    pub fd: u32,
 }
 
 impl<'a> ParseCommand<'a> for vFileFstat {

--- a/src/protocol/commands/_vFile_fstat.rs
+++ b/src/protocol/commands/_vFile_fstat.rs
@@ -1,11 +1,11 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct vFileSetfs {
-    pub pid: usize,
+pub struct vFileFstat {
+    pub fd: i32,
 }
 
-impl<'a> ParseCommand<'a> for vFileSetfs {
+impl<'a> ParseCommand<'a> for vFileFstat {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
         let body = buf.into_body();
         if body.is_empty() {
@@ -14,8 +14,9 @@ impl<'a> ParseCommand<'a> for vFileSetfs {
 
         match body {
             [b':', body @ ..] => {
-                let pid = decode_hex(body).ok()?;
-                Some(vFileSetfs{pid})
+                let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
+                let fd = decode_hex(body.next()?).ok()?;
+                Some(vFileFstat{fd})
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_fstat.rs
+++ b/src/protocol/commands/_vFile_fstat.rs
@@ -14,8 +14,7 @@ impl<'a> ParseCommand<'a> for vFileFstat {
 
         match body {
             [b':', body @ ..] => {
-                let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
-                let fd = decode_hex(body.next()?).ok()?;
+                let fd = decode_hex(body).ok()?;
                 Some(vFileFstat{fd})
             },
             _ => None,

--- a/src/protocol/commands/_vFile_open.rs
+++ b/src/protocol/commands/_vFile_open.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
-use crate::common::{HostOpenFlags, HostMode};
+use crate::target::ext::host_io::{HostOpenFlags, HostMode};
 
 #[derive(Debug)]
 pub struct vFileOpen<'a> {
@@ -20,8 +20,8 @@ impl<'a> ParseCommand<'a> for vFileOpen<'a> {
             [b':', body @ ..] => {
                 let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
                 let filename = decode_hex_buf(body.next()?).ok()?;
-                let flags = HostOpenFlags::from_bits_truncate(decode_hex(body.next()?).ok()?);
-                let mode = HostMode::from_bits_truncate(decode_hex(body.next()?).ok()?);
+                let flags = HostOpenFlags::from_bits(decode_hex(body.next()?).ok()?).unwrap();
+                let mode = HostMode::from_bits(decode_hex(body.next()?).ok()?).unwrap();
                 Some(vFileOpen{filename, flags, mode})
             },
             _ => None,

--- a/src/protocol/commands/_vFile_open.rs
+++ b/src/protocol/commands/_vFile_open.rs
@@ -1,10 +1,12 @@
 use super::prelude::*;
 
+use crate::common::{HostOpenFlags, HostMode};
+
 #[derive(Debug)]
 pub struct vFileOpen<'a> {
     pub filename: &'a [u8],
-    pub flags: u64,
-    pub mode: u64,
+    pub flags: HostOpenFlags,
+    pub mode: HostMode,
 }
 
 impl<'a> ParseCommand<'a> for vFileOpen<'a> {
@@ -18,8 +20,8 @@ impl<'a> ParseCommand<'a> for vFileOpen<'a> {
             [b':', body @ ..] => {
                 let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
                 let filename = decode_hex_buf(body.next()?).ok()?;
-                let flags= decode_hex(body.next()?).ok()?;
-                let mode= decode_hex(body.next()?).ok()?;
+                let flags = HostOpenFlags::from_bits_truncate(decode_hex(body.next()?).ok()?);
+                let mode = HostMode::from_bits_truncate(decode_hex(body.next()?).ok()?);
                 Some(vFileOpen{filename, flags, mode})
             },
             _ => None,

--- a/src/protocol/commands/_vFile_open.rs
+++ b/src/protocol/commands/_vFile_open.rs
@@ -1,0 +1,28 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct vFileOpen<'a> {
+    pub filename: &'a [u8],
+    pub flags: u64,
+    pub mode: u64,
+}
+
+impl<'a> ParseCommand<'a> for vFileOpen<'a> {
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let body = buf.into_body();
+        if body.is_empty() {
+            return None;
+        }
+
+        match body {
+            [b':', body @ ..] => {
+                let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
+                let filename = decode_hex_buf(body.next()?).ok()?;
+                let flags= decode_hex(body.next()?).ok()?;
+                let mode= decode_hex(body.next()?).ok()?;
+                Some(vFileOpen{filename, flags, mode})
+            },
+            _ => None,
+        }
+    }
+}

--- a/src/protocol/commands/_vFile_open.rs
+++ b/src/protocol/commands/_vFile_open.rs
@@ -1,12 +1,12 @@
 use super::prelude::*;
 
-use crate::target::ext::host_io::{HostOpenFlags, HostMode};
+use crate::target::ext::host_io::{HostIoOpenFlags, HostIoMode};
 
 #[derive(Debug)]
 pub struct vFileOpen<'a> {
     pub filename: &'a [u8],
-    pub flags: HostOpenFlags,
-    pub mode: HostMode,
+    pub flags: HostIoOpenFlags,
+    pub mode: HostIoMode,
 }
 
 impl<'a> ParseCommand<'a> for vFileOpen<'a> {
@@ -20,8 +20,8 @@ impl<'a> ParseCommand<'a> for vFileOpen<'a> {
             [b':', body @ ..] => {
                 let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
                 let filename = decode_hex_buf(body.next()?).ok()?;
-                let flags = HostOpenFlags::from_bits(decode_hex(body.next()?).ok()?).unwrap();
-                let mode = HostMode::from_bits(decode_hex(body.next()?).ok()?).unwrap();
+                let flags = HostIoOpenFlags::from_bits(decode_hex(body.next()?).ok()?).unwrap();
+                let mode = HostIoMode::from_bits(decode_hex(body.next()?).ok()?).unwrap();
                 Some(vFileOpen{filename, flags, mode})
             },
             _ => None,

--- a/src/protocol/commands/_vFile_open.rs
+++ b/src/protocol/commands/_vFile_open.rs
@@ -20,8 +20,8 @@ impl<'a> ParseCommand<'a> for vFileOpen<'a> {
             [b':', body @ ..] => {
                 let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
                 let filename = decode_hex_buf(body.next()?).ok()?;
-                let flags = HostIoOpenFlags::from_bits(decode_hex(body.next()?).ok()?).unwrap();
-                let mode = HostIoOpenMode::from_bits(decode_hex(body.next()?).ok()?).unwrap();
+                let flags = HostIoOpenFlags::from_bits(decode_hex(body.next()?).ok()?)?;
+                let mode = HostIoOpenMode::from_bits(decode_hex(body.next()?).ok()?)?;
                 Some(vFileOpen{filename, flags, mode})
             },
             _ => None,

--- a/src/protocol/commands/_vFile_open.rs
+++ b/src/protocol/commands/_vFile_open.rs
@@ -1,12 +1,12 @@
 use super::prelude::*;
 
-use crate::target::ext::host_io::{HostIoOpenFlags, HostIoMode};
+use crate::target::ext::host_io::{HostIoOpenFlags, HostIoOpenMode};
 
 #[derive(Debug)]
 pub struct vFileOpen<'a> {
     pub filename: &'a [u8],
     pub flags: HostIoOpenFlags,
-    pub mode: HostIoMode,
+    pub mode: HostIoOpenMode,
 }
 
 impl<'a> ParseCommand<'a> for vFileOpen<'a> {
@@ -21,7 +21,7 @@ impl<'a> ParseCommand<'a> for vFileOpen<'a> {
                 let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
                 let filename = decode_hex_buf(body.next()?).ok()?;
                 let flags = HostIoOpenFlags::from_bits(decode_hex(body.next()?).ok()?).unwrap();
-                let mode = HostIoMode::from_bits(decode_hex(body.next()?).ok()?).unwrap();
+                let mode = HostIoOpenMode::from_bits(decode_hex(body.next()?).ok()?).unwrap();
                 Some(vFileOpen{filename, flags, mode})
             },
             _ => None,

--- a/src/protocol/commands/_vFile_pread.rs
+++ b/src/protocol/commands/_vFile_pread.rs
@@ -1,0 +1,28 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct vFilePread {
+    pub fd: usize,
+    pub count: usize,
+    pub offset: usize,
+}
+
+impl<'a> ParseCommand<'a> for vFilePread {
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let body = buf.into_body();
+        if body.is_empty() {
+            return None;
+        }
+
+        match body {
+            [b':', body @ ..] => {
+                let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
+                let fd = decode_hex(body.next()?).ok()?;
+                let count= decode_hex(body.next()?).ok()?;
+                let offset= decode_hex(body.next()?).ok()?;
+                Some(vFilePread{fd, count, offset})
+            },
+            _ => None,
+        }
+    }
+}

--- a/src/protocol/commands/_vFile_pread.rs
+++ b/src/protocol/commands/_vFile_pread.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 
 #[derive(Debug)]
 pub struct vFilePread<'a> {
-    pub fd: i32,
+    pub fd: u32,
     pub count: &'a [u8],
     pub offset: &'a [u8],
 }

--- a/src/protocol/commands/_vFile_pread.rs
+++ b/src/protocol/commands/_vFile_pread.rs
@@ -1,13 +1,13 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct vFilePread {
+pub struct vFilePread<'a> {
     pub fd: usize,
-    pub count: usize,
-    pub offset: usize,
+    pub count: &'a [u8],
+    pub offset: &'a [u8],
 }
 
-impl<'a> ParseCommand<'a> for vFilePread {
+impl<'a> ParseCommand<'a> for vFilePread<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
         let body = buf.into_body();
         if body.is_empty() {
@@ -18,8 +18,8 @@ impl<'a> ParseCommand<'a> for vFilePread {
             [b':', body @ ..] => {
                 let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
                 let fd = decode_hex(body.next()?).ok()?;
-                let count= decode_hex(body.next()?).ok()?;
-                let offset= decode_hex(body.next()?).ok()?;
+                let count = decode_hex_buf(body.next()?).ok()?;
+                let offset = decode_hex_buf(body.next()?).ok()?;
                 Some(vFilePread{fd, count, offset})
             },
             _ => None,

--- a/src/protocol/commands/_vFile_pwrite.rs
+++ b/src/protocol/commands/_vFile_pwrite.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 
 #[derive(Debug)]
 pub struct vFilePwrite<'a> {
-    pub fd: i32,
+    pub fd: u32,
     pub offset: &'a [u8],
     pub data: &'a [u8],
 }

--- a/src/protocol/commands/_vFile_pwrite.rs
+++ b/src/protocol/commands/_vFile_pwrite.rs
@@ -19,7 +19,7 @@ impl<'a> ParseCommand<'a> for vFilePwrite<'a> {
                 let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
                 let fd = decode_hex(body.next()?).ok()?;
                 let offset = decode_hex_buf(body.next()?).ok()?;
-                let data = body.next()?;
+                let data = decode_bin_buf(body.next()?).ok()?;
                 Some(vFilePwrite{fd, offset, data})
             },
             _ => None,

--- a/src/protocol/commands/_vFile_pwrite.rs
+++ b/src/protocol/commands/_vFile_pwrite.rs
@@ -1,13 +1,13 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct vFilePread<'a> {
+pub struct vFilePwrite<'a> {
     pub fd: i32,
-    pub count: &'a [u8],
     pub offset: &'a [u8],
+    pub data: &'a [u8],
 }
 
-impl<'a> ParseCommand<'a> for vFilePread<'a> {
+impl<'a> ParseCommand<'a> for vFilePwrite<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
         let body = buf.into_body();
         if body.is_empty() {
@@ -18,9 +18,9 @@ impl<'a> ParseCommand<'a> for vFilePread<'a> {
             [b':', body @ ..] => {
                 let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
                 let fd = decode_hex(body.next()?).ok()?;
-                let count = decode_hex_buf(body.next()?).ok()?;
                 let offset = decode_hex_buf(body.next()?).ok()?;
-                Some(vFilePread{fd, count, offset})
+                let data = decode_hex_buf(body.next()?).ok()?;
+                Some(vFilePwrite{fd, offset, data})
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_pwrite.rs
+++ b/src/protocol/commands/_vFile_pwrite.rs
@@ -19,7 +19,7 @@ impl<'a> ParseCommand<'a> for vFilePwrite<'a> {
                 let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
                 let fd = decode_hex(body.next()?).ok()?;
                 let offset = decode_hex_buf(body.next()?).ok()?;
-                let data = decode_hex_buf(body.next()?).ok()?;
+                let data = body.next()?;
                 Some(vFilePwrite{fd, offset, data})
             },
             _ => None,

--- a/src/protocol/commands/_vFile_readlink.rs
+++ b/src/protocol/commands/_vFile_readlink.rs
@@ -1,11 +1,11 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct vFileSetfs {
-    pub pid: usize,
+pub struct vFileReadlink<'a> {
+    pub filename: &'a [u8],
 }
 
-impl<'a> ParseCommand<'a> for vFileSetfs {
+impl<'a> ParseCommand<'a> for vFileReadlink<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
         let body = buf.into_body();
         if body.is_empty() {
@@ -14,8 +14,8 @@ impl<'a> ParseCommand<'a> for vFileSetfs {
 
         match body {
             [b':', body @ ..] => {
-                let pid = decode_hex(body).ok()?;
-                Some(vFileSetfs{pid})
+                let filename = decode_hex_buf(body).ok()?;
+                Some(vFileReadlink{filename})
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_setfs.rs
+++ b/src/protocol/commands/_vFile_setfs.rs
@@ -1,8 +1,10 @@
 use super::prelude::*;
+use crate::target::ext::host_io::FsKind;
+use core::num::NonZeroUsize;
 
 #[derive(Debug)]
 pub struct vFileSetfs {
-    pub pid: usize,
+    pub fs: FsKind,
 }
 
 impl<'a> ParseCommand<'a> for vFileSetfs {
@@ -14,8 +16,11 @@ impl<'a> ParseCommand<'a> for vFileSetfs {
 
         match body {
             [b':', body @ ..] => {
-                let pid = decode_hex(body).ok()?;
-                Some(vFileSetfs{pid})
+                let fs = match decode_hex(body).ok()? {
+                    0 => FsKind::Stub,
+                    pid => FsKind::Pid(NonZeroUsize::new(pid).unwrap()),
+                };
+                Some(vFileSetfs{fs})
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_setfs.rs
+++ b/src/protocol/commands/_vFile_setfs.rs
@@ -16,9 +16,9 @@ impl<'a> ParseCommand<'a> for vFileSetfs {
 
         match body {
             [b':', body @ ..] => {
-                let fs = match decode_hex(body).ok()? {
-                    0 => FsKind::Stub,
-                    pid => FsKind::Pid(NonZeroUsize::new(pid).unwrap()),
+                let fs = match NonZeroUsize::new(decode_hex(body).ok()?) {
+                    None => FsKind::Stub,
+                    Some(pid) => FsKind::Pid(pid),
                 };
                 Some(vFileSetfs{fs})
             },

--- a/src/protocol/commands/_vFile_setfs.rs
+++ b/src/protocol/commands/_vFile_setfs.rs
@@ -1,0 +1,23 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct vFileSetfs {
+    pub fd: usize,
+}
+
+impl<'a> ParseCommand<'a> for vFileSetfs {
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let body = buf.into_body();
+        if body.is_empty() {
+            return None;
+        }
+
+        match body {
+            [b':', body @ ..] => {
+                let fd = decode_hex(body).ok()?;
+                Some(vFileSetfs{fd})
+            },
+            _ => None,
+        }
+    }
+}

--- a/src/protocol/commands/_vFile_setfs.rs
+++ b/src/protocol/commands/_vFile_setfs.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
+
 use crate::target::ext::host_io::FsKind;
-use core::num::NonZeroUsize;
 
 #[derive(Debug)]
 pub struct vFileSetfs {
@@ -16,7 +16,7 @@ impl<'a> ParseCommand<'a> for vFileSetfs {
 
         match body {
             [b':', body @ ..] => {
-                let fs = match NonZeroUsize::new(decode_hex(body).ok()?) {
+                let fs = match core::num::NonZeroUsize::new(decode_hex(body).ok()?) {
                     None => FsKind::Stub,
                     Some(pid) => FsKind::Pid(pid),
                 };

--- a/src/protocol/commands/_vFile_unlink.rs
+++ b/src/protocol/commands/_vFile_unlink.rs
@@ -1,11 +1,11 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct vFileSetfs {
-    pub pid: usize,
+pub struct vFileUnlink<'a> {
+    pub filename: &'a [u8],
 }
 
-impl<'a> ParseCommand<'a> for vFileSetfs {
+impl<'a> ParseCommand<'a> for vFileUnlink<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
         let body = buf.into_body();
         if body.is_empty() {
@@ -14,8 +14,8 @@ impl<'a> ParseCommand<'a> for vFileSetfs {
 
         match body {
             [b':', body @ ..] => {
-                let pid = decode_hex(body).ok()?;
-                Some(vFileSetfs{pid})
+                let filename = decode_hex_buf(body).ok()?;
+                Some(vFileUnlink{filename})
             },
             _ => None,
         }

--- a/src/protocol/common/hex.rs
+++ b/src/protocol/common/hex.rs
@@ -200,6 +200,7 @@ pub fn decode_bin_buf(buf: &mut [u8]) -> Result<&mut [u8], DecodeBinBufError> {
     if cfg!(feature = "paranoid_unsafe") {
         Ok(&mut buf[..j])
     } else {
+        debug_assert!(j <= len);
         unsafe { Ok(buf.get_unchecked_mut(..j)) }
     }
 }

--- a/src/protocol/console_output.rs
+++ b/src/protocol/console_output.rs
@@ -30,7 +30,7 @@ impl<'a> fmt::Write for ConsoleOutput<'a> {
 }
 
 impl<'a> ConsoleOutput<'a> {
-    pub(crate) fn new(callback: &'a mut dyn FnMut(&[u8])) -> Self {
+    pub(crate) fn new(callback: &'a mut dyn FnMut(&[u8])) -> ConsoleOutput<'a> {
         ConsoleOutput {
             #[cfg(feature = "alloc")]
             buf: Vec::new(),

--- a/src/protocol/console_output.rs
+++ b/src/protocol/console_output.rs
@@ -30,7 +30,7 @@ impl<'a> fmt::Write for ConsoleOutput<'a> {
 }
 
 impl<'a> ConsoleOutput<'a> {
-    pub(crate) fn new(callback: &'a mut dyn FnMut(&[u8])) -> ConsoleOutput<'a> {
+    pub(crate) fn new(callback: &'a mut dyn FnMut(&[u8])) -> Self {
         ConsoleOutput {
             #[cfg(feature = "alloc")]
             buf: Vec::new(),

--- a/src/protocol/packet.rs
+++ b/src/protocol/packet.rs
@@ -40,7 +40,7 @@ pub struct PacketBuf<'a> {
 
 impl<'a> PacketBuf<'a> {
     /// Validate the contents of the raw packet buffer, checking for checksum
-    /// consistency, structural correctness, and ASCII validation.
+    /// consistency and structural correctness.
     pub fn new(pkt_buf: &'a mut [u8]) -> Result<PacketBuf<'a>, PacketParseError> {
         if pkt_buf.is_empty() {
             return Err(PacketParseError::EmptyBuf);
@@ -75,7 +75,7 @@ impl<'a> PacketBuf<'a> {
     }
 
     /// (used for tests) Create a packet buffer from a raw body buffer, skipping
-    /// the header/checksum trimming stage. ASCII validation is still performed.
+    /// the header/checksum trimming stage.
     #[cfg(test)]
     pub fn new_with_raw_body(body: &'a mut [u8]) -> Result<PacketBuf<'a>, PacketParseError> {
         let len = body.len();

--- a/src/protocol/packet.rs
+++ b/src/protocol/packet.rs
@@ -10,7 +10,6 @@ pub enum PacketParseError {
     MissingChecksum,
     MalformedChecksum,
     MalformedCommand,
-    NotAscii,
     UnexpectedHeader(u8),
 }
 
@@ -57,11 +56,6 @@ impl<'a> PacketBuf<'a> {
             .get(..2)
             .ok_or(PacketParseError::MalformedChecksum)?;
 
-        // validate that the body is valid ASCII
-        if !body.is_ascii() {
-            return Err(PacketParseError::NotAscii);
-        }
-
         // validate the checksum
         let checksum = decode_hex(checksum).map_err(|_| PacketParseError::MalformedChecksum)?;
         let calculated = body.iter().fold(0u8, |a, x| a.wrapping_add(*x));
@@ -84,11 +78,6 @@ impl<'a> PacketBuf<'a> {
     /// the header/checksum trimming stage. ASCII validation is still performed.
     #[cfg(test)]
     pub fn new_with_raw_body(body: &'a mut [u8]) -> Result<PacketBuf<'a>, PacketParseError> {
-        // validate the packet is valid ASCII
-        if !body.is_ascii() {
-            return Err(PacketParseError::NotAscii);
-        }
-
         let len = body.len();
         Ok(PacketBuf {
             buf: body,

--- a/src/protocol/response_writer.rs
+++ b/src/protocol/response_writer.rs
@@ -54,7 +54,7 @@ impl<'a, C: Connection + 'a> ResponseWriter<'a, C> {
         #[cfg(feature = "std")]
         trace!(
             "--> ${}#{:02x?}",
-            core::str::from_utf8(&self.msg).unwrap(), // buffers are always ascii
+            String::from_utf8_lossy(&self.msg),
             checksum
         );
 

--- a/src/target/ext/host_io.rs
+++ b/src/target/ext/host_io.rs
@@ -1,7 +1,8 @@
 //! Provide Host I/O operations for the target.
+use bitflags::bitflags;
+
 use crate::arch::Arch;
 use crate::target::Target;
-use bitflags::bitflags;
 
 bitflags! {
     /// Host flags for opening files.
@@ -95,9 +96,9 @@ pub struct HostIoStat {
 /// command.
 #[derive(Debug)]
 pub enum FsKind {
-    /// select the filesystem as seen by the remote stub
+    /// Select the filesystem as seen by the remote stub.
     Stub,
-    /// select the filesystem as seen by process pid
+    /// Select the filesystem as seen by process pid.
     Pid(crate::common::Pid),
 }
 
@@ -197,7 +198,7 @@ impl<E> From<std::io::Error> for HostIoError<E> {
 /// See [`HostIoError`] for more details.
 pub type HostIoResult<T, Tgt> = Result<T, HostIoError<<Tgt as Target>::Error>>;
 
-/// Zero-sized type token that ensures HostIoOutput::write is called
+/// Zero-sized type token that ensures HostIoOutput::write is called.
 pub struct HostIoToken<'a>(core::marker::PhantomData<&'a *mut ()>);
 
 /// An interface to send pread data back to the GDB client.
@@ -269,13 +270,12 @@ define_ext!(HostIoOps, HostIo);
 
 /// Nested Target Extension - Host I/O open operation.
 pub trait HostIoOpen: HostIo {
-    /// Open a file at filename and return a file descriptor for it, or return
+    /// Open a file at `filename` and return a file descriptor for it, or return
     /// [`HostIoError::Errno`] if an error occurs.
     ///
-    /// The filename is a string, flags is an integer indicating a mask of open
-    /// flags (see [`HostIoOpenFlags`]), and mode is an integer indicating a
-    /// mask of mode bits to use if the file is created (see
-    /// [`HostIoOpenMode`]).
+    /// `flags` is the flags used when open (see [`HostIoOpenFlags`]), and
+    /// `mode` is the mode used if the file is created
+    /// (see [`HostIoOpenMode`]).
     fn open(
         &mut self,
         filename: &[u8],
@@ -288,7 +288,7 @@ define_ext!(HostIoOpenOps, HostIoOpen);
 
 /// Nested Target Extension - Host I/O close operation.
 pub trait HostIoClose: HostIo {
-    /// Close the open file corresponding to fd.
+    /// Close the open file corresponding to `fd`.
     fn close(&mut self, fd: u32) -> HostIoResult<(), Self>;
 }
 
@@ -296,9 +296,9 @@ define_ext!(HostIoCloseOps, HostIoClose);
 
 /// Nested Target Extension - Host I/O pread operation.
 pub trait HostIoPread: HostIo {
-    /// Read data from the open file corresponding to fd.
+    /// Read data from the open file corresponding to `fd`.
     ///
-    /// Up to count bytes will be read from the file, starting at offset
+    /// Up to `count` bytes will be read from the file, starting at `offset`
     /// relative to the start of the file.
     ///
     /// The data read _must_ be sent by calling [`HostIoOutput::write`], which
@@ -318,12 +318,9 @@ define_ext!(HostIoPreadOps, HostIoPread);
 
 /// Nested Target Extension - Host I/O pwrite operation.
 pub trait HostIoPwrite: HostIo {
-    /// Write data (a binary buffer) to the open file corresponding to fd.
+    /// Write `data` to the open file corresponding to `fd`.
     ///
-    /// Start the write at offset from the start of the file.
-    ///
-    /// Unlike many write system calls, there is no separate count argument; the
-    /// length of data in the packet is used.
+    /// Start the write at `offset` from the start of the file.
     ///
     /// Return the number of bytes written, which may be shorter
     /// than the length of data, or [`HostIoError::Errno`] if an error occurred.
@@ -332,14 +329,14 @@ pub trait HostIoPwrite: HostIo {
         fd: u32,
         offset: <Self::Arch as Arch>::Usize,
         data: &[u8],
-    ) -> HostIoResult<u32, Self>;
+    ) -> HostIoResult<<Self::Arch as Arch>::Usize, Self>;
 }
 
 define_ext!(HostIoPwriteOps, HostIoPwrite);
 
 /// Nested Target Extension - Host I/O fstat operation.
 pub trait HostIoFstat: HostIo {
-    /// Get information about the open file corresponding to fd.
+    /// Get information about the open file corresponding to `fd`.
     ///
     /// On success return a [`HostIoStat`] struct.
     /// Return [`HostIoError::Errno`] if an error occurs.
@@ -350,7 +347,7 @@ define_ext!(HostIoFstatOps, HostIoFstat);
 
 /// Nested Target Extension - Host I/O unlink operation.
 pub trait HostIoUnlink: HostIo {
-    /// Delete the file at filename on the target.
+    /// Delete the file at `filename` on the target.
     fn unlink(&mut self, filename: &[u8]) -> HostIoResult<(), Self>;
 }
 
@@ -358,7 +355,7 @@ define_ext!(HostIoUnlinkOps, HostIoUnlink);
 
 /// Nested Target Extension - Host I/O readlink operation.
 pub trait HostIoReadlink: HostIo {
-    /// Read value of symbolic link filename on the target.
+    /// Read value of symbolic link `filename` on the target.
     ///
     /// The data read _must_ be sent by calling [`HostIoOutput::write`], which
     /// will consume the `output` object and return a [`HostIoToken`]. This
@@ -380,7 +377,7 @@ pub trait HostIoSetfs: HostIo {
     /// remote targets where the remote stub does not share a common filesystem
     /// with the inferior(s).
     ///
-    /// See [`FsKind`] for the meaning of argument.
+    /// See [`FsKind`] for the meaning of `fs`.
     ///
     /// If setfs indicates success, the selected filesystem remains selected
     /// until the next successful setfs operation.

--- a/src/target/ext/host_io.rs
+++ b/src/target/ext/host_io.rs
@@ -1,16 +1,40 @@
 //! Provide Host I/O operations for the target.
+use crate::arch::Arch;
+use crate::common::{HostMode, HostOpenFlags};
 use crate::target::Target;
+
+/// An interface to send pread data back to the GDB client.
+pub struct PreadOutput<'a> {
+    cb: &'a mut dyn FnMut(&[u8]),
+}
+
+impl<'a> PreadOutput<'a> {
+    pub(crate) fn new(cb: &'a mut dyn FnMut(&[u8])) -> Self {
+        Self { cb }
+    }
+
+    /// Write out raw file bytes to the GDB debugger.
+    pub fn write(&mut self, buf: &[u8]) {
+        (self.cb)(buf)
+    }
+}
 
 /// Target Extension - Perform I/O operations on host
 pub trait HostIo: Target {
     /// Open a file at filename and return a file descriptor for it, or return
     /// -1 if an error occurs.
-    fn open(&self, filename: &[u8], flags: u64, mode: u64) -> i64;
+    fn open(&self, filename: &[u8], flags: HostOpenFlags, mode: HostMode) -> i64;
     /// Close the open file corresponding to fd and return 0, or -1 if an error
     /// occurs.
     fn close(&self, fd: usize) -> i64;
     /// Read data from the open file corresponding to fd.
-    fn pread(&self, fd: usize, count: usize, offset: usize) -> &[u8];
+    fn pread(
+        &self,
+        fd: usize,
+        count: <Self::Arch as Arch>::Usize,
+        offset: <Self::Arch as Arch>::Usize,
+        output: &mut PreadOutput<'_>,
+    ) -> Result<(), Self::Error>;
     /// Select the filesystem on which vFile operations with filename arguments
     /// will operate.
     fn setfs(&self, fd: usize) -> i64;

--- a/src/target/ext/host_io.rs
+++ b/src/target/ext/host_io.rs
@@ -1,6 +1,6 @@
 //! Provide Host I/O operations for the target.
 use crate::arch::Arch;
-use crate::target::{Target, TargetResult};
+use crate::target::Target;
 use bitflags::bitflags;
 
 bitflags! {
@@ -8,7 +8,7 @@ bitflags! {
     ///
     /// Extracted from the GDB documentation at
     /// [Open Flags](https://sourceware.org/gdb/current/onlinedocs/gdb/Open-Flags.html#Open-Flags)
-    pub struct HostOpenFlags: u32 {
+    pub struct HostIoOpenFlags: u32 {
         /// A read-only file.
         const O_RDONLY = 0x0;
         /// A write-only file.
@@ -31,7 +31,7 @@ bitflags! {
     ///
     /// Extracted from the GDB documentation at
     /// [mode_t Values](https://sourceware.org/gdb/current/onlinedocs/gdb/mode_005ft-Values.html#mode_005ft-Values)
-    pub struct HostMode: u32 {
+    pub struct HostIoMode: u32 {
         /// A regular file.
         const S_IFREG = 0o100000;
         /// A directory.
@@ -68,7 +68,7 @@ pub struct HostStat {
     /// The inode.
     pub st_ino: u32,
     /// Protection bits.
-    pub st_mode: HostMode,
+    pub st_mode: HostIoMode,
     /// The number of hard links.
     pub st_nlink: u32,
     /// The user id of the owner.
@@ -101,7 +101,84 @@ pub enum FsKind {
     Pid(crate::common::Pid),
 }
 
-/// Token to ensure PreadOutput is used
+/// Errno values for Host I/O operations.
+///
+/// Extracted from the GDB documentation at
+/// [Errno Values]: https://sourceware.org/gdb/onlinedocs/gdb/Errno-Values.html
+#[derive(Debug)]
+pub enum HostIoErrno {
+    /// Operation not permitted (POSIX.1-2001).
+    EPERM = 1,
+    /// No such file or directory (POSIX.1-2001).
+    ///
+    /// Typically, this error results when a specified pathname does not exist,
+    /// or one of the components in the directory prefix of a pathname does not
+    /// exist, or the specified pathname is a dangling symbolic link.
+    ENOENT = 2,
+    /// Interrupted function call (POSIX.1-2001); see signal(7).
+    EINTR = 4,
+    /// Bad file descriptor (POSIX.1-2001).
+    EBADF = 9,
+    /// Permission denied (POSIX.1-2001).
+    EACCES = 13,
+    /// Bad address (POSIX.1-2001).
+    EFAULT = 14,
+    /// Device or resource busy (POSIX.1-2001).
+    EBUSY = 16,
+    /// File exists (POSIX.1-2001).
+    EEXIST = 17,
+    /// No such device (POSIX.1-2001).
+    ENODEV = 19,
+    /// Not a directory (POSIX.1-2001).
+    ENOTDIR = 20,
+    /// Is a directory (POSIX.1-2001).
+    EISDIR = 21,
+    /// Invalid argument (POSIX.1-2001).
+    EINVAL = 22,
+    /// Too many open files in system (POSIX.1-2001). On Linux, this is probably
+    /// a result of encountering the /proc/sys/fs/file-max limit (see proc(5)).
+    ENFILE = 23,
+    /// Too many open files (POSIX.1-2001). Commonly caused by exceeding the
+    /// RLIMIT_NOFILE resource limit described in getrlimit(2).
+    EMFILE = 24,
+    /// File too large (POSIX.1-2001).
+    EFBIG = 27,
+    /// No space left on device (POSIX.1-2001).
+    ENOSPC = 28,
+    /// Invalid seek (POSIX.1-2001).
+    ESPIPE = 29,
+    /// Read-only filesystem (POSIX.1-2001).
+    EROFS = 30,
+    /// Filename too long (POSIX.1-2001).
+    ENAMETOOLONG = 91,
+    /// Unknown errno - there may not be a GDB mapping for this value
+    EUNKNOWN = 9999,
+}
+
+/// The error type for Host I/O operations.
+pub enum HostIoError<E> {
+    /// An operation-specific non-fatal error code.
+    ///
+    /// See [`HostIoErrno`] for more details.
+    Errno(HostIoErrno),
+    /// A target-specific fatal error.
+    ///
+    /// **WARNING:** Returning this error will immediately halt the target's
+    /// execution and return a `GdbStubError::TargetError` from `GdbStub::run`!
+    ///
+    /// Note that the debugging session will will _not_ be terminated, and can
+    /// be resumed by calling `GdbStub::run` after resolving the error and/or
+    /// setting up a post-mortem debugging environment.
+    Fatal(E),
+}
+
+/// A specialized `Result` type for Host I/O operations. Supports reporting
+/// non-fatal errors back to the GDB client.
+///
+/// See [`HostIoError`] for more details.
+pub type HostIoResult<T, Tgt> = Result<T, HostIoError<<Tgt as Target>::Error>>;
+
+/// Zero-sized type token that ensures PreadOutput::write is called
 pub struct PreadToken<'a>(core::marker::PhantomData<&'a *mut ()>);
 
 /// An interface to send pread data back to the GDB client.
@@ -177,14 +254,15 @@ pub trait HostIoOpen: HostIo {
     /// -1 if an error occurs.
     ///
     /// The filename is a string, flags is an integer indicating a mask of open
-    /// flags (see [`HostOpenFlags`]), and mode is an integer indicating a mask
-    /// of mode bits to use if the file is created (see [`HostMode`]).
+    /// flags (see [`HostIoOpenFlags`]), and mode is an integer indicating a
+    /// mask of mode bits to use if the file is created (see
+    /// [`HostIoMode`]).
     fn open(
         &mut self,
         filename: &[u8],
-        flags: HostOpenFlags,
-        mode: HostMode,
-    ) -> TargetResult<i32, Self>;
+        flags: HostIoOpenFlags,
+        mode: HostIoMode,
+    ) -> HostIoResult<u32, Self>;
 }
 
 define_ext!(HostIoOpenOps, HostIoOpen);
@@ -193,7 +271,7 @@ define_ext!(HostIoOpenOps, HostIoOpen);
 pub trait HostIoClose: HostIo {
     /// Close the open file corresponding to fd and return 0, or -1 if an error
     /// occurs.
-    fn close(&mut self, fd: i32) -> TargetResult<i64, Self>;
+    fn close(&mut self, fd: i32) -> HostIoResult<u32, Self>;
 }
 
 define_ext!(HostIoCloseOps, HostIoClose);
@@ -216,7 +294,7 @@ pub trait HostIoPread: HostIo {
         count: <Self::Arch as Arch>::Usize,
         offset: <Self::Arch as Arch>::Usize,
         output: PreadOutput<'a>,
-    ) -> TargetResult<PreadToken<'a>, Self>;
+    ) -> HostIoResult<PreadToken<'a>, Self>;
 }
 
 define_ext!(HostIoPreadOps, HostIoPread);
@@ -237,7 +315,7 @@ pub trait HostIoPwrite: HostIo {
         fd: i32,
         offset: <Self::Arch as Arch>::Usize,
         data: &[u8],
-    ) -> TargetResult<i32, Self>;
+    ) -> HostIoResult<u32, Self>;
 }
 
 define_ext!(HostIoPwriteOps, HostIoPwrite);
@@ -249,7 +327,7 @@ pub trait HostIoFstat: HostIo {
     /// On success the information is returned as a binary attachment and the
     /// return value is the size of this attachment in bytes. If an error occurs
     /// the return value is -1.
-    fn fstat(&mut self, fd: i32) -> TargetResult<HostStat, Self>;
+    fn fstat(&mut self, fd: i32) -> HostIoResult<HostStat, Self>;
 }
 
 define_ext!(HostIoFstatOps, HostIoFstat);
@@ -259,7 +337,7 @@ pub trait HostIoUnlink: HostIo {
     /// Delete the file at filename on the target.
     ///
     /// Return 0, or -1 if an error occurs.
-    fn unlink(&mut self, filename: &[u8]) -> TargetResult<i32, Self>;
+    fn unlink(&mut self, filename: &[u8]) -> HostIoResult<u32, Self>;
 }
 
 define_ext!(HostIoUnlinkOps, HostIoUnlink);
@@ -275,7 +353,7 @@ pub trait HostIoReadlink: HostIo {
     ///
     /// The return value is the number of target bytes read; the binary
     /// attachment may be longer if some characters were escaped.
-    fn readlink(&mut self, filename: &[u8]) -> TargetResult<i32, Self>;
+    fn readlink(&mut self, filename: &[u8]) -> HostIoResult<u32, Self>;
 }
 
 define_ext!(HostIoReadlinkOps, HostIoReadlink);
@@ -293,7 +371,7 @@ pub trait HostIoSetfs: HostIo {
     /// Return 0 on success, or -1 if an error occurs. If vFile:setfs: indicates
     /// success, the selected filesystem remains selected until the next
     /// successful vFile:setfs: operation.
-    fn setfs(&mut self, fs: FsKind) -> TargetResult<i32, Self>;
+    fn setfs(&mut self, fs: FsKind) -> HostIoResult<u32, Self>;
 }
 
 define_ext!(HostIoSetfsOps, HostIoSetfs);

--- a/src/target/ext/host_io.rs
+++ b/src/target/ext/host_io.rs
@@ -181,14 +181,15 @@ pub enum HostIoError<E> {
 impl<E> From<std::io::Error> for HostIoError<E> {
     fn from(e: std::io::Error) -> HostIoError<E> {
         use std::io::ErrorKind::*;
-        match e.kind() {
-            PermissionDenied => HostIoError::Errno(HostIoErrno::EPERM),
-            NotFound => HostIoError::Errno(HostIoErrno::ENOENT),
-            Interrupted => HostIoError::Errno(HostIoErrno::EINTR),
-            AlreadyExists => HostIoError::Errno(HostIoErrno::EEXIST),
-            InvalidInput => HostIoError::Errno(HostIoErrno::EINVAL),
-            _ => HostIoError::Errno(HostIoErrno::EUNKNOWN),
-        }
+        let errno = match e.kind() {
+            PermissionDenied => HostIoErrno::EPERM,
+            NotFound => HostIoErrno::ENOENT,
+            Interrupted => HostIoErrno::EINTR,
+            AlreadyExists => HostIoErrno::EEXIST,
+            InvalidInput => HostIoErrno::EINVAL,
+            _ => HostIoErrno::EUNKNOWN,
+        };
+        HostIoError::Errno(errno)
     }
 }
 
@@ -273,9 +274,9 @@ pub trait HostIoOpen: HostIo {
     /// Open a file at `filename` and return a file descriptor for it, or return
     /// [`HostIoError::Errno`] if an error occurs.
     ///
-    /// `flags` is the flags used when open (see [`HostIoOpenFlags`]), and
-    /// `mode` is the mode used if the file is created
-    /// (see [`HostIoOpenMode`]).
+    /// `flags` are the flags used when opening the file (see
+    /// [`HostIoOpenFlags`]), and `mode` is the mode used if the file is
+    /// created (see [`HostIoOpenMode`]).
     fn open(
         &mut self,
         filename: &[u8],

--- a/src/target/ext/host_io.rs
+++ b/src/target/ext/host_io.rs
@@ -1,43 +1,228 @@
 //! Provide Host I/O operations for the target.
 use crate::arch::Arch;
-use crate::common::{HostMode, HostOpenFlags};
-use crate::target::Target;
+use crate::target::{Target, TargetResult};
+use bitflags::bitflags;
+
+bitflags! {
+    /// Host flags for opening files.
+    /// [Open Flags]: https://sourceware.org/gdb/onlinedocs/gdb/Open-Flags.html
+    pub struct HostOpenFlags: u32 {
+        /// A read-only file.
+        const O_RDONLY = 0x0;
+        /// A write-only file.
+        const O_WRONLY = 0x1;
+        /// A read-write file.
+        const O_RDWR = 0x2;
+        /// Append to an existing file.
+        const O_APPEND = 0x8;
+        /// Create a non-existent file.
+        const O_CREAT = 0x200;
+        /// Truncate an existing file.
+        const O_TRUNC = 0x400;
+        /// Exclusive access.
+        const O_EXCL = 0x800;
+    }
+}
+
+bitflags! {
+    /// Host file permissions.
+    /// [mode_t Values]: https://sourceware.org/gdb/onlinedocs/gdb/mode_005ft-Values.html
+    pub struct HostMode: u32 {
+        /// A regular file.
+        const S_IFREG = 0o100000;
+        /// A directory.
+        const S_IFDIR = 0o40000;
+        /// User read permissions.
+        const S_IRUSR = 0o400;
+        /// User write permissions.
+        const S_IWUSR = 0o200;
+        /// User execute permissions.
+        const S_IXUSR = 0o100;
+        /// Group read permissions.
+        const S_IRGRP = 0o40;
+        /// Group write permissions
+        const S_IWGRP = 0o20;
+        /// Group execute permissions.
+        const S_IXGRP = 0o10;
+        /// World read permissions.
+        const S_IROTH = 0o4;
+        /// World write permissions
+        const S_IWOTH = 0o2;
+        /// World execute permissions.
+        const S_IXOTH = 0o1;
+    }
+}
 
 /// An interface to send pread data back to the GDB client.
-pub struct PreadOutput<'a> {
+pub struct HostIoOutput<'a> {
     cb: &'a mut dyn FnMut(&[u8]),
 }
 
-impl<'a> PreadOutput<'a> {
+impl<'a> HostIoOutput<'a> {
     pub(crate) fn new(cb: &'a mut dyn FnMut(&[u8])) -> Self {
         Self { cb }
     }
 
     /// Write out raw file bytes to the GDB debugger.
-    pub fn write(&mut self, buf: &[u8]) {
+    pub fn write(self, buf: &[u8]) {
         (self.cb)(buf)
     }
 }
 
 /// Target Extension - Perform I/O operations on host
 pub trait HostIo: Target {
-    /// Open a file at filename and return a file descriptor for it, or return
-    /// -1 if an error occurs.
-    fn open(&self, filename: &[u8], flags: HostOpenFlags, mode: HostMode) -> i64;
-    /// Close the open file corresponding to fd and return 0, or -1 if an error
-    /// occurs.
-    fn close(&self, fd: usize) -> i64;
-    /// Read data from the open file corresponding to fd.
-    fn pread(
-        &self,
-        fd: usize,
-        count: <Self::Arch as Arch>::Usize,
-        offset: <Self::Arch as Arch>::Usize,
-        output: &mut PreadOutput<'_>,
-    ) -> Result<(), Self::Error>;
-    /// Select the filesystem on which vFile operations with filename arguments
-    /// will operate.
-    fn setfs(&self, fd: usize) -> i64;
+    /// Enable open operation.
+    #[inline(always)]
+    fn enable_open(&mut self) -> Option<HostIoOpenOps<Self>> {
+        None
+    }
+    /// Enable close operation.
+    #[inline(always)]
+    fn enable_close(&mut self) -> Option<HostIoCloseOps<Self>> {
+        None
+    }
+    /// Enable pread operation.
+    #[inline(always)]
+    fn enable_pread(&mut self) -> Option<HostIoPreadOps<Self>> {
+        None
+    }
+    /// Enable pwrite operation.
+    #[inline(always)]
+    fn enable_pwrite(&mut self) -> Option<HostIoPwriteOps<Self>> {
+        None
+    }
+    /// Enable fstat operation.
+    #[inline(always)]
+    fn enable_fstat(&mut self) -> Option<HostIoFstatOps<Self>> {
+        None
+    }
+    /// Enable unlink operation.
+    #[inline(always)]
+    fn enable_unlink(&mut self) -> Option<HostIoUnlinkOps<Self>> {
+        None
+    }
+    /// Enable readlink operation.
+    #[inline(always)]
+    fn enable_readlink(&mut self) -> Option<HostIoReadlinkOps<Self>> {
+        None
+    }
+    /// Enable setfs operation.
+    #[inline(always)]
+    fn enable_setfs(&mut self) -> Option<HostIoSetfsOps<Self>> {
+        None
+    }
 }
 
 define_ext!(HostIoOps, HostIo);
+
+/// Nested Target Extension - Host I/O open operation.
+pub trait HostIoOpen: HostIo {
+    /// Close the open file corresponding to fd and return 0, or -1 if an error
+    /// occurs.
+    fn open(
+        &mut self,
+        filename: &[u8],
+        flags: HostOpenFlags,
+        mode: HostMode,
+    ) -> TargetResult<i32, Self>;
+}
+
+define_ext!(HostIoOpenOps, HostIoOpen);
+
+/// Nested Target Extension - Host I/O close operation.
+pub trait HostIoClose: HostIo {
+    /// Close the open file corresponding to fd and return 0, or -1 if an error
+    /// occurs.
+    fn close(&mut self, fd: i32) -> TargetResult<i64, Self>;
+}
+
+define_ext!(HostIoCloseOps, HostIoClose);
+
+/// Nested Target Extension - Host I/O pread operation.
+pub trait HostIoPread: HostIo {
+    /// Read data from the open file corresponding to fd. Up to count bytes will
+    /// be read from the file, starting at offset relative to the start of the
+    /// file. The target may read fewer bytes; common reasons include packet
+    /// size limits and an end-of-file condition. The number of bytes read is
+    /// returned. Zero should only be returned for a successful read at the end
+    /// of the file, or if count was zero.
+    fn pread(
+        &mut self,
+        fd: i32,
+        count: <Self::Arch as Arch>::Usize,
+        offset: <Self::Arch as Arch>::Usize,
+        output: HostIoOutput<'_>,
+    ) -> TargetResult<(), Self>;
+}
+
+define_ext!(HostIoPreadOps, HostIoPread);
+
+/// Nested Target Extension - Host I/O pwrite operation.
+pub trait HostIoPwrite: HostIo {
+    /// Write data (a binary buffer) to the open file corresponding to fd. Start
+    /// the write at offset from the start of the file. Unlike many write system
+    /// calls, there is no separate count argument; the length of data in the
+    /// packet is used. ‘vFile:pwrite’ returns the number of bytes written,
+    /// which may be shorter than the length of data, or -1 if an error
+    /// occurred.
+    fn pwrite(
+        &mut self,
+        fd: i32,
+        offset: <Self::Arch as Arch>::Usize,
+        data: &[u8],
+    ) -> TargetResult<i32, Self>;
+}
+
+define_ext!(HostIoPwriteOps, HostIoPwrite);
+
+/// Nested Target Extension - Host I/O fstat operation.
+pub trait HostIoFstat: HostIo {
+    /// Get information about the open file corresponding to fd. On success the
+    /// information is returned as a binary attachment and the return value is
+    /// the size of this attachment in bytes. If an error occurs the return
+    /// value is -1.
+    fn fstat(&mut self, fd: i32, output: HostIoOutput<'_>) -> TargetResult<i32, Self>;
+}
+
+define_ext!(HostIoFstatOps, HostIoFstat);
+
+/// Nested Target Extension - Host I/O unlink operation.
+pub trait HostIoUnlink: HostIo {
+    /// Delete the file at filename on the target. Return 0, or -1 if an error
+    /// occurs. The filename is a string.
+    fn unlink(&mut self, filename: &[u8]) -> TargetResult<i32, Self>;
+}
+
+define_ext!(HostIoUnlinkOps, HostIoUnlink);
+
+/// Nested Target Extension - Host I/O readlink operation.
+pub trait HostIoReadlink: HostIo {
+    /// Read value of symbolic link filename on the target. Return the number of
+    /// bytes read, or -1 if an error occurs.
+
+    /// The data read should be returned as a binary attachment on success. If
+    /// zero bytes were read, the response should include an empty binary
+    /// attachment (i.e. a trailing semicolon). The return value is the number
+    /// of target bytes read; the binary attachment may be longer if some
+    /// characters were escaped.
+    fn readlink(&mut self, filename: &[u8]) -> TargetResult<i32, Self>;
+}
+
+define_ext!(HostIoReadlinkOps, HostIoReadlink);
+
+/// Nested Target Extension - Host I/O setfs operation.
+pub trait HostIoSetfs: HostIo {
+    /// Select the filesystem on which vFile operations with filename arguments
+    /// will operate. This is required for GDB to be able to access files on
+    /// remote targets where the remote stub does not share a common filesystem
+    /// with the inferior(s).
+
+    /// If pid is nonzero, select the filesystem as seen by process pid. If pid
+    /// is zero, select the filesystem as seen by the remote stub. Return 0 on
+    /// success, or -1 if an error occurs. If vFile:setfs: indicates success,
+    /// the selected filesystem remains selected until the next successful
+    /// vFile:setfs: operation.
+    fn setfs(&mut self, pid: usize) -> TargetResult<i32, Self>;
+}
+
+define_ext!(HostIoSetfsOps, HostIoSetfs);

--- a/src/target/ext/host_io.rs
+++ b/src/target/ext/host_io.rs
@@ -1,0 +1,19 @@
+//! Provide Host I/O operations for the target.
+use crate::target::Target;
+
+/// Target Extension - Perform I/O operations on host
+pub trait HostIo: Target {
+    /// Open a file at filename and return a file descriptor for it, or return
+    /// -1 if an error occurs.
+    fn open(&self, filename: &[u8], flags: u64, mode: u64) -> i64;
+    /// Close the open file corresponding to fd and return 0, or -1 if an error
+    /// occurs.
+    fn close(&self, fd: usize) -> i64;
+    /// Read data from the open file corresponding to fd.
+    fn pread(&self, fd: usize, count: usize, offset: usize) -> &[u8];
+    /// Select the filesystem on which vFile operations with filename arguments
+    /// will operate.
+    fn setfs(&self, fd: usize) -> i64;
+}
+
+define_ext!(HostIoOps, HostIo);

--- a/src/target/ext/mod.rs
+++ b/src/target/ext/mod.rs
@@ -260,6 +260,7 @@ pub mod base;
 pub mod breakpoints;
 pub mod catch_syscalls;
 pub mod extended_mode;
+pub mod host_io;
 pub mod memory_map;
 pub mod monitor_cmd;
 pub mod section_offsets;

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -400,6 +400,16 @@ macro_rules! impl_dyn_target {
             }
 
             #[inline(always)]
+            fn host_io(&mut self) -> Option<ext::host_io::HostIoOps<Self>> {
+                (**self).host_io()
+            }
+
+            #[inline(always)]
+            fn memory_map(&mut self) -> Option<ext::memory_map::MemoryMapOps<Self>> {
+                (**self).memory_map()
+            }
+
+            #[inline(always)]
             fn section_offsets(&mut self) -> Option<ext::section_offsets::SectionOffsetsOps<Self>> {
                 (**self).section_offsets()
             }

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -360,6 +360,7 @@ pub trait Target {
     }
 
     /// Support Host I/O operations.
+    #[inline(always)]
     fn host_io(&mut self) -> Option<ext::host_io::HostIoOps<Self>> {
         None
     }

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -358,6 +358,11 @@ pub trait Target {
     fn catch_syscalls(&mut self) -> Option<ext::catch_syscalls::CatchSyscallsOps<Self>> {
         None
     }
+
+    /// Support Host I/O operations.
+    fn host_io(&mut self) -> Option<ext::host_io::HostIoOps<Self>> {
+        None
+    }
 }
 
 macro_rules! impl_dyn_target {


### PR DESCRIPTION
### Description

<!-- Please include a brief description of what is being added/changed -->

Support Host I/O operations 

Refer: #32 

### API Stability

- [x] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
- Documentation
  - [x] rustdoc + approprate inline code comments
  - [ ] Updated CHANGELOG.md
  - [x] (if appropriate) Added feature to "Debugging Features" in README.md
- _If implementing a new protocol extension IDET_
  - [x] Included a basic sample implementation in `examples/armv4t`
  - [x] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [x] Confirmed that IDET can be optimized away (using `./scripts/test_dead_code_elim.sh` and/or `./example_no_std/check_size.sh`)
  - [ ] **OR** Implementation requires adding non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [ ] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- If you are implementing `gdbstub` in an open-source project, consider updating the README.md's "Real World Examples" section to link back to your project! -->

### Validation

<!-- example output, from https://github.com/daniel5151/gdbstub/pull/54 -->

<details>
<summary>GDB output</summary>

```
(gdb) remote get /tmp/remote.txt /tmp/local.txt
Successfully fetched file "/tmp/remote.txt".
(gdb) remote put /tmp/local.txt /tmp/remote.txt
Successfully sent file "/tmp/local.txt".
(gdb) remote delete /tmp/remote.txt
Successfully deleted file "/tmp/remote.txt"
```

</details>

<details>
<summary>armv4t output</summary>

```
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/examples/armv4t`
loading section ".text" into memory from [0x55550000..0x55550078]
Setting PC to 0x55550000
Waiting for a GDB connection on "127.0.0.1:9001"...
Debugger connected from 127.0.0.1:36992
 TRACE gdbstub::protocol::recv_packet > <-- +
 TRACE gdbstub::protocol::recv_packet > <-- $qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;no-resumed+;xmlRegisters=i386#6a
 TRACE gdbstub::protocol::response_writer > --> $PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;ReverseContinue+;ReverseStep+;QDisableRandomization+;QEnvironmentHexEncoded+;QEnvironmentUnset+;QEnvironmentReset+;QStartupWithShell+;QSetWorkingDir+;swbreak+;hwbreak+;QCatchSyscalls+;qXfer:features:read+;qXfer:memory-map:read+#cc
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $vMustReplyEmpty#3a
 INFO  gdbstub::gdbstub_impl              > Unknown command: vMustReplyEmpty
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $QStartNoAckMode#b0
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $Hgp0.0#ad
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:0,ffb#79
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<target version="1.0">
    <architecture>armv4t</architecture>
    <feature name="org.gnu.gdb.arm.core">
        <vector id="padding" type="uint32" count="25"/>

        <reg name="r0" bitsize="32" type="uint32"/>
        <reg name="r1" bitsize="32" type="uint32"/>
        <reg name="r2" bitsize="32" type="uint32"/>
        <reg name="r3" bitsize="32" type="uint32"/>
        <reg name="r4" bitsize="32" type="uint32"/>
        <reg name="r5" bitsize="32" type="uint32"/>
        <reg name="r6" bitsize="32" type="uint32"/>
        <reg name="r7" bitsize="32" type="uint32"/>
        <reg name="r8" bitsize="32" type="uint32"/>
        <reg name="r9" bitsize="32" type="uint32"/>
        <reg name="r10" bitsize="32" type="uint32"/>
        <reg name="r11" bitsize="32" type="uint32"/>
        <reg name="r12" bitsize="32" type="uint32"/>
        <reg name="sp" bitsize="32" type="data_ptr"/>
        <reg name="lr" bitsize="32"/>
        <reg name="pc" bitsize="32" type="code_ptr"/>

        <!--
            For some reason, my version of `gdb-multiarch` doesn't seem to
            respect "regnum", and will not parse this custom target.xml unless I
            manually include the padding bytes in the target description.

            On the bright side, AFAIK, there aren't all that many architectures
            that use padding bytes. Heck, the only reason armv4t uses padding is
            for historical reasons (see comment below).

            Odds are if you're defining your own custom arch, you won't run into
            this issue, since you can just lay out all the registers in the
            correct order.
        -->
        <reg name="padding" type="padding" bitsize="32"/>

        <!-- The CPSR is register 25, rather than register 16, because
        the FPA registers historically were placed between the PC
        and the CPSR in the "g" packet. -->
        <reg name="cpsr" bitsize="32" regnum="25"/>
    </feature>
    <feature name="custom-armv4t-extension">
        <!--
            maps to a simple scratch register within the emulator. the GDB
            client can read the register using `p }custom` and set it using
            `set }custom=1337`
        -->
        <reg name="custom" bitsize="32" type="uint32"/>

        <!--
            pseudo-register that return the current time when read.

            notably, i've set up the target to NOT send this register as part of
            the regular register list, which means that GDB will fetch/update
            this register via the 'p' and 'P' packets respectively
        -->
        <reg name="time" bitsize="32" type="uint32"/>
    </feature>
</target>#0f
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:aa4,ffb#3f
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 INFO  gdbstub::gdbstub_impl              > Unknown command: qTStatus
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $?#3f
 TRACE gdbstub::protocol::response_writer > --> $S05#b8
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qAttached:1#fa
GDB queried if it was attached to a process with PID 1
 TRACE gdbstub::protocol::response_writer > --> $1#31
 TRACE gdbstub::protocol::recv_packet     > <-- $Hc-1#09
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qC#b4
 INFO  gdbstub::gdbstub_impl              > Unknown command: qC
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000107856341200005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1000000078563412#0a
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::0,ffb#18
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE memory-map
    PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN"
            "http://sourceware.org/gdb/gdb-memory-map.dtd">
<memory-map>
    <memory type="ram" start="0x0" length="0x100000000"/>
</memory-map>#76
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::f4,ffb#82
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffe,2#35
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,2#33
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffe,2#35
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,2#33
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m0,4#fd
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:setfs:0#bf
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746d702f72656d6f74652e747874,0,0#2c
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
 TRACE gdbstub::protocol::response_writer > --> $F06;origin#6f
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,6#f5
 TRACE gdbstub::protocol::response_writer > --> $F00;#e1
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:close:0#b0
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746d702f72656d6f74652e747874,601,1c0#27
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pwrite:0,0,changed#87
 TRACE gdbstub::protocol::response_writer > --> $F07#ad
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:close:0#b0
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:unlink:2f746d702f72656d6f74652e747874#53
 TRACE gdbstub::protocol::response_writer > --> $F0#76
```
</details>