### PR TITLE
Pass PacketBuf as an argument of API

### DIFF
--- a/examples/armv4t/gdb/exec_file.rs
+++ b/examples/armv4t/gdb/exec_file.rs
@@ -2,6 +2,7 @@ use gdbstub::common::Pid;
 use gdbstub::target;
 use gdbstub::target::TargetResult;
 
+use super::copy_range_to_buf;
 use crate::emu::Emu;
 
 impl target::ext::exec_file::ExecFile for Emu {
@@ -13,10 +14,6 @@ impl target::ext::exec_file::ExecFile for Emu {
         buf: &mut [u8],
     ) -> TargetResult<usize, Self> {
         let filename = b"/test.elf";
-        let len = filename.len();
-        let data = &filename[len.min(offset as usize)..len.min(offset as usize + length)];
-        let buf = &mut buf[..data.len()];
-        buf.copy_from_slice(data);
-        Ok(data.len())
+        Ok(copy_range_to_buf(filename, offset, length, buf))
     }
 }

--- a/examples/armv4t/gdb/host_io.rs
+++ b/examples/armv4t/gdb/host_io.rs
@@ -262,7 +262,11 @@ impl target::ext::host_io::HostIoReadlink for Emu {
             .to_str()
             .ok_or(HostIoError::Errno(HostIoErrno::ENOENT))?
             .as_bytes();
-        Ok(copy_range_to_buf(data, 0, data.len(), buf))
+        if data.len() <= buf.len() {
+            Ok(copy_range_to_buf(data, 0, data.len(), buf))
+        } else {
+            Err(HostIoError::Errno(HostIoErrno::ENAMETOOLONG))
+        }
     }
 }
 

--- a/examples/armv4t/gdb/memory_map.rs
+++ b/examples/armv4t/gdb/memory_map.rs
@@ -1,17 +1,31 @@
 use gdbstub::target;
+use gdbstub::target::TargetResult;
 
 use crate::emu::Emu;
 
 impl target::ext::memory_map::MemoryMap for Emu {
-    fn memory_map_xml(&self) -> &str {
+    fn memory_map_xml(
+        &self,
+        offset: u64,
+        length: usize,
+        buf: &mut [u8],
+    ) -> TargetResult<usize, Self> {
         // Sample memory map, with RAM coverying the whole
         // memory space.
-        r#"<?xml version="1.0"?>
+        let memory_map = r#"<?xml version="1.0"?>
 <!DOCTYPE memory-map
     PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN"
             "http://sourceware.org/gdb/gdb-memory-map.dtd">
 <memory-map>
     <memory type="ram" start="0x0" length="0x100000000"/>
 </memory-map>"#
+            .trim()
+            .as_bytes();
+
+        let len = memory_map.len();
+        let data = &memory_map[len.min(offset as usize)..len.min(offset as usize + length)];
+        let buf = &mut buf[..data.len()];
+        buf.copy_from_slice(data);
+        Ok(data.len())
     }
 }

--- a/examples/armv4t/gdb/memory_map.rs
+++ b/examples/armv4t/gdb/memory_map.rs
@@ -1,6 +1,7 @@
 use gdbstub::target;
 use gdbstub::target::TargetResult;
 
+use super::copy_range_to_buf;
 use crate::emu::Emu;
 
 impl target::ext::memory_map::MemoryMap for Emu {
@@ -21,11 +22,6 @@ impl target::ext::memory_map::MemoryMap for Emu {
 </memory-map>"#
             .trim()
             .as_bytes();
-
-        let len = memory_map.len();
-        let data = &memory_map[len.min(offset as usize)..len.min(offset as usize + length)];
-        let buf = &mut buf[..data.len()];
-        buf.copy_from_slice(data);
-        Ok(data.len())
+        Ok(copy_range_to_buf(memory_map, offset, length, buf))
     }
 }

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -36,6 +36,14 @@ fn cpu_reg_id(id: ArmCoreRegId) -> Option<u8> {
     }
 }
 
