### PR TITLE
Enable logging for responses with only alloc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ goblin = "0.2"
 default = ["std"]
 alloc = ["managed/alloc"]
 std = ["alloc"]
+trace-pkt = ["alloc"]
 paranoid_unsafe = []
 
 # INTERNAL: enables the `__dead_code_marker!` macro.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ pretty_env_logger = "0.4"
 goblin = "0.2"
 
 [features]
-default = ["std"]
+default = ["std", "trace-pkt"]
 alloc = ["managed/alloc"]
 std = ["alloc"]
 trace-pkt = ["alloc"]

--- a/src/protocol/recv_packet.rs
+++ b/src/protocol/recv_packet.rs
@@ -53,6 +53,7 @@ impl RecvPacketStateMachine {
         }
 
         if matches!(self.state, State::Ready) {
+            #[cfg(feature = "trace-pkt")]
             trace!(
                 "<-- {}",
                 core::str::from_utf8(buf.as_slice()).unwrap_or("<invalid packet>")
@@ -111,6 +112,7 @@ impl RecvPacketBlocking {
             buf.push(get_byte().map_err(RecvPacketError::Connection)?)?;
         }
 
+        #[cfg(feature = "trace-pkt")]
         trace!(
             "<-- {}",
             core::str::from_utf8(buf.as_slice()).unwrap_or("<invalid packet>")

--- a/src/protocol/response_writer.rs
+++ b/src/protocol/response_writer.rs
@@ -1,3 +1,6 @@
+use alloc::vec::Vec;
+use alloc::string::String;
+
 use num_traits::PrimInt;
 
 use crate::internal::BeBytes;
@@ -24,7 +27,7 @@ pub struct ResponseWriter<'a, C: Connection + 'a> {
     rle_char: u8,
     rle_repeat: u8,
     // buffer to log outgoing packets. only allocates if logging is enabled.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     msg: Vec<u8>,
 }
 
@@ -37,7 +40,7 @@ impl<'a, C: Connection + 'a> ResponseWriter<'a, C> {
             checksum: 0,
             rle_char: 0,
             rle_repeat: 0,
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             msg: Vec::new(),
         }
     }
@@ -51,7 +54,7 @@ impl<'a, C: Connection + 'a> ResponseWriter<'a, C> {
         // added to the checksum, and is just sitting in the RLE buffer)
         let checksum = self.checksum;
 
-        #[cfg(feature = "std")]
+        #[cfg(feature = "alloc")]
         trace!(
             "--> ${}#{:02x?}",
             String::from_utf8_lossy(&self.msg),
@@ -73,7 +76,7 @@ impl<'a, C: Connection + 'a> ResponseWriter<'a, C> {
     }
 
     fn inner_write(&mut self, byte: u8) -> Result<(), Error<C::Error>> {
-        #[cfg(feature = "std")]
+        #[cfg(feature = "alloc")]
         if log_enabled!(log::Level::Trace) {
             match self.msg.as_slice() {
                 [.., c, b'*'] => {

--- a/src/protocol/response_writer.rs
+++ b/src/protocol/response_writer.rs
@@ -1,5 +1,7 @@
-use alloc::vec::Vec;
+#[cfg(feature = "trace-pkt")]
 use alloc::string::String;
+#[cfg(feature = "trace-pkt")]
+use alloc::vec::Vec;
 
 use num_traits::PrimInt;
 
@@ -27,7 +29,7 @@ pub struct ResponseWriter<'a, C: Connection + 'a> {
     rle_char: u8,
     rle_repeat: u8,
     // buffer to log outgoing packets. only allocates if logging is enabled.
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "trace-pkt")]
     msg: Vec<u8>,
 }
 
@@ -40,7 +42,7 @@ impl<'a, C: Connection + 'a> ResponseWriter<'a, C> {
             checksum: 0,
             rle_char: 0,
             rle_repeat: 0,
-            #[cfg(feature = "alloc")]
+            #[cfg(feature = "trace-pkt")]
             msg: Vec::new(),
         }
     }
@@ -54,7 +56,7 @@ impl<'a, C: Connection + 'a> ResponseWriter<'a, C> {
         // added to the checksum, and is just sitting in the RLE buffer)
         let checksum = self.checksum;
 
-        #[cfg(feature = "alloc")]
+        #[cfg(feature = "trace-pkt")]
         trace!(
             "--> ${}#{:02x?}",
             String::from_utf8_lossy(&self.msg),
@@ -76,7 +78,7 @@ impl<'a, C: Connection + 'a> ResponseWriter<'a, C> {
     }
 
     fn inner_write(&mut self, byte: u8) -> Result<(), Error<C::Error>> {
-        #[cfg(feature = "alloc")]
+        #[cfg(feature = "trace-pkt")]
         if log_enabled!(log::Level::Trace) {
             match self.msg.as_slice() {
                 [.., c, b'*'] => {


### PR DESCRIPTION
### Description

Enable logging for responses (as discussed here https://github.com/daniel5151/gdbstub/discussions/77)

### API Stability

- [x] This PR does not require a breaking API change

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
