### PR TITLE
Support read exec-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Of course, most use-cases will want to support additional debugging features as 
     -   Extend the GDB protocol with custom debug commands using GDB's `monitor` command
 -   Get target memory map
 -   Perform Host I/O operations
+-   Get target exec file
 
 _Note:_ GDB features are implemented on an as-needed basis by `gdbstub`'s contributors. If there's a missing GDB feature that you'd like `gdbstub` to implement, please file an issue and/or open a PR!
 

--- a/examples/armv4t/gdb/exec_file.rs
+++ b/examples/armv4t/gdb/exec_file.rs
@@ -15,7 +15,7 @@ impl target::ext::exec_file::ExecFile for Emu {
         let filename = b"/test.elf";
         let len = filename.len();
         let data =
-            &filename[(offset as usize).min(len) as usize..((offset + length) as usize).min(len)];
+            &filename[offset.min(len)..(offset + length).min(len)];
         let buf = &mut buf[..data.len()];
         buf.copy_from_slice(data);
         Ok(data.len())

--- a/examples/armv4t/gdb/exec_file.rs
+++ b/examples/armv4t/gdb/exec_file.rs
@@ -5,19 +5,19 @@ use gdbstub::target::TargetResult;
 use crate::emu::Emu;
 
 impl target::ext::exec_file::ExecFile for Emu {
-    fn get_exec_file<'a>(
+    fn get_exec_file(
         &self,
         _pid: Option<Pid>,
-        offset: u32,
-        length: u32,
-        buf: &'a mut [u8],
-    ) -> TargetResult<&'a [u8], Self> {
+        offset: usize,
+        length: usize,
+        buf: &mut [u8],
+    ) -> TargetResult<usize, Self> {
         let filename = b"/test.elf";
         let len = filename.len();
         let data =
             &filename[(offset as usize).min(len) as usize..((offset + length) as usize).min(len)];
         let buf = &mut buf[..data.len()];
         buf.copy_from_slice(data);
-        Ok(buf)
+        Ok(data.len())
     }
 }

--- a/examples/armv4t/gdb/exec_file.rs
+++ b/examples/armv4t/gdb/exec_file.rs
@@ -5,7 +5,19 @@ use gdbstub::target::TargetResult;
 use crate::emu::Emu;
 
 impl target::ext::exec_file::ExecFile for Emu {
-    fn get_exec_file(&self, _pid: Option<Pid>) -> TargetResult<&[u8], Self> {
-        Ok(b"/test.elf")
+    fn get_exec_file<'a>(
+        &self,
+        _pid: Option<Pid>,
+        offset: u32,
+        length: u32,
+        buf: &'a mut [u8],
+    ) -> TargetResult<&'a [u8], Self> {
+        let filename = b"/test.elf";
+        let len = filename.len();
+        let data =
+            &filename[(offset as usize).min(len) as usize..((offset + length) as usize).min(len)];
+        let buf = &mut buf[..data.len()];
+        buf.copy_from_slice(data);
+        Ok(buf)
     }
 }