+pub fn copy_range_to_buf(data: &[u8], offset: u64, length: usize, buf: &mut [u8]) -> usize {
+    let len = data.len();
+    let data = &data[len.min(offset as usize)..len.min(offset as usize + length)];
+    let buf = &mut buf[..data.len()];
+    buf.copy_from_slice(data);
+    data.len()
+}
+
 impl Target for Emu {
     // As an example, I've defined a custom architecture based off
     // `gdbstub_arch::arm::Armv4t`. The implementation is in the `custom_arch`

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -36,6 +36,10 @@ fn cpu_reg_id(id: ArmCoreRegId) -> Option<u8> {
     }
 }
 
+/// Copy a range of `data` (start at `offset` with a size of `length`) to `buf`.
+/// Return the size of data copied. Return 0 if encounter EOF.
+///
+/// Mainly used by qXfer:_object_:read commands.
 pub fn copy_range_to_buf(data: &[u8], offset: u64, length: usize, buf: &mut [u8]) -> usize {
     let len = data.len();
     let data = &data[len.min(offset as usize)..len.min(offset as usize + length)];

--- a/examples/armv4t/gdb/target_description_xml_override.rs
+++ b/examples/armv4t/gdb/target_description_xml_override.rs
@@ -76,7 +76,6 @@ impl target::ext::target_description_xml_override::TargetDescriptionXmlOverride 
         "#
         .trim()
         .as_bytes();
-
         Ok(copy_range_to_buf(xml, offset, length, buf))
     }
 }

--- a/examples/armv4t/gdb/target_description_xml_override.rs
+++ b/examples/armv4t/gdb/target_description_xml_override.rs
@@ -1,6 +1,7 @@
 use gdbstub::target;
 use gdbstub::target::TargetResult;
 
+use super::copy_range_to_buf;
 use crate::emu::Emu;
 
 impl target::ext::target_description_xml_override::TargetDescriptionXmlOverride for Emu {
@@ -76,10 +77,6 @@ impl target::ext::target_description_xml_override::TargetDescriptionXmlOverride 
         .trim()
         .as_bytes();
 
-        let len = xml.len();
-        let data = &xml[len.min(offset as usize)..len.min(offset as usize + length)];
-        let buf = &mut buf[..data.len()];
-        buf.copy_from_slice(data);
-        Ok(data.len())
+        Ok(copy_range_to_buf(xml, offset, length, buf))
     }
 }

--- a/examples/armv4t/gdb/target_description_xml_override.rs
+++ b/examples/armv4t/gdb/target_description_xml_override.rs
@@ -1,10 +1,16 @@
 use gdbstub::target;
