### PR TITLE
Dynamic `read_register` + `RegId` support

### DIFF
--- a/examples/armv4t/gdb/host_io.rs
+++ b/examples/armv4t/gdb/host_io.rs
@@ -5,7 +5,7 @@ use gdbstub::target::ext::host_io::{
     FsKind, HostIoErrno, HostIoError, HostIoOpenFlags, HostIoOpenMode, HostIoResult, HostIoStat,
 };
 
-use super::copy_range_to_buf;
+use super::{copy_range_to_buf, copy_to_buf};
 use crate::emu::Emu;
 use crate::TEST_PROGRAM_ELF;
 
@@ -246,11 +246,11 @@ impl target::ext::host_io::HostIoReadlink for Emu {
         if filename == b"/proc/1/exe" {
             // Support `info proc exe` command
             let exe = b"/test.elf";
-            return Ok(copy_range_to_buf(exe, 0, exe.len(), buf));
+            return Ok(copy_to_buf(exe, buf));
         } else if filename == b"/proc/1/cwd" {
             // Support `info proc cwd` command
             let cwd = b"/";
-            return Ok(copy_range_to_buf(cwd, 0, cwd.len(), buf));
+            return Ok(copy_to_buf(cwd, buf));
         } else if filename.starts_with(b"/proc") {
             return Err(HostIoError::Errno(HostIoErrno::ENOENT));
         }
@@ -263,7 +263,7 @@ impl target::ext::host_io::HostIoReadlink for Emu {
             .ok_or(HostIoError::Errno(HostIoErrno::ENOENT))?
             .as_bytes();
         if data.len() <= buf.len() {
-            Ok(copy_range_to_buf(data, 0, data.len(), buf))
+            Ok(copy_to_buf(data, buf))
         } else {
             Err(HostIoError::Errno(HostIoErrno::ENAMETOOLONG))
         }

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -367,6 +367,8 @@ impl target::ext::base::singlethread::SingleThreadRangeStepping for Emu {
 }
 
 mod custom_arch {
+    use core::num::NonZeroUsize;
+
     use gdbstub::arch::{Arch, RegId, Registers};
 
     use gdbstub_arch::arm::reg::id::ArmCoreRegId;
@@ -451,7 +453,7 @@ mod custom_arch {
     }
 
     impl RegId for ArmCoreRegIdCustom {
-        fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+        fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
             let reg = match id {
                 26 => Self::Custom,
                 27 => Self::Time,
@@ -460,7 +462,7 @@ mod custom_arch {
                     return Some((Self::Core(reg), size));
                 }
             };
-            Some((reg, 4))
+            Some((reg, Some(NonZeroUsize::new(4)?)))
         }
     }
 

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -269,23 +269,25 @@ impl target::ext::base::SingleRegisterAccess<()> for Emu {
             custom_arch::ArmCoreRegIdCustom::Core(reg_id) => {
                 if let Some(i) = cpu_reg_id(reg_id) {
                     let w = self.cpu.reg_get(self.cpu.mode(), i);
-                    let data = &w.to_le_bytes();
-                    Ok(copy_to_buf(data, buf))
+                    buf.copy_from_slice(&w.to_le_bytes());
+                    Ok(buf.len())
                 } else {
                     Err(().into())
                 }
             }
             custom_arch::ArmCoreRegIdCustom::Custom => {
-                let data = &self.custom_reg.to_le_bytes();
-                Ok(copy_to_buf(data, buf))
+                buf.copy_from_slice(&self.custom_reg.to_le_bytes());
+                Ok(buf.len())
             }
             custom_arch::ArmCoreRegIdCustom::Time => {
-                let data = &(std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis() as u32)
-                    .to_le_bytes();
-                Ok(copy_to_buf(data, buf))
+                buf.copy_from_slice(
+                    &(std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_millis() as u32)
+                        .to_le_bytes(),
+                );
+                Ok(buf.len())
             }
         }
     }

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -451,16 +451,16 @@ mod custom_arch {
     }
 
     impl RegId for ArmCoreRegIdCustom {
-        fn from_raw_id(id: usize) -> Option<Self> {
+        fn from_raw_id(id: usize) -> Option<(Self, usize)> {
             let reg = match id {
                 26 => Self::Custom,
                 27 => Self::Time,
                 _ => {
-                    let reg = ArmCoreRegId::from_raw_id(id)?;
-                    return Some(Self::Core(reg));
+                    let (reg, size) = ArmCoreRegId::from_raw_id(id)?;
+                    return Some((Self::Core(reg), size));
                 }
             };
-            Some(reg)
+            Some((reg, 4))
         }
     }
 

--- a/gdbstub_arch/src/arm/reg/id.rs
+++ b/gdbstub_arch/src/arm/reg/id.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroUsize;
+
 use gdbstub::arch::RegId;
 
 /// 32-bit ARM core register identifier.
@@ -21,7 +23,7 @@ pub enum ArmCoreRegId {
 }
 
 impl RegId for ArmCoreRegId {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         let reg = match id {
             0..=12 => Self::Gpr(id as u8),
             13 => Self::Sp,
@@ -31,6 +33,6 @@ impl RegId for ArmCoreRegId {
             25 => Self::Cpsr,
             _ => return None,
         };
-        Some((reg, 4))
+        Some((reg, Some(NonZeroUsize::new(4)?)))
     }
 }

--- a/gdbstub_arch/src/arm/reg/id.rs
+++ b/gdbstub_arch/src/arm/reg/id.rs
@@ -21,7 +21,7 @@ pub enum ArmCoreRegId {
 }
 
 impl RegId for ArmCoreRegId {
-    fn from_raw_id(id: usize) -> Option<Self> {
+    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
         let reg = match id {
             0..=12 => Self::Gpr(id as u8),
             13 => Self::Sp,
@@ -31,6 +31,6 @@ impl RegId for ArmCoreRegId {
             25 => Self::Cpsr,
             _ => return None,
         };
-        Some(reg)
+        Some((reg, 4))
     }
 }

--- a/gdbstub_arch/src/arm/reg/id.rs
+++ b/gdbstub_arch/src/arm/reg/id.rs
@@ -21,7 +21,7 @@ pub enum ArmCoreRegId {
 }
 
 impl RegId for ArmCoreRegId {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<Self> {
         let reg = match id {
             0..=12 => Self::Gpr(id as u8),
             13 => Self::Sp,
@@ -31,6 +31,6 @@ impl RegId for ArmCoreRegId {
             25 => Self::Cpsr,
             _ => return None,
         };
-        Some((reg, 4))
+        Some(reg)
     }
 }

--- a/gdbstub_arch/src/mips/reg/id.rs
+++ b/gdbstub_arch/src/mips/reg/id.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroUsize;
+
 use gdbstub::arch::RegId;
 
 /// MIPS register identifier.
@@ -44,7 +46,7 @@ pub enum MipsRegId<U> {
     _Size(U),
 }
 
-fn from_raw_id<U>(id: usize) -> Option<(MipsRegId<U>, usize)> {
+fn from_raw_id<U>(id: usize) -> Option<(MipsRegId<U>, Option<NonZeroUsize>)> {
     let reg = match id {
         0..=31 => MipsRegId::Gpr(id as u8),
         32 => MipsRegId::Status,
@@ -63,23 +65,23 @@ fn from_raw_id<U>(id: usize) -> Option<(MipsRegId<U>, usize)> {
         76 => MipsRegId::Hi3,
         77 => MipsRegId::Lo3,
         // `MipsRegId::Dspctl` is the only register that will always be 4 bytes wide
-        78 => return Some((MipsRegId::Dspctl, 4)),
+        78 => return Some((MipsRegId::Dspctl, Some(NonZeroUsize::new(4)?))),
         79 => MipsRegId::Restart,
         _ => return None,
     };
 
     let ptrsize = core::mem::size_of::<U>();
-    Some((reg, ptrsize))
+    Some((reg, Some(NonZeroUsize::new(ptrsize)?)))
 }
 
 impl RegId for MipsRegId<u32> {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         from_raw_id::<u32>(id)
     }
 }
 
 impl RegId for MipsRegId<u64> {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         from_raw_id::<u64>(id)
     }
 }
@@ -104,7 +106,7 @@ mod tests {
         let mut i = 0;
         let mut sum_reg_sizes = 0;
         while let Some((_, size)) = RId::from_raw_id(i) {
-            sum_reg_sizes += size;
+            sum_reg_sizes += size.unwrap().get();
             i += 1;
         }
 

--- a/gdbstub_arch/src/mips/reg/id.rs
+++ b/gdbstub_arch/src/mips/reg/id.rs
@@ -44,7 +44,7 @@ pub enum MipsRegId<U> {
     _Size(U),
 }
 
-fn from_raw_id<U>(id: usize) -> Option<MipsRegId<U>> {
+fn from_raw_id<U>(id: usize) -> Option<(MipsRegId<U>, usize)> {
     let reg = match id {
         0..=31 => MipsRegId::Gpr(id as u8),
         32 => MipsRegId::Status,
@@ -62,22 +62,62 @@ fn from_raw_id<U>(id: usize) -> Option<MipsRegId<U>> {
         75 => MipsRegId::Lo2,
         76 => MipsRegId::Hi3,
         77 => MipsRegId::Lo3,
-        78 => MipsRegId::Dspctl,
+        // `MipsRegId::Dspctl` is the only register that will always be 4 bytes wide
+        78 => return Some((MipsRegId::Dspctl, 4)),
         79 => MipsRegId::Restart,
         _ => return None,
     };
 
-    Some(reg)
+    let ptrsize = core::mem::size_of::<U>();
+    Some((reg, ptrsize))
 }
 
 impl RegId for MipsRegId<u32> {
-    fn from_raw_id(id: usize) -> Option<Self> {
+    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
         from_raw_id::<u32>(id)
     }
 }
 
 impl RegId for MipsRegId<u64> {
-    fn from_raw_id(id: usize) -> Option<Self> {
+    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
         from_raw_id::<u64>(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gdbstub::arch::RegId;
+    use gdbstub::arch::Registers;
+
+    fn test<Rs: Registers, RId: RegId>() {
+        // Obtain the data length written by `gdb_serialize` by passing a custom
+        // closure.
+        let mut serialized_data_len = 0;
+        let counter = |b: Option<u8>| {
+            if b.is_some() {
+                serialized_data_len += 1;
+            }
+        };
+        Rs::default().gdb_serialize(counter);
+
+        // Accumulate register sizes returned by `from_raw_id`.
+        let mut i = 0;
+        let mut sum_reg_sizes = 0;
+        while let Some((_, size)) = RId::from_raw_id(i) {
+            sum_reg_sizes += size;
+            i += 1;
+        }
+
+        assert_eq!(serialized_data_len, sum_reg_sizes);
+    }
+
+    #[test]
+    fn test_mips32() {
+        test::<crate::mips::reg::MipsCoreRegsWithDsp<u32>, crate::mips::reg::id::MipsRegId<u32>>()
+    }
+
+    #[test]
+    fn test_mips64() {
+        test::<crate::mips::reg::MipsCoreRegsWithDsp<u64>, crate::mips::reg::id::MipsRegId<u64>>()
     }
 }

--- a/gdbstub_arch/src/msp430/reg/id.rs
+++ b/gdbstub_arch/src/msp430/reg/id.rs
@@ -21,7 +21,7 @@ pub enum Msp430RegId<U> {
     _Size(U),
 }
 
-fn from_raw_id<U>(id: usize) -> Option<(Msp430RegId<U>, usize)> {
+fn from_raw_id<U>(id: usize) -> Option<Msp430RegId<U>> {
     let reg = match id {
         0 => Msp430RegId::Pc,
         1 => Msp430RegId::Sp,
@@ -31,60 +31,17 @@ fn from_raw_id<U>(id: usize) -> Option<(Msp430RegId<U>, usize)> {
         _ => return None,
     };
 
-    let ptrsize = core::mem::size_of::<U>();
-    Some((reg, ptrsize))
+    Some(reg)
 }
 
 impl RegId for Msp430RegId<u16> {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<Self> {
         from_raw_id::<u16>(id)
     }
 }
 
 impl RegId for Msp430RegId<u32> {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<Self> {
         from_raw_id::<u32>(id)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use gdbstub::arch::RegId;
-    use gdbstub::arch::Registers;
-
-    fn test<Rs: Registers, RId: RegId>() {
-        // Obtain the data length written by `gdb_serialize` by passing a custom
-        // closure.
-        let mut serialized_data_len = 0;
-        let counter = |b: Option<u8>| {
-            if b.is_some() {
-                serialized_data_len += 1;
-            }
-        };
-        Rs::default().gdb_serialize(counter);
-
-        // The `Msp430Regs` implementation does not increment the size for
-        // the CG register since it will always be the constant zero.
-        serialized_data_len += RId::from_raw_id(3).unwrap().1;
-
-        // Accumulate register sizes returned by `from_raw_id`.
-        let mut i = 0;
-        let mut sum_reg_sizes = 0;
-        while let Some((_, size)) = RId::from_raw_id(i) {
-            sum_reg_sizes += size;
-            i += 1;
-        }
-
-        assert_eq!(serialized_data_len, sum_reg_sizes);
-    }
-
-    #[test]
-    fn test_msp430() {
-        test::<crate::msp430::reg::Msp430Regs<u16>, crate::msp430::reg::id::Msp430RegId<u16>>()
-    }
-
-    #[test]
-    fn test_msp430x() {
-        test::<crate::msp430::reg::Msp430Regs<u32>, crate::msp430::reg::id::Msp430RegId<u32>>()
     }
 }

--- a/gdbstub_arch/src/riscv/reg/id.rs
+++ b/gdbstub_arch/src/riscv/reg/id.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroUsize;
+
 use gdbstub::arch::RegId;
 
 /// RISC-V Register identifier.
@@ -22,10 +24,10 @@ pub enum RiscvRegId<U> {
 macro_rules! impl_riscv_reg_id {
     ($usize:ty) => {
         impl RegId for RiscvRegId<$usize> {
-            fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+            fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
                 const USIZE: usize = core::mem::size_of::<$usize>();
 
-                let reg_size = match id {
+                let (id, size) = match id {
                     0..=31 => (Self::Gpr(id as u8), USIZE),
                     32 => (Self::Pc, USIZE),
                     33..=64 => (Self::Fpr((id - 33) as u8), USIZE),
@@ -33,7 +35,8 @@ macro_rules! impl_riscv_reg_id {
                     4161 => (Self::Priv, 1),
                     _ => return None,
                 };
-                Some(reg_size)
+
+                Some((id, Some(NonZeroUsize::new(size)?)))
             }
         }
     };

--- a/gdbstub_arch/src/riscv/reg/id.rs
+++ b/gdbstub_arch/src/riscv/reg/id.rs
@@ -22,15 +22,13 @@ pub enum RiscvRegId<U> {
 macro_rules! impl_riscv_reg_id {
     ($usize:ty) => {
         impl RegId for RiscvRegId<$usize> {
-            fn from_raw_id(id: usize) -> Option<(Self, usize)> {
-                const USIZE: usize = core::mem::size_of::<$usize>();
-
+            fn from_raw_id(id: usize) -> Option<Self> {
                 let reg_size = match id {
-                    0..=31 => (Self::Gpr(id as u8), USIZE),
-                    32 => (Self::Pc, USIZE),
-                    33..=64 => (Self::Fpr((id - 33) as u8), USIZE),
-                    65..=4160 => (Self::Csr((id - 65) as u16), USIZE),
-                    4161 => (Self::Priv, 1),
+                    0..=31 => Self::Gpr(id as u8),
+                    32 => Self::Pc,
+                    33..=64 => Self::Fpr((id - 33) as u8),
+                    65..=4160 => Self::Csr((id - 65) as u16),
+                    4161 => Self::Priv,
                     _ => return None,
                 };
                 Some(reg_size)

--- a/gdbstub_arch/src/riscv/reg/id.rs
+++ b/gdbstub_arch/src/riscv/reg/id.rs
@@ -22,13 +22,15 @@ pub enum RiscvRegId<U> {
 macro_rules! impl_riscv_reg_id {
     ($usize:ty) => {
         impl RegId for RiscvRegId<$usize> {
-            fn from_raw_id(id: usize) -> Option<Self> {
+            fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+                const USIZE: usize = core::mem::size_of::<$usize>();
+
                 let reg_size = match id {
-                    0..=31 => Self::Gpr(id as u8),
-                    32 => Self::Pc,
-                    33..=64 => Self::Fpr((id - 33) as u8),
-                    65..=4160 => Self::Csr((id - 65) as u16),
-                    4161 => Self::Priv,
+                    0..=31 => (Self::Gpr(id as u8), USIZE),
+                    32 => (Self::Pc, USIZE),
+                    33..=64 => (Self::Fpr((id - 33) as u8), USIZE),
+                    65..=4160 => (Self::Csr((id - 65) as u16), USIZE),
+                    4161 => (Self::Priv, 1),
                     _ => return None,
                 };
                 Some(reg_size)

--- a/gdbstub_arch/src/x86/reg/id.rs
+++ b/gdbstub_arch/src/x86/reg/id.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroUsize;
+
 use gdbstub::arch::RegId;
 
 /// FPU register identifier.
@@ -115,10 +117,10 @@ pub enum X86CoreRegId {
 }
 
 impl RegId for X86CoreRegId {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         use self::X86CoreRegId::*;
 
-        let r = match id {
+        let (r, sz): (X86CoreRegId, usize) = match id {
             0 => (Eax, 4),
             1 => (Ecx, 4),
             2 => (Edx, 4),
@@ -136,7 +138,8 @@ impl RegId for X86CoreRegId {
             40 => (Mxcsr, 4),
             _ => return None,
         };
-        Some(r)
+
+        Some((r, Some(NonZeroUsize::new(sz)?)))
     }
 }
 
@@ -167,10 +170,10 @@ pub enum X86_64CoreRegId {
 }
 
 impl RegId for X86_64CoreRegId {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         use self::X86_64CoreRegId::*;
 
-        let r = match id {
+        let (r, sz): (X86_64CoreRegId, usize) = match id {
             0..=15 => (Gpr(id as u8), 8),
             16 => (Rip, 8),
             17 => (Eflags, 4),
@@ -181,7 +184,8 @@ impl RegId for X86_64CoreRegId {
             56 => (Mxcsr, 4),
             _ => return None,
         };
-        Some(r)
+
+        Some((r, Some(NonZeroUsize::new(sz)?)))
     }
 }
 
@@ -208,7 +212,7 @@ mod tests {
         let mut i = 0;
         let mut sum_reg_sizes = 0;
         while let Some((_, size)) = RId::from_raw_id(i) {
-            sum_reg_sizes += size;
+            sum_reg_sizes += size.unwrap().get();
             i += 1;
         }
 

--- a/gdbstub_arch/src/x86/reg/id.rs
+++ b/gdbstub_arch/src/x86/reg/id.rs
@@ -115,25 +115,25 @@ pub enum X86CoreRegId {
 }
 
 impl RegId for X86CoreRegId {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<Self> {
         use self::X86CoreRegId::*;
 
         let r = match id {
-            0 => (Eax, 4),
-            1 => (Ecx, 4),
-            2 => (Edx, 4),
-            3 => (Ebx, 4),
-            4 => (Esp, 4),
-            5 => (Ebp, 4),
-            6 => (Esi, 4),
-            7 => (Edi, 4),
-            8 => (Eip, 4),
-            9 => (Eflags, 4),
-            10..=15 => (Segment(X86SegmentRegId::from_u8(id as u8 - 10)?), 4),
-            16..=23 => (St(id as u8 - 16), 10),
-            24..=31 => (Fpu(X87FpuInternalRegId::from_u8(id as u8 - 24)?), 4),
-            32..=39 => (Xmm(id as u8 - 32), 16),
-            40 => (Mxcsr, 4),
+            0 => Eax,
+            1 => Ecx,
+            2 => Edx,
+            3 => Ebx,
+            4 => Esp,
+            5 => Ebp,
+            6 => Esi,
+            7 => Edi,
+            8 => Eip,
+            9 => Eflags,
+            10..=15 => Segment(X86SegmentRegId::from_u8(id as u8 - 10)?),
+            16..=23 => St(id as u8 - 16),
+            24..=31 => Fpu(X87FpuInternalRegId::from_u8(id as u8 - 24)?),
+            32..=39 => Xmm(id as u8 - 32),
+            40 => Mxcsr,
             _ => return None,
         };
         Some(r)
@@ -167,61 +167,20 @@ pub enum X86_64CoreRegId {
 }
 
 impl RegId for X86_64CoreRegId {
-    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(id: usize) -> Option<Self> {
         use self::X86_64CoreRegId::*;
 
         let r = match id {
-            0..=15 => (Gpr(id as u8), 8),
-            16 => (Rip, 4),
-            17 => (Eflags, 8),
-            18..=23 => (Segment(X86SegmentRegId::from_u8(id as u8 - 18)?), 4),
-            24..=31 => (St(id as u8 - 24), 10),
-            32..=39 => (Fpu(X87FpuInternalRegId::from_u8(id as u8 - 32)?), 4),
-            40..=55 => (Xmm(id as u8 - 40), 16),
-            56 => (Mxcsr, 4),
+            0..=15 => Gpr(id as u8),
+            16 => Rip,
+            17 => Eflags,
+            18..=23 => Segment(X86SegmentRegId::from_u8(id as u8 - 18)?),
+            24..=31 => St(id as u8 - 24),
+            32..=39 => Fpu(X87FpuInternalRegId::from_u8(id as u8 - 32)?),
+            40..=55 => Xmm(id as u8 - 40),
+            56 => Mxcsr,
             _ => return None,
         };
         Some(r)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use gdbstub::arch::RegId;
-    use gdbstub::arch::Registers;
-
-    /// Compare the following two values which are expected to be the same:
-    /// * length of data written by `Registers::gdb_serialize()` in byte
-    /// * sum of sizes of all registers obtained by `RegId::from_raw_id()`
-    fn test<Rs: Registers, RId: RegId>() {
-        // Obtain the data length written by `gdb_serialize` by passing a custom
-        // closure.
-        let mut serialized_data_len = 0;
-        let counter = |b: Option<u8>| {
-            if b.is_some() {
-                serialized_data_len += 1;
-            }
-        };
-        Rs::default().gdb_serialize(counter);
-
-        // Accumulate register sizes returned by `from_raw_id`.
-        let mut i = 0;
-        let mut sum_reg_sizes = 0;
-        while let Some((_, size)) = RId::from_raw_id(i) {
-            sum_reg_sizes += size;
-            i += 1;
-        }
-
-        assert_eq!(serialized_data_len, sum_reg_sizes);
-    }
-
-    #[test]
-    fn test_x86() {
-        test::<crate::x86::reg::X86CoreRegs, crate::x86::reg::id::X86CoreRegId>()
-    }
-
-    #[test]
-    fn test_x86_64() {
-        test::<crate::x86::reg::X86_64CoreRegs, crate::x86::reg::id::X86_64CoreRegId>()
     }
 }

--- a/gdbstub_arch/src/x86/reg/id.rs
+++ b/gdbstub_arch/src/x86/reg/id.rs
@@ -115,25 +115,25 @@ pub enum X86CoreRegId {
 }
 
 impl RegId for X86CoreRegId {
-    fn from_raw_id(id: usize) -> Option<Self> {
+    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
         use self::X86CoreRegId::*;
 
         let r = match id {
-            0 => Eax,
-            1 => Ecx,
-            2 => Edx,
-            3 => Ebx,
-            4 => Esp,
-            5 => Ebp,
-            6 => Esi,
-            7 => Edi,
-            8 => Eip,
-            9 => Eflags,
-            10..=15 => Segment(X86SegmentRegId::from_u8(id as u8 - 10)?),
-            16..=23 => St(id as u8 - 16),
-            24..=31 => Fpu(X87FpuInternalRegId::from_u8(id as u8 - 24)?),
-            32..=39 => Xmm(id as u8 - 32),
-            40 => Mxcsr,
+            0 => (Eax, 4),
+            1 => (Ecx, 4),
+            2 => (Edx, 4),
+            3 => (Ebx, 4),
+            4 => (Esp, 4),
+            5 => (Ebp, 4),
+            6 => (Esi, 4),
+            7 => (Edi, 4),
+            8 => (Eip, 4),
+            9 => (Eflags, 4),
+            10..=15 => (Segment(X86SegmentRegId::from_u8(id as u8 - 10)?), 4),
+            16..=23 => (St(id as u8 - 16), 10),
+            24..=31 => (Fpu(X87FpuInternalRegId::from_u8(id as u8 - 24)?), 4),
+            32..=39 => (Xmm(id as u8 - 32), 16),
+            40 => (Mxcsr, 4),
             _ => return None,
         };
         Some(r)
@@ -167,20 +167,61 @@ pub enum X86_64CoreRegId {
 }
 
 impl RegId for X86_64CoreRegId {
-    fn from_raw_id(id: usize) -> Option<Self> {
+    fn from_raw_id(id: usize) -> Option<(Self, usize)> {
         use self::X86_64CoreRegId::*;
 
         let r = match id {
-            0..=15 => Gpr(id as u8),
-            16 => Rip,
-            17 => Eflags,
-            18..=23 => Segment(X86SegmentRegId::from_u8(id as u8 - 18)?),
-            24..=31 => St(id as u8 - 24),
-            32..=39 => Fpu(X87FpuInternalRegId::from_u8(id as u8 - 32)?),
-            40..=55 => Xmm(id as u8 - 40),
-            56 => Mxcsr,
+            0..=15 => (Gpr(id as u8), 8),
+            16 => (Rip, 8),
+            17 => (Eflags, 4),
+            18..=23 => (Segment(X86SegmentRegId::from_u8(id as u8 - 18)?), 4),
+            24..=31 => (St(id as u8 - 24), 10),
+            32..=39 => (Fpu(X87FpuInternalRegId::from_u8(id as u8 - 32)?), 4),
+            40..=55 => (Xmm(id as u8 - 40), 16),
+            56 => (Mxcsr, 4),
             _ => return None,
         };
         Some(r)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gdbstub::arch::RegId;
+    use gdbstub::arch::Registers;
+
+    /// Compare the following two values which are expected to be the same:
+    /// * length of data written by `Registers::gdb_serialize()` in byte
+    /// * sum of sizes of all registers obtained by `RegId::from_raw_id()`
+    fn test<Rs: Registers, RId: RegId>() {
+        // Obtain the data length written by `gdb_serialize` by passing a custom
+        // closure.
+        let mut serialized_data_len = 0;
+        let counter = |b: Option<u8>| {
+            if b.is_some() {
+                serialized_data_len += 1;
+            }
+        };
+        Rs::default().gdb_serialize(counter);
+
+        // Accumulate register sizes returned by `from_raw_id`.
+        let mut i = 0;
+        let mut sum_reg_sizes = 0;
+        while let Some((_, size)) = RId::from_raw_id(i) {
+            sum_reg_sizes += size;
+            i += 1;
+        }
+
+        assert_eq!(serialized_data_len, sum_reg_sizes);
+    }
+
+    #[test]
+    fn test_x86() {
+        test::<crate::x86::reg::X86CoreRegs, crate::x86::reg::id::X86CoreRegId>()
+    }
+
+    #[test]
+    fn test_x86_64() {
+        test::<crate::x86::reg::X86_64CoreRegs, crate::x86::reg::id::X86_64CoreRegId>()
     }
 }

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -15,7 +15,7 @@
 //! > Having community-created `Arch` implementations distributed in a separate
 //! crate helps minimize any unnecessary "version churn" in `gdbstub` core.
 
-use core::fmt::Debug;
+use core::{fmt::Debug, num::NonZeroUsize};
 
 use num_traits::{FromPrimitive, PrimInt, Unsigned};
 
@@ -28,15 +28,20 @@ use crate::internal::{BeBytes, LeBytes};
 ///
 /// [single register accesses]: crate::target::ext::base::SingleRegisterAccess
 pub trait RegId: Sized + Debug {
-    /// Map raw GDB register number corresponding `RegId` and register size.
+    /// Map raw GDB register number to a corresponding `RegId` and optional
+    /// register size.
+    ///
+    /// If the register size is specified here, gdbstub will include a runtime
+    /// check that ensures target implementations do not send back more
+    /// bytes than the register allows.
     ///
     /// Returns `None` if the register is not available.
-    fn from_raw_id(id: usize) -> Option<(Self, usize)>;
+    fn from_raw_id(id: usize) -> Option<(Self, Option<NonZeroUsize>)>;
 }
 
 /// Stub implementation -- Returns `None` for all raw IDs.
 impl RegId for () {
-    fn from_raw_id(_id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(_id: usize) -> Option<(Self, Option<NonZeroUsize>)> {
         None
     }
 }

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -28,15 +28,15 @@ use crate::internal::{BeBytes, LeBytes};
 ///
 /// [single register accesses]: crate::target::ext::base::SingleRegisterAccess
 pub trait RegId: Sized + Debug {
-    /// Map raw GDB register number corresponding `RegId`.
+    /// Map raw GDB register number corresponding `RegId` and register size.
     ///
     /// Returns `None` if the register is not available.
-    fn from_raw_id(id: usize) -> Option<Self>;
+    fn from_raw_id(id: usize) -> Option<(Self, usize)>;
 }
 
 /// Stub implementation -- Returns `None` for all raw IDs.
 impl RegId for () {
-    fn from_raw_id(_id: usize) -> Option<Self> {
+    fn from_raw_id(_id: usize) -> Option<(Self, usize)> {
         None
     }
 }

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -15,7 +15,8 @@
 //! > Having community-created `Arch` implementations distributed in a separate
 //! crate helps minimize any unnecessary "version churn" in `gdbstub` core.
 
-use core::{fmt::Debug, num::NonZeroUsize};
+use core::fmt::Debug;
+use core::num::NonZeroUsize;
 
 use num_traits::{FromPrimitive, PrimInt, Unsigned};
 

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -28,15 +28,15 @@ use crate::internal::{BeBytes, LeBytes};
 ///
 /// [single register accesses]: crate::target::ext::base::SingleRegisterAccess
 pub trait RegId: Sized + Debug {
-    /// Map raw GDB register number corresponding `RegId` and register size.
+    /// Map raw GDB register number corresponding `RegId`.
     ///
     /// Returns `None` if the register is not available.
-    fn from_raw_id(id: usize) -> Option<(Self, usize)>;
+    fn from_raw_id(id: usize) -> Option<Self>;
 }
 
 /// Stub implementation -- Returns `None` for all raw IDs.
 impl RegId for () {
-    fn from_raw_id(_id: usize) -> Option<(Self, usize)> {
+    fn from_raw_id(_id: usize) -> Option<Self> {
         None
     }
 }

--- a/src/gdbstub_impl/ext/single_register_access.rs
+++ b/src/gdbstub_impl/ext/single_register_access.rs
@@ -21,7 +21,9 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 };
                 let mut buf = p.buf;
                 if let Some(size) = reg_size {
-                    buf = &mut buf[0..size.get()];
+                    buf = buf
+                        .get_mut(..size.get())
+                        .ok_or(Error::PacketBufferOverflow)?;
                 }
 
                 let len = ops.read_register(id, reg_id, buf).handle_error()?;
@@ -31,7 +33,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                         return Err(Error::TargetMismatch);
                     }
                 } else {
-                    buf = &mut buf[0..len];
+                    buf = buf.get_mut(..len).ok_or(Error::PacketBufferOverflow)?;
                 }
                 res.write_hex_buf(buf)?;
                 HandlerStatus::Handled

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -188,7 +188,7 @@ commands! {
     }
 
     single_register_access use 'a {
-        "p" => _p::p,
+        "p" => _p::p<'a>,
         "P" => _p_upcase::P<'a>,
     }
 

--- a/src/protocol/commands/_p.rs
+++ b/src/protocol/commands/_p.rs
@@ -1,13 +1,23 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct p {
+pub struct p<'a> {
     pub reg_id: usize,
+
+    pub buf: &'a mut [u8],
 }
 
-impl<'a> ParseCommand<'a> for p {
+impl<'a> ParseCommand<'a> for p<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
-        let reg_id = decode_hex(buf.into_body()).ok()?;
-        Some(p { reg_id })
+        let (buf, body_range) = buf.into_raw_buf();
+        let body = buf.get(body_range.start..body_range.end)?;
+
+        if body.is_empty() {
+            return None;
+        }
+
+        let reg_id = decode_hex(body).ok()?;
+
+        Some(p { reg_id, buf })
     }
 }

--- a/src/target/ext/base/single_register_access.rs
+++ b/src/target/ext/base/single_register_access.rs
@@ -22,16 +22,18 @@ pub trait SingleRegisterAccess<Id>: Target {
     /// On single threaded targets, `tid` is set to `()` and can be ignored.
     ///
     /// Implementations should write the value of the register using target's
-    /// native byte order in the buffer `dst`.
+    /// native byte order in the buffer `buf`.
     ///
     /// If the requested register could not be accessed, an appropriate
     /// non-fatal error should be returned.
+    ///
+    /// Return the number of bytes written into `buf`.
     fn read_register(
         &mut self,
         tid: Id,
         reg_id: <Self::Arch as Arch>::RegId,
-        dst: &mut [u8],
-    ) -> TargetResult<(), Self>;
+        buf: &mut [u8],
+    ) -> TargetResult<usize, Self>;
 
     /// Write from a single register on the target.
     ///

--- a/src/target/ext/base/single_register_access.rs
+++ b/src/target/ext/base/single_register_access.rs
@@ -24,10 +24,10 @@ pub trait SingleRegisterAccess<Id>: Target {
     /// Implementations should write the value of the register using target's
     /// native byte order in the buffer `buf`.
     ///
+    /// Return the number of bytes written into `buf`.
+    ///
     /// If the requested register could not be accessed, an appropriate
     /// non-fatal error should be returned.
-    ///
-    /// Return the number of bytes written into `buf`.
     fn read_register(
         &mut self,
         tid: Id,


### PR DESCRIPTION
### Description

<!-- Please include a brief description of what is being added/changed -->

New approach to #58.

Part of #70.

Closes #58. Closes #80.

### API Stability

- [ ] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
- Documentation
  - [x] rustdoc + approprate inline code comments
  - [ ] Updated CHANGELOG.md
  - [ ] (if appropriate) Added feature to "Debugging Features" in README.md
- _If implementing a new protocol extension IDET_
  - [ ] Included a basic sample implementation in `examples/armv4t`
  - [ ] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [ ] Confirmed that IDET can be optimized away (using `./scripts/test_dead_code_elim.sh` and/or `./example_no_std/check_size.sh`)
  - [ ] **OR** Implementation requires adding non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [ ] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- If you are implementing `gdbstub` in an open-source project, consider updating the README.md's "Real World Examples" section to link back to your project! -->