--- a/examples/armv4t/gdb/exec_file.rs
+++ b/examples/armv4t/gdb/exec_file.rs
@@ -14,8 +14,7 @@ impl target::ext::exec_file::ExecFile for Emu {
     ) -> TargetResult<usize, Self> {
         let filename = b"/test.elf";
         let len = filename.len();
-        let data =
-            &filename[offset.min(len)..(offset + length).min(len)];
+        let data = &filename[len.min(offset)..len.min(offset + length)];
         let buf = &mut buf[..data.len()];
         buf.copy_from_slice(data);
         Ok(data.len())

--- a/examples/armv4t/gdb/exec_file.rs
+++ b/examples/armv4t/gdb/exec_file.rs
@@ -8,13 +8,13 @@ impl target::ext::exec_file::ExecFile for Emu {
     fn get_exec_file(
         &self,
         _pid: Option<Pid>,
-        offset: usize,
+        offset: u64,
         length: usize,
         buf: &mut [u8],
     ) -> TargetResult<usize, Self> {
         let filename = b"/test.elf";
         let len = filename.len();
-        let data = &filename[len.min(offset)..len.min(offset + length)];
+        let data = &filename[len.min(offset as usize)..len.min(offset as usize + length)];
         let buf = &mut buf[..data.len()];
         buf.copy_from_slice(data);
         Ok(data.len())

--- a/examples/armv4t/gdb/exec_file.rs
+++ b/examples/armv4t/gdb/exec_file.rs
@@ -1,0 +1,10 @@
+use gdbstub::common::Pid;
+use gdbstub::target;
+
+use crate::emu::Emu;
+
+impl target::ext::exec_file::ExecFile for Emu {
+    fn get_exec_file(&self, _pid: Option<Pid>) -> &[u8] {
+        b"/test.elf"
+    }
+}

--- a/examples/armv4t/gdb/exec_file.rs
+++ b/examples/armv4t/gdb/exec_file.rs
@@ -1,10 +1,11 @@
 use gdbstub::common::Pid;
 use gdbstub::target;
+use gdbstub::target::TargetResult;
 
 use crate::emu::Emu;
 
 impl target::ext::exec_file::ExecFile for Emu {
-    fn get_exec_file(&self, _pid: Option<Pid>) -> &[u8] {
-        b"/test.elf"
+    fn get_exec_file(&self, _pid: Option<Pid>) -> TargetResult<&[u8], Self> {
+        Ok(b"/test.elf")
     }
 }

--- a/examples/armv4t/gdb/host_io.rs
+++ b/examples/armv4t/gdb/host_io.rs
@@ -1,6 +1,5 @@
 use std::io::{Read, Seek, Write};
 
-use crate::TEST_PROGRAM_ELF;
 use gdbstub::target;
 use gdbstub::target::ext::host_io::{
     FsKind, HostIoErrno, HostIoError, HostIoOpenFlags, HostIoOpenMode, HostIoOutput, HostIoResult,
@@ -8,6 +7,7 @@ use gdbstub::target::ext::host_io::{
 };
 
 use crate::emu::Emu;
+use crate::TEST_PROGRAM_ELF;
 
 const FD_RESERVED: u32 = 1;
 
@@ -64,6 +64,10 @@ impl target::ext::host_io::HostIoOpen for Emu {
             return Err(HostIoError::Errno(HostIoErrno::ENOENT));
         }
 
+        // In this example, the test binary is compiled into the binary itself as the
+        // `TEST_PROGRAM_ELF` array using `include_bytes!`. As such, we must "spoof" the
+        // existence of a real file, which will actually be backed by the in-binary
+        // `TEST_PROGRAM_ELF` array.
         if filename == b"/test.elf" {
             return Ok(0);
         }

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -16,6 +16,7 @@ use crate::emu::{Emu, Event};
 
 mod breakpoints;
 mod catch_syscalls;
+mod exec_file;
 mod extended_mode;
 mod host_io;
 mod memory_map;
@@ -98,6 +99,11 @@ impl Target for Emu {
 
     #[inline(always)]
     fn host_io(&mut self) -> Option<target::ext::host_io::HostIoOps<Self>> {
+        Some(self)
+    }
+
+    #[inline(always)]
+    fn exec_file(&mut self) -> Option<target::ext::exec_file::ExecFileOps<Self>> {
         Some(self)
     }
 }

--- a/examples/armv4t/main.rs
+++ b/examples/armv4t/main.rs
@@ -9,7 +9,7 @@ use gdbstub::{target::Target, ConnectionExt, DisconnectReason, GdbStub};
 
 pub type DynResult<T> = Result<T, Box<dyn std::error::Error>>;
 
-static TEST_PROGRAM_ELF: &[u8] = include_bytes!("test_bin/test.elf");
+pub static TEST_PROGRAM_ELF: &[u8] = include_bytes!("test_bin/test.elf");
 
 mod emu;
 mod gdb;

--- a/examples/armv4t/test_bin/.gdbinit
+++ b/examples/armv4t/test_bin/.gdbinit
@@ -1,2 +1,1 @@
-file test.elf
 target extended-remote :9001

--- a/src/gdbstub_impl/ext/base.rs
+++ b/src/gdbstub_impl/ext/base.rs
@@ -115,6 +115,10 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     res.write_str(";qXfer:memory-map:read+")?;
                 }
 
+                if target.exec_file().is_some() {
+                    res.write_str(";qXfer:exec-file:read+")?;
+                }
+
                 HandlerStatus::Handled
             }
             Base::QStartNoAckMode(_) => {

--- a/src/gdbstub_impl/ext/exec_file.rs
+++ b/src/gdbstub_impl/ext/exec_file.rs
@@ -1,6 +1,8 @@
 use super::prelude::*;
 use crate::protocol::commands::ext::ExecFile;
 
+use crate::arch::Arch;
+
 impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     pub(crate) fn handle_exec_file(
         &mut self,
@@ -17,8 +19,19 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
         let handler_status = match command {
             ExecFile::qXferExecFileRead(cmd) => {
-                let filename = ops.get_exec_file(cmd.pid).handle_error()?;
-                res.write_binary_range(filename, cmd.offset, cmd.len)?;
+                let offset = <T::Arch as Arch>::Usize::from_be_bytes(cmd.offset)
+                    .ok_or(Error::TargetMismatch)?;
+                let length = <T::Arch as Arch>::Usize::from_be_bytes(cmd.length)
+                    .ok_or(Error::TargetMismatch)?;
+                let ret = ops
+                    .get_exec_file(cmd.pid, offset, length, cmd.buf)
+                    .handle_error()?;
+                if ret.is_empty() {
+                    res.write_str("l")?;
+                } else {
+                    res.write_str("m")?;
+                    res.write_binary(ret)?;
+                }
                 HandlerStatus::Handled
             }
         };

--- a/src/gdbstub_impl/ext/exec_file.rs
+++ b/src/gdbstub_impl/ext/exec_file.rs
@@ -24,7 +24,8 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     res.write_str("l")?;
                 } else {
                     res.write_str("m")?;
-                    res.write_binary(&cmd.buf[..ret])?;
+                    // TODO: add more specific error variant?
+                    res.write_binary(cmd.buf.get(..ret).ok_or(Error::PacketBufferOverflow)?)?;
                 }
                 HandlerStatus::Handled
             }

--- a/src/gdbstub_impl/ext/exec_file.rs
+++ b/src/gdbstub_impl/ext/exec_file.rs
@@ -1,0 +1,28 @@
+use super::prelude::*;
+use crate::protocol::commands::ext::ExecFile;
+
+impl<T: Target, C: Connection> GdbStubImpl<T, C> {
+    pub(crate) fn handle_exec_file(
+        &mut self,
+        res: &mut ResponseWriter<C>,
+        target: &mut T,
+        command: ExecFile,
+    ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
+        let ops = match target.exec_file() {
+            Some(ops) => ops,
+            None => return Ok(HandlerStatus::Handled),
+        };
+
+        crate::__dead_code_marker!("exec_file", "impl");
+
+        let handler_status = match command {
+            ExecFile::qXferExecFileRead(cmd) => {
+                let filename = ops.get_exec_file(cmd.pid);
+                res.write_binary_range(filename, cmd.offset, cmd.len)?;
+                HandlerStatus::Handled
+            }
+        };
+
+        Ok(handler_status)
+    }
+}

--- a/src/gdbstub_impl/ext/exec_file.rs
+++ b/src/gdbstub_impl/ext/exec_file.rs
@@ -17,7 +17,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
         let handler_status = match command {
             ExecFile::qXferExecFileRead(cmd) => {
-                let filename = ops.get_exec_file(cmd.pid);
+                let filename = ops.get_exec_file(cmd.pid).handle_error()?;
                 res.write_binary_range(filename, cmd.offset, cmd.len)?;
                 HandlerStatus::Handled
             }

--- a/src/gdbstub_impl/ext/mod.rs
+++ b/src/gdbstub_impl/ext/mod.rs
@@ -14,6 +14,7 @@ mod prelude {
 mod base;
 mod breakpoints;
 mod catch_syscalls;
+mod exec_file;
 mod extended_mode;
 mod host_io;
 mod memory_map;

--- a/src/gdbstub_impl/mod.rs
+++ b/src/gdbstub_impl/mod.rs
@@ -578,6 +578,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Command::ReverseStep(cmd) => self.handle_reverse_step(res, target, cmd),
             Command::MemoryMap(cmd) => self.handle_memory_map(res, target, cmd),
             Command::HostIo(cmd) => self.handle_host_io(res, target, cmd),
+            Command::ExecFile(cmd) => self.handle_exec_file(res, target, cmd),
         }
     }
 }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -225,8 +225,8 @@ commands! {
         "qXfer:memory-map:read" => _qXfer_memory_map::qXferMemoryMapRead,
     }
 
-    exec_file {
-        "qXfer:exec-file:read" => _qXfer_exec_file::qXferExecFileRead,
+    exec_file use 'a{
+        "qXfer:exec-file:read" => _qXfer_exec_file::qXferExecFileRead<'a>,
     }
 
     host_io use 'a {

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -225,6 +225,10 @@ commands! {
         "qXfer:memory-map:read" => _qXfer_memory_map::qXferMemoryMapRead,
     }
 
+    exec_file {
+        "qXfer:exec-file:read" => _qXfer_exec_file::qXferExecFileRead,
+    }
+
     host_io use 'a {
         "vFile:open" => _vFile_open::vFileOpen<'a>,
         "vFile:close" => _vFile_close::vFileClose,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -225,7 +225,7 @@ commands! {
         "qXfer:memory-map:read" => _qXfer_memory_map::qXferMemoryMapRead,
     }
 
-    exec_file use 'a{
+    exec_file use 'a {
         "qXfer:exec-file:read" => _qXfer_exec_file::qXferExecFileRead<'a>,
     }
 

--- a/src/protocol/commands/_qXfer_exec_file.rs
+++ b/src/protocol/commands/_qXfer_exec_file.rs
@@ -21,7 +21,10 @@ impl<'a> ParseCommand<'a> for qXferExecFileRead<'a> {
         }
 
         let mut body = body.split(|b| *b == b':').skip(1);
-        let pid = decode_hex(body.next()?).ok().and_then(Pid::new);
+        let pid = match body.next()? {
+            [] => None,
+            buf => Some(Pid::new(decode_hex(buf).ok()?)?)
+        }
 
         let mut body = body.next()?.split(|b| *b == b',');
         let offset = decode_hex(body.next()?).ok()?;

--- a/src/protocol/commands/_qXfer_exec_file.rs
+++ b/src/protocol/commands/_qXfer_exec_file.rs
@@ -1,0 +1,29 @@
+use super::prelude::*;
+
+use crate::common::Pid;
+
+#[derive(Debug)]
+pub struct qXferExecFileRead {
+    pub pid: Option<Pid>,
+    pub offset: usize,
+    pub len: usize,
+}
+
+impl<'a> ParseCommand<'a> for qXferExecFileRead {
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let body = buf.into_body();
+
+        if body.is_empty() {
+            return None;
+        }
+
+        let mut body = body.split(|b| *b == b':').skip(1);
+        let pid = decode_hex(body.next()?).ok().and_then(Pid::new);
+
+        let mut body = body.next()?.split(|b| *b == b',');
+        let offset = decode_hex(body.next()?).ok()?;
+        let len = decode_hex(body.next()?).ok()?;
+
+        Some(qXferExecFileRead {pid, offset, len})
+    }
+}

--- a/src/protocol/commands/_qXfer_exec_file.rs
+++ b/src/protocol/commands/_qXfer_exec_file.rs
@@ -3,27 +3,32 @@ use super::prelude::*;
 use crate::common::Pid;
 
 #[derive(Debug)]
-pub struct qXferExecFileRead {
+pub struct qXferExecFileRead<'a> {
     pub pid: Option<Pid>,
-    pub offset: usize,
-    pub len: usize,
+    pub offset: &'a [u8],
+    pub length: &'a [u8],
+
+    pub buf: &'a mut [u8],
 }
 
-impl<'a> ParseCommand<'a> for qXferExecFileRead {
+impl<'a> ParseCommand<'a> for qXferExecFileRead<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
-        let body = buf.into_body();
+        let (buf, body_range) = buf.into_raw_buf();
+        let (body, buf) = buf[body_range.start..].split_at_mut(body_range.end - body_range.start);
 
         if body.is_empty() {
             return None;
         }
 
-        let mut body = body.split(|b| *b == b':').skip(1);
+        let mut body = body.split_mut_no_panic(|b| *b == b':').skip(1);
         let pid = decode_hex(body.next()?).ok().and_then(Pid::new);
 
-        let mut body = body.next()?.split(|b| *b == b',');
-        let offset = decode_hex(body.next()?).ok()?;
-        let len = decode_hex(body.next()?).ok()?;
+        let mut body = body.next()?.split_mut_no_panic(|b| *b == b',');
+        let offset = decode_hex_buf(body.next()?).ok()?;
+        let length = decode_hex_buf(body.next()?).ok()?;
 
-        Some(qXferExecFileRead {pid, offset, len})
+        drop(body);
+
+        Some(qXferExecFileRead {pid, offset, length, buf})
     }
 }

--- a/src/protocol/commands/_qXfer_exec_file.rs
+++ b/src/protocol/commands/_qXfer_exec_file.rs
@@ -5,7 +5,7 @@ use crate::common::Pid;
 #[derive(Debug)]
 pub struct qXferExecFileRead<'a> {
     pub pid: Option<Pid>,
-    pub offset: usize,
+    pub offset: u64,
     pub length: usize,
 
     pub buf: &'a mut [u8],

--- a/src/protocol/commands/_qXfer_exec_file.rs
+++ b/src/protocol/commands/_qXfer_exec_file.rs
@@ -24,7 +24,7 @@ impl<'a> ParseCommand<'a> for qXferExecFileRead<'a> {
         let pid = match body.next()? {
             [] => None,
             buf => Some(Pid::new(decode_hex(buf).ok()?)?)
-        }
+        };
 
         let mut body = body.next()?.split(|b| *b == b',');
         let offset = decode_hex(body.next()?).ok()?;

--- a/src/protocol/commands/_vFile_setfs.rs
+++ b/src/protocol/commands/_vFile_setfs.rs
@@ -16,7 +16,7 @@ impl<'a> ParseCommand<'a> for vFileSetfs {
 
         match body {
             [b':', body @ ..] => {
-                let fs = match core::num::NonZeroUsize::new(decode_hex(body).ok()?) {
+                let fs = match crate::common::Pid::new(decode_hex(body).ok()?) {
                     None => FsKind::Stub,
                     Some(pid) => FsKind::Pid(pid),
                 };

--- a/src/target/ext/exec_file.rs
+++ b/src/target/ext/exec_file.rs
@@ -1,0 +1,13 @@
+//! Provide exec-file path for the target.
+use crate::target::Target;
+
+use crate::common::Pid;
+
+/// Target Extension - Provide current exec-file.
+pub trait ExecFile: Target {
+    /// Return the full absolute name of the file that was executed to create a
+    /// process running on the remote system.
+    fn get_exec_file(&self, pid: Option<Pid>) -> &[u8];
+}
+
+define_ext!(ExecFileOps, ExecFile);

--- a/src/target/ext/exec_file.rs
+++ b/src/target/ext/exec_file.rs
@@ -1,6 +1,7 @@
 //! Provide exec-file path for the target.
 use crate::target::{Target, TargetResult};
 
+use crate::arch::Arch;
 use crate::common::Pid;
 
 /// Target Extension - Provide current exec-file.
@@ -13,7 +14,13 @@ pub trait ExecFile: Target {
     /// process running on the remote system.
     /// If no `pid` is provided, return the filename corresponding to the
     /// currently executing process.
-    fn get_exec_file(&self, pid: Option<Pid>) -> TargetResult<&[u8], Self>;
+    fn get_exec_file<'a>(
+        &self,
+        pid: Option<Pid>,
+        offset: <Self::Arch as Arch>::Usize,
+        length: <Self::Arch as Arch>::Usize,
+        buf: &'a mut [u8],
+    ) -> TargetResult<&'a [u8], Self>;
 }
 
 define_ext!(ExecFileOps, ExecFile);

--- a/src/target/ext/exec_file.rs
+++ b/src/target/ext/exec_file.rs
@@ -9,11 +9,15 @@ use crate::common::Pid;
 /// I/O Extensions`](crate::target::ext::host_io), which enables the GDB client
 /// to read the executable file directly from the target
 pub trait ExecFile: Target {
-    /// Get full absolute name of the file that was executed to create
-    /// process `pid` running on the remote system, or the filename
-    /// corresponding to the currently executing process if no `pid` is
-    /// provided.
-    /// Store the name into `buf`, and return the length of name.
+    /// Get full absolute path of the file that was executed to create
+    /// process `pid` running on the remote system.
+    ///
+    /// If `pid` is `None`, return the filename corresponding to the 
+    /// currently executing process.
+    ///
+    /// Return the number of bytes written into `buf` (which may be less than `length`).
+    ///
+    /// If `offset` is greater than the length of the underlying data, return `Ok(0)`.
     fn get_exec_file(
         &self,
         pid: Option<Pid>,

--- a/src/target/ext/exec_file.rs
+++ b/src/target/ext/exec_file.rs
@@ -1,7 +1,6 @@
 //! Provide exec-file path for the target.
 use crate::target::{Target, TargetResult};
 
-use crate::arch::Arch;
 use crate::common::Pid;
 
 /// Target Extension - Provide current exec-file.
@@ -10,17 +9,18 @@ use crate::common::Pid;
 /// I/O Extensions`](crate::target::ext::host_io), which enables the GDB client
 /// to read the executable file directly from the target
 pub trait ExecFile: Target {
-    /// Return the full absolute name of the file that was executed to create a
-    /// process running on the remote system.
-    /// If no `pid` is provided, return the filename corresponding to the
-    /// currently executing process.
-    fn get_exec_file<'a>(
+    /// Get full absolute name of the file that was executed to create
+    /// process `pid` running on the remote system, or the filename
+    /// corresponding to the currently executing process if no `pid` is
+    /// provided.
+    /// Store the name into `buf`, and return the length of name.
+    fn get_exec_file(
         &self,
         pid: Option<Pid>,
-        offset: <Self::Arch as Arch>::Usize,
-        length: <Self::Arch as Arch>::Usize,
-        buf: &'a mut [u8],
-    ) -> TargetResult<&'a [u8], Self>;
+        offset: usize,
+        length: usize,
+        buf: &mut [u8],
+    ) -> TargetResult<usize, Self>;
 }
 
 define_ext!(ExecFileOps, ExecFile);

--- a/src/target/ext/exec_file.rs
+++ b/src/target/ext/exec_file.rs
@@ -1,13 +1,19 @@
 //! Provide exec-file path for the target.
-use crate::target::Target;
+use crate::target::{Target, TargetResult};
 
 use crate::common::Pid;
 
 /// Target Extension - Provide current exec-file.
+///
+/// NOTE: this extension is primarily intended to be used alongside the [`Host
+/// I/O Extensions`](crate::target::ext::host_io), which enables the GDB client
+/// to read the executable file directly from the target
 pub trait ExecFile: Target {
     /// Return the full absolute name of the file that was executed to create a
     /// process running on the remote system.
-    fn get_exec_file(&self, pid: Option<Pid>) -> &[u8];
+    /// If no `pid` is provided, return the filename corresponding to the
+    /// currently executing process.
+    fn get_exec_file(&self, pid: Option<Pid>) -> TargetResult<&[u8], Self>;
 }
 
 define_ext!(ExecFileOps, ExecFile);

--- a/src/target/ext/exec_file.rs
+++ b/src/target/ext/exec_file.rs
@@ -23,7 +23,7 @@ pub trait ExecFile: Target {
     fn get_exec_file(
         &self,
         pid: Option<Pid>,
-        offset: usize,
+        offset: u64,
         length: usize,
         buf: &mut [u8],
     ) -> TargetResult<usize, Self>;

--- a/src/target/ext/exec_file.rs
+++ b/src/target/ext/exec_file.rs
@@ -12,12 +12,14 @@ pub trait ExecFile: Target {
     /// Get full absolute path of the file that was executed to create
     /// process `pid` running on the remote system.
     ///
-    /// If `pid` is `None`, return the filename corresponding to the 
+    /// If `pid` is `None`, return the filename corresponding to the
     /// currently executing process.
     ///
-    /// Return the number of bytes written into `buf` (which may be less than `length`).
+    /// Return the number of bytes written into `buf` (which may be less than
+    /// `length`).
     ///
-    /// If `offset` is greater than the length of the underlying data, return `Ok(0)`.
+    /// If `offset` is greater than the length of the underlying data, return
+    /// `Ok(0)`.
     fn get_exec_file(
         &self,
         pid: Option<Pid>,

--- a/src/target/ext/mod.rs
+++ b/src/target/ext/mod.rs
@@ -259,6 +259,7 @@ macro_rules! define_ext {
 pub mod base;
 pub mod breakpoints;
 pub mod catch_syscalls;
+pub mod exec_file;
 pub mod extended_mode;
 pub mod host_io;
 pub mod memory_map;

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -364,6 +364,11 @@ pub trait Target {
     fn host_io(&mut self) -> Option<ext::host_io::HostIoOps<Self>> {
         None
     }
+
+    /// Provide exec-file
+    fn exec_file(&mut self) -> Option<ext::exec_file::ExecFileOps<Self>> {
+        None
+    }
 }
 
 macro_rules! impl_dyn_target {
@@ -393,6 +398,11 @@ macro_rules! impl_dyn_target {
             #[inline(always)]
             fn monitor_cmd(&mut self) -> Option<ext::monitor_cmd::MonitorCmdOps<Self>> {
                 (**self).monitor_cmd()
+            }
+
+            #[inline(always)]
+            fn exec_file(&mut self) -> Option<ext::exec_file::ExecFileOps<Self>> {
+                (**self).exec_file()
             }
 
             #[inline(always)]


### PR DESCRIPTION
### Description

This PR implements the `qXfer:exec-file:read` command, based off the GDB documentation [here](https://sourceware.org/gdb/current/onlinedocs/gdb/General-Query-Packets.html#qXfer-executable-filename-read).

### API Stability

- [x] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
- Documentation
  - [x] rustdoc + approprate inline code comments
  - [ ] Updated CHANGELOG.md
  - [x] (if appropriate) Added feature to "Debugging Features" in README.md
- _If implementing a new protocol extension IDET_
  - [x] Included a basic sample implementation in `examples/armv4t`
  - [x] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [x] Confirmed that IDET can be optimized away (using `./scripts/test_dead_code_elim.sh` and/or `./example_no_std/check_size.sh`)
  - [ ] **OR** Implementation requires adding non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [ ] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- If you are implementing `gdbstub` in an open-source project, consider updating the README.md's "Real World Examples" section to link back to your project! -->

### Validation

<!-- example output, from https://github.com/daniel5151/gdbstub/pull/54 -->

<details>
<summary>GDB output</summary>

```
Remote debugging using :9001
Reading /test.elf from remote target...
warning: File transfers from remote targets can be slow. Use "set sysroot" to access files locally instead.
Reading /test.elf from remote target...
Reading symbols from target:/test.elf...
main () at test.c:1
1       int main() {
```

</details>

<details>
<summary>armv4t output</summary>

```
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/examples/armv4t`
loading section ".text" into memory from [0x55550000..0x55550078]
Setting PC to 0x55550000
Waiting for a GDB connection on "127.0.0.1:9001"...
Debugger connected from 127.0.0.1:37052
 TRACE gdbstub::protocol::recv_packet > <-- +
 TRACE gdbstub::protocol::recv_packet > <-- $qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;no-resumed+;xmlRegisters=i386#6a
 TRACE gdbstub::protocol::response_writer > --> $PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;ReverseContinue+;ReverseStep+;QDisableRandomization+;QEnvironmentHexEncoded+;QEnvironmentUnset+;QEnvironmentReset+;QStartupWithShell+;QSetWorkingDir+;swbreak+;hwbreak+;QCatchSyscalls+;qXfer:features:read+;qXfer:memory-map:read+;qXfer:exec-file:read+#ba
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $vMustReplyEmpty#3a
 INFO  gdbstub::gdbstub_impl              > Unknown command: Ok("vMustReplyEmpty")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $QStartNoAckMode#b0
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $!#21
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $Hgp0.0#ad
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:0,ffb#79
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<target version="1.0">
    <architecture>armv4t</architecture>
    <feature name="org.gnu.gdb.arm.core">
        <vector id="padding" type="uint32" count="25"/>

        <reg name="r0" bitsize="32" type="uint32"/>
        <reg name="r1" bitsize="32" type="uint32"/>
        <reg name="r2" bitsize="32" type="uint32"/>
        <reg name="r3" bitsize="32" type="uint32"/>
        <reg name="r4" bitsize="32" type="uint32"/>
        <reg name="r5" bitsize="32" type="uint32"/>
        <reg name="r6" bitsize="32" type="uint32"/>
        <reg name="r7" bitsize="32" type="uint32"/>
        <reg name="r8" bitsize="32" type="uint32"/>
        <reg name="r9" bitsize="32" type="uint32"/>
        <reg name="r10" bitsize="32" type="uint32"/>
        <reg name="r11" bitsize="32" type="uint32"/>
        <reg name="r12" bitsize="32" type="uint32"/>
        <reg name="sp" bitsize="32" type="data_ptr"/>
        <reg name="lr" bitsize="32"/>
        <reg name="pc" bitsize="32" type="code_ptr"/>

        <!--
            For some reason, my version of `gdb-multiarch` doesn't seem to
            respect "regnum", and will not parse this custom target.xml unless I
            manually include the padding bytes in the target description.

            On the bright side, AFAIK, there aren't all that many architectures
            that use padding bytes. Heck, the only reason armv4t uses padding is
            for historical reasons (see comment below).

            Odds are if you're defining your own custom arch, you won't run into
            this issue, since you can just lay out all the registers in the
            correct order.
        -->
        <reg name="padding" type="padding" bitsize="32"/>

        <!-- The CPSR is register 25, rather than register 16, because
        the FPA registers historically were placed between the PC
        and the CPSR in the "g" packet. -->
        <reg name="cpsr" bitsize="32" regnum="25"/>
    </feature>
    <feature name="custom-armv4t-extension">
        <!--
            maps to a simple scratch register within the emulator. the GDB
            client can read the register using `p }custom` and set it using
            `set }custom=1337`
        -->
        <reg name="custom" bitsize="32" type="uint32"/>

        <!--
            pseudo-register that return the current time when read.

            notably, i've set up the target to NOT send this register as part of
            the regular register list, which means that GDB will fetch/update
            this register via the 'p' and 'P' packets respectively
        -->
        <reg name="time" bitsize="32" type="uint32"/>
    </feature>
</target>#0f
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:aa4,ffb#3f
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 INFO  gdbstub::gdbstub_impl              > Unknown command: Ok("qTStatus")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $?#3f
 TRACE gdbstub::protocol::response_writer > --> $S05#b8
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qAttached:1#fa
GDB queried if it was attached to a process with PID 1
 TRACE gdbstub::protocol::response_writer > --> $1#31
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:0,ffb#b7
 TRACE gdbstub::protocol::response_writer > --> $m/test.elf#c1
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:9,ffb#c0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:setfs:0#bf
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:6a7573742070726f62696e67,0,1c0#ed
 TRACE gdbstub::protocol::response_writer > --> $F-1,02#32
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:setfs:1#c0
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746573742e656c66,0,0#1e
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      ?:
                                                                                                        ;
                                                                                                         9
                                                                                                          I@▒�B:
                                                                                                                ;
                                                                                                                 9
                                                                                                                  I▒
                                                                                                                    }

                                                                                                                     >
test.c                                                                                                               UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T▒▒
                                                                                                          ����|
UUxB�B
B�UUxUU
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      ?:
                                                                                                        ;
                                                                                                         9
                                                                                                          I@▒�B:
                                                                                                                ;
                                                                                                                 9
                                                                                                                  I▒
                                                                                                                    }

                                                                                                                     >
test.c                                                                                                               UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T▒▒
                                                                                                          ����|
UUxB�B
B�UUxUU
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      ?:
                                                                                                        ;
                                                                                                         9
                                                                                                          I@▒�B:
                                                                                                                ;
                                                                                                                 9
                                                                                                                  I▒
                                                                                                                    }

                                                                                                                     >
test.c                                                                                                               UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T▒▒
                                                                                                          ����|
UUxB�B
B�UUxUU
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      ?:
                                                                                                        ;
                                                                                                         9
                                                                                                          I@▒�B:
                                                                                                                ;
                                                                                                                 9
                                                                                                                  I▒
                                                                                                                    }

                                                                                                                     >
test.c                                                                                                               UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T▒▒
                                                                                                          ����|
UUxB�B
B�UUxUU
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,102fc#1b
 TRACE gdbstub::protocol::response_writer > --> $F0474;UUxUU
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#31
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746573742e656c66,0,0#1e
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      ?:
                                                                                                        ;
                                                                                                         9
                                                                                                          I@▒�B:
                                                                                                                ;
                                                                                                                 9
                                                                                                                  I▒
                                                                                                                    }

                                                                                                                     >
test.c                                                                                                               UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T▒▒
                                                                                                          ����|
UUxB�B
B�UUxUU
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      ?:
                                                                                                        ;
                                                                                                         9
                                                                                                          I@▒�B:
                                                                                                                ;
                                                                                                                 9
                                                                                                                  I▒
                                                                                                                    }

                                                                                                                     >
test.c                                                                                                               UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T▒▒
                                                                                                          ����|
UUxB�B
B�UUxUU
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      ?:
                                                                                                        ;
                                                                                                         9
                                                                                                          I@▒�B:
                                                                                                                ;
                                                                                                                 9
                                                                                                                  I▒
                                                                                                                    }

                                                                                                                     >
test.c                                                                                                               UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T▒▒
                                                                                                          ����|
UUxB�B
B�UUxUU
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      ?:
                                                                                                        ;
                                                                                                         9
                                                                                                          I@▒�B:
                                                                                                                ;
                                                                                                                 9
                                                                                                                  I▒
                                                                                                                    }

                                                                                                                     >
test.c                                                                                                               UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T▒▒
                                                                                                          ����|
UUxB�B
B�UUxUU
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,102fc#1b
 TRACE gdbstub::protocol::response_writer > --> $F0474;UUxUU
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#31
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      ?:
                                                                                                        ;
                                                                                                         9
                                                                                                          I@▒�B:
                                                                                                                ;
                                                                                                                 9
                                                                                                                  I▒
                                                                                                                    }

                                                                                                                     >
test.c                                                                                                               UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T▒▒
                                                                                                          ����|
UUxB�B
B�UUxUU
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $qSymbol::#5b
 INFO  gdbstub::gdbstub_impl              > Unknown command: Ok("qSymbol::")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:0,ffb#b7
 TRACE gdbstub::protocol::response_writer > --> $m/test.elf#c1
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:9,ffb#c0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $Hc-1#09
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qC#b4
 INFO  gdbstub::gdbstub_impl              > Unknown command: Ok("qC")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qOffsets#4b
 TRACE gdbstub::protocol::response_writer > --> $Text=00;Data=00;Bss=00#94
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000107856341200005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1000000078563412#0a
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::0,ffb#18
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE memory-map
    PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN"
            "http://sourceware.org/gdb/gdb-memory-map.dtd">
<memory-map>
    <memory type="ram" start="0x0" length="0x100000000"/>
</memory-map>#76
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::f4,ffb#82
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffe,2#35
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,2#33
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffe,2#35
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,2#33
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
```
</details>