+use gdbstub::target::TargetResult;
 
 use crate::emu::Emu;
 
 impl target::ext::target_description_xml_override::TargetDescriptionXmlOverride for Emu {
-    fn target_description_xml(&self) -> &str {
-        r#"<?xml version="1.0"?>
+    fn target_description_xml(
+        &self,
+        offset: u64,
+        length: usize,
+        buf: &mut [u8],
+    ) -> TargetResult<usize, Self> {
+        let xml = r#"<?xml version="1.0"?>
 <!DOCTYPE target SYSTEM "gdb-target.dtd">
 <target version="1.0">
     <architecture>armv4t</architecture>
@@ -67,5 +73,13 @@ impl target::ext::target_description_xml_override::TargetDescriptionXmlOverride 
     </feature>
 </target>
         "#
+        .trim()
+        .as_bytes();
+
+        let len = xml.len();
+        let data = &xml[len.min(offset as usize)..len.min(offset as usize + length)];
+        let buf = &mut buf[..data.len()];
+        buf.copy_from_slice(data);
+        Ok(data.len())
     }
 }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -180,7 +180,7 @@ commands! {
         "QStartNoAckMode" => _QStartNoAckMode::QStartNoAckMode,
         "qsThreadInfo" => _qsThreadInfo::qsThreadInfo,
         "qSupported" => _qSupported::qSupported<'a>,
-        "qXfer:features:read" => _qXfer_features_read::qXferFeaturesRead,
+        "qXfer:features:read" => _qXfer_features_read::qXferFeaturesRead<'a>,
         "s" => _s::s<'a>,
         "T" => _t_upcase::T,
         "vCont" => _vCont::vCont<'a>,
@@ -221,8 +221,8 @@ commands! {
         "bs" => _bs::bs,
     }
 
-    memory_map {
-        "qXfer:memory-map:read" => _qXfer_memory_map::qXferMemoryMapRead,
+    memory_map use 'a {
+        "qXfer:memory-map:read" => _qXfer_memory_map::qXferMemoryMapRead<'a>,
     }
 
     exec_file use 'a {

--- a/src/protocol/commands/_qXfer_features_read.rs
+++ b/src/protocol/commands/_qXfer_features_read.rs
@@ -1,14 +1,17 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct qXferFeaturesRead {
-    pub offset: usize,
-    pub len: usize,
+pub struct qXferFeaturesRead<'a> {
+    pub offset: u64,
+    pub length: usize,
+
+    pub buf: &'a mut [u8],
 }
 
-impl<'a> ParseCommand<'a> for qXferFeaturesRead {
+impl<'a> ParseCommand<'a> for qXferFeaturesRead<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
-        let body = buf.into_body();
+        let (buf, body_range) = buf.into_raw_buf();
+        let body = buf.get_mut(body_range.start..body_range.end)?;
 
         if body.is_empty() {
             return None;
@@ -22,8 +25,10 @@ impl<'a> ParseCommand<'a> for qXferFeaturesRead {
 
         let mut body = body.next()?.split(|b| *b == b',');
         let offset = decode_hex(body.next()?).ok()?;
-        let len = decode_hex(body.next()?).ok()?;
+        let length = decode_hex(body.next()?).ok()?;
 
-        Some(qXferFeaturesRead { offset, len })
+        drop(body);
+
+        Some(qXferFeaturesRead { offset, length, buf })
     }
 }

--- a/src/protocol/commands/_qXfer_memory_map.rs
+++ b/src/protocol/commands/_qXfer_memory_map.rs
@@ -1,14 +1,17 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct qXferMemoryMapRead {
-    pub offset: usize,
-    pub len: usize,
+pub struct qXferMemoryMapRead<'a> {
+    pub offset: u64,
+    pub length: usize,
+
+    pub buf: &'a mut [u8],
 }
 
-impl<'a> ParseCommand<'a> for qXferMemoryMapRead {
+impl<'a> ParseCommand<'a> for qXferMemoryMapRead<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
-        let body = buf.into_body();
+        let (buf, body_range) = buf.into_raw_buf();
+        let body = buf.get_mut(body_range.start..body_range.end)?;
 
         if body.is_empty() {
             return None;
@@ -22,8 +25,10 @@ impl<'a> ParseCommand<'a> for qXferMemoryMapRead {
 
         let mut body = body.next()?.split(|b| *b == b',');
         let offset = decode_hex(body.next()?).ok()?;
-        let len = decode_hex(body.next()?).ok()?;
+        let length = decode_hex(body.next()?).ok()?;
 
-        Some(qXferMemoryMapRead { offset, len })
+        drop(body);
+
+        Some(qXferMemoryMapRead { offset, length , buf})
     }
 }

--- a/src/protocol/commands/_vFile_pread.rs
+++ b/src/protocol/commands/_vFile_pread.rs
@@ -3,13 +3,17 @@ use super::prelude::*;
 #[derive(Debug)]
 pub struct vFilePread<'a> {
     pub fd: u32,
-    pub count: &'a [u8],
-    pub offset: &'a [u8],
+    pub count: usize,
+    pub offset: u64,
+
+    pub buf: &'a mut [u8],
 }
 
 impl<'a> ParseCommand<'a> for vFilePread<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
-        let body = buf.into_body();
+        let (buf, body_range) = buf.into_raw_buf();
+        let body = buf.get_mut(body_range.start..body_range.end)?;
+
         if body.is_empty() {
             return None;
         }
@@ -18,9 +22,12 @@ impl<'a> ParseCommand<'a> for vFilePread<'a> {
             [b':', body @ ..] => {
                 let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
                 let fd = decode_hex(body.next()?).ok()?;
-                let count = decode_hex_buf(body.next()?).ok()?;
-                let offset = decode_hex_buf(body.next()?).ok()?;
-                Some(vFilePread{fd, count, offset})
+                let count = decode_hex(body.next()?).ok()?;
+                let offset = decode_hex(body.next()?).ok()?;
+
+                drop(body);
+
+                Some(vFilePread{fd, count, offset, buf})
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_readlink.rs
+++ b/src/protocol/commands/_vFile_readlink.rs
@@ -3,11 +3,15 @@ use super::prelude::*;
 #[derive(Debug)]
 pub struct vFileReadlink<'a> {
     pub filename: &'a [u8],
+
+    pub buf: &'a mut [u8],
 }
 
 impl<'a> ParseCommand<'a> for vFileReadlink<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
-        let body = buf.into_body();
+        let (buf, body_range) = buf.into_raw_buf();
+        let (body, buf) = buf[body_range.start..].split_at_mut(body_range.end - body_range.start);
+
         if body.is_empty() {
             return None;
         }
@@ -15,7 +19,7 @@ impl<'a> ParseCommand<'a> for vFileReadlink<'a> {
         match body {
             [b':', body @ ..] => {
                 let filename = decode_hex_buf(body).ok()?;
-                Some(vFileReadlink{filename})
+                Some(vFileReadlink{filename, buf})
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_readlink.rs
+++ b/src/protocol/commands/_vFile_readlink.rs
@@ -10,6 +10,7 @@ pub struct vFileReadlink<'a> {
 impl<'a> ParseCommand<'a> for vFileReadlink<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
         let (buf, body_range) = buf.into_raw_buf();
+        // TODO: rewrite to avoid panic
         let (body, buf) = buf[body_range.start..].split_at_mut(body_range.end - body_range.start);
 
         if body.is_empty() {

--- a/src/protocol/response_writer.rs
+++ b/src/protocol/response_writer.rs
@@ -193,25 +193,6 @@ impl<'a, C: Connection + 'a> ResponseWriter<'a, C> {
         Ok(())
     }
 
-    /// Write a range of data specified by offset and len.
-    /// Used by qXfer:_object_:read commands.
-    pub fn write_binary_range(
-        &mut self,
-        data: &[u8],
-        offset: usize,
-        len: usize,
-    ) -> Result<(), Error<C::Error>> {
-        if offset < data.len() {
-            // still more data
-            self.write_str("m")?;
-            self.write_binary(&data[offset..][..len.min(data.len() - offset)])?
-        } else {
-            // no more data
-            self.write_str("l")?;
-        }
-        Ok(())
-    }
-
     /// Write a number as a big-endian hex string using the most compact
     /// representation possible (i.e: trimming leading zeros).
     pub fn write_num<D: BeBytes + PrimInt>(&mut self, digit: D) -> Result<(), Error<C::Error>> {

--- a/src/target/ext/host_io.rs
+++ b/src/target/ext/host_io.rs
@@ -336,6 +336,10 @@ pub trait HostIoReadlink: HostIo {
     /// Read value of symbolic link `filename` on the target.
     ///
     /// Return the number of bytes written into `buf`.
+    ///
+    /// Unlike most other Host IO handlers, if the resolved file path exceeds
+    /// the length of the provided `buf`, the target should NOT return a
+    /// partial response, and MUST return a `Err(HostIoErrno::ENAMETOOLONG)`.
     fn readlink(&mut self, filename: &[u8], buf: &mut [u8]) -> HostIoResult<usize, Self>;
 }
 

--- a/src/target/ext/host_io.rs
+++ b/src/target/ext/host_io.rs
@@ -278,11 +278,12 @@ pub trait HostIoPread: HostIo {
     /// Up to `count` bytes will be read from the file, starting at `offset`
     /// relative to the start of the file.
     ///
-    /// The data read _must_ be sent by calling [`HostIoOutput::write`], which
-    /// will consume the `output` object and return a [`HostIoToken`]. This
-    /// token ensures that the implementer of this method calls
-    /// [`HostIoOutput::write`].
-    fn pread<'a>(
+    /// Return the number of bytes written into `buf` (which may be less than
+    /// `count`).
+    ///
+    /// If `offset` is greater than the length of the underlying data, return
+    /// `Ok(0)`.
+    fn pread(
         &mut self,
         fd: u32,
         count: usize,
@@ -334,11 +335,8 @@ define_ext!(HostIoUnlinkOps, HostIoUnlink);
 pub trait HostIoReadlink: HostIo {
     /// Read value of symbolic link `filename` on the target.
     ///
-    /// The data read _must_ be sent by calling [`HostIoOutput::write`], which
-    /// will consume the `output` object and return a [`HostIoToken`]. This
-    /// token ensures that the implementer of this method calls
-    /// [`HostIoOutput::write`].
-    fn readlink<'a>(&mut self, filename: &[u8], buf: &mut [u8]) -> HostIoResult<usize, Self>;
+    /// Return the number of bytes written into `buf`.
+    fn readlink(&mut self, filename: &[u8], buf: &mut [u8]) -> HostIoResult<usize, Self>;
 }
 
 define_ext!(HostIoReadlinkOps, HostIoReadlink);

--- a/src/target/ext/memory_map.rs
+++ b/src/target/ext/memory_map.rs
@@ -1,5 +1,5 @@
 //! Provide a memory map for the target.
-use crate::target::Target;
+use crate::target::{Target, TargetResult};
 
 /// Target Extension - Provide a target memory map.
 pub trait MemoryMap: Target {
@@ -8,7 +8,12 @@ pub trait MemoryMap: Target {
     /// See the [GDB Documentation] for a description of the format.
     ///
     /// [GDB Documentation]: https://sourceware.org/gdb/onlinedocs/gdb/Memory-Map-Format.html
-    fn memory_map_xml(&self) -> &str;
+    fn memory_map_xml(
+        &self,
+        offset: u64,
+        length: usize,
+        buf: &mut [u8],
+    ) -> TargetResult<usize, Self>;
 }
 
 define_ext!(MemoryMapOps, MemoryMap);

--- a/src/target/ext/target_description_xml_override.rs
+++ b/src/target/ext/target_description_xml_override.rs
@@ -1,5 +1,5 @@
 //! Override the target description XML specified by `Target::Arch`.
-use crate::target::Target;
+use crate::target::{Target, TargetResult};
 
 /// Target Extension - Override the target description XML specified by
 /// `Target::Arch`.
@@ -13,7 +13,12 @@ pub trait TargetDescriptionXmlOverride: Target {
     /// Refer to the
     /// [target_description_xml](crate::arch::Arch::target_description_xml)
     /// docs for more info.
-    fn target_description_xml(&self) -> &str;
+    fn target_description_xml(
+        &self,
+        offset: u64,
+        length: usize,
+        buf: &mut [u8],
+    ) -> TargetResult<usize, Self>;
 }
 
 define_ext!(


### PR DESCRIPTION
### Description
- Update the other qXfer-backed protocol extensions to use the `(length: usize, offset: u64, buf: &mut [u8])` API
  - At the moment, I think this is just `MemoryMap` and `TargetXmlOverride`
- Update the vFile API to use the `&mut [u8]` PacketBuf instead of the current callback-based approach.
- Update the vFile API to use plain 'ol `usize` for `length` and `offset` parameters, instead of `Target::Arch::Usize`
  - Context: https://github.com/daniel5151/gdbstub/pull/69#discussion_r707477573

_Originally posted by @daniel5151 in https://github.com/daniel5151/gdbstub/issues/69#issuecomment-920159984_

### API Stability

- [x] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
- Documentation
  - [x] rustdoc + approprate inline code comments
  - [ ] Updated CHANGELOG.md
  - [ ] (if appropriate) Added feature to "Debugging Features" in README.md
- _If implementing a new protocol extension IDET_
  - [ ] Included a basic sample implementation in `examples/armv4t`
  - [ ] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [ ] Confirmed that IDET can be optimized away (using `./scripts/test_dead_code_elim.sh` and/or `./example_no_std/check_size.sh`)
  - [ ] **OR** Implementation requires adding non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [ ] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- If you are implementing `gdbstub` in an open-source project, consider updating the README.md's "Real World Examples" section to link back to your project! -->