### PR TITLE
Support read auxv

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Of course, most use-cases will want to support additional debugging features as 
 -   Get target memory map
 -   Perform Host I/O operations
 -   Get target exec file
+-   Get target auxiliary vector
 
 _Note:_ GDB features are implemented on an as-needed basis by `gdbstub`'s contributors. If there's a missing GDB feature that you'd like `gdbstub` to implement, please file an issue and/or open a PR!
 

--- a/examples/armv4t/gdb/auxv.rs
+++ b/examples/armv4t/gdb/auxv.rs
@@ -1,0 +1,12 @@
+use gdbstub::target;
+use gdbstub::target::TargetResult;
+
+use super::copy_range_to_buf;
+use crate::emu::Emu;
+
+impl target::ext::auxv::Auxv for Emu {
+    fn get_auxv(&self, offset: u64, length: usize, buf: &mut [u8]) -> TargetResult<usize, Self> {
+        let auxv = b"\x00\x00\x00\x00\x00\x00\x00\x00";
+        Ok(copy_range_to_buf(auxv, offset, length, buf))
+    }
+}

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -14,6 +14,7 @@ use crate::emu::{Emu, Event};
 
 // Additional GDB extensions
 
+mod auxv;
 mod breakpoints;
 mod catch_syscalls;
 mod exec_file;
@@ -120,6 +121,11 @@ impl Target for Emu {
 
     #[inline(always)]
     fn exec_file(&mut self) -> Option<target::ext::exec_file::ExecFileOps<Self>> {
+        Some(self)
+    }
+
+    #[inline(always)]
+    fn auxv(&mut self) -> Option<target::ext::auxv::AuxvOps<Self>> {
         Some(self)
     }
 }

--- a/src/gdbstub_impl/ext/auxv.rs
+++ b/src/gdbstub_impl/ext/auxv.rs
@@ -1,0 +1,36 @@
+use super::prelude::*;
+use crate::protocol::commands::ext::Auxv;
+
+impl<T: Target, C: Connection> GdbStubImpl<T, C> {
+    pub(crate) fn handle_auxv(
+        &mut self,
+        res: &mut ResponseWriter<C>,
+        target: &mut T,
+        command: Auxv,
+    ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
+        let ops = match target.auxv() {
+            Some(ops) => ops,
+            None => return Ok(HandlerStatus::Handled),
+        };
+
+        crate::__dead_code_marker!("auxv", "impl");
+
+        let handler_status = match command {
+            Auxv::qXferAuxvRead(cmd) => {
+                let ret = ops
+                    .get_auxv(cmd.offset, cmd.length, cmd.buf)
+                    .handle_error()?;
+                if ret == 0 {
+                    res.write_str("l")?;
+                } else {
+                    res.write_str("m")?;
+                    // TODO: add more specific error variant?
+                    res.write_binary(cmd.buf.get(..ret).ok_or(Error::PacketBufferOverflow)?)?;
+                }
+                HandlerStatus::Handled
+            }
+        };
+
+        Ok(handler_status)
+    }
+}

--- a/src/gdbstub_impl/ext/base.rs
+++ b/src/gdbstub_impl/ext/base.rs
@@ -119,6 +119,10 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     res.write_str(";qXfer:exec-file:read+")?;
                 }
 
+                if target.auxv().is_some() {
+                    res.write_str(";qXfer:auxv:read+")?;
+                }
+
                 HandlerStatus::Handled
             }
             Base::QStartNoAckMode(_) => {

--- a/src/gdbstub_impl/ext/mod.rs
+++ b/src/gdbstub_impl/ext/mod.rs
@@ -11,6 +11,7 @@ mod prelude {
     pub(super) use super::super::{DisconnectReason, GdbStubImpl, HandlerStatus};
 }
 
+mod auxv;
 mod base;
 mod breakpoints;
 mod catch_syscalls;

--- a/src/gdbstub_impl/mod.rs
+++ b/src/gdbstub_impl/mod.rs
@@ -579,6 +579,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Command::MemoryMap(cmd) => self.handle_memory_map(res, target, cmd),
             Command::HostIo(cmd) => self.handle_host_io(res, target, cmd),
             Command::ExecFile(cmd) => self.handle_exec_file(res, target, cmd),
+            Command::Auxv(cmd) => self.handle_auxv(res, target, cmd),
         }
     }
 }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -225,6 +225,10 @@ commands! {
         "qXfer:memory-map:read" => _qXfer_memory_map::qXferMemoryMapRead<'a>,
     }
 
+    auxv use 'a {
+        "qXfer:auxv:read" => _qXfer_auxv_read::qXferAuxvRead<'a>,
+    }
+
     exec_file use 'a {
         "qXfer:exec-file:read" => _qXfer_exec_file::qXferExecFileRead<'a>,
     }

--- a/src/protocol/commands/_qXfer_auxv_read.rs
+++ b/src/protocol/commands/_qXfer_auxv_read.rs
@@ -1,0 +1,34 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct qXferAuxvRead<'a> {
+    pub offset: u64,
+    pub length: usize,
+
+    pub buf: &'a mut [u8],
+}
+
+impl<'a> ParseCommand<'a> for qXferAuxvRead<'a> {
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let (buf, body_range) = buf.into_raw_buf();
+        let body = buf.get_mut(body_range.start..body_range.end)?;
+
+        if body.is_empty() {
+            return None;
+        }
+
+        let mut body = body.split(|b| *b == b':').skip(1);
+        let annex = body.next()?;
+        if annex != b"" {
+            return None;
+        }
+
+        let mut body = body.next()?.split(|b| *b == b',');
+        let offset = decode_hex(body.next()?).ok()?;
+        let length = decode_hex(body.next()?).ok()?;
+
+        drop(body);
+
+        Some(qXferAuxvRead { offset, length, buf })
+    }
+}

--- a/src/protocol/commands/_qXfer_exec_file.rs
+++ b/src/protocol/commands/_qXfer_exec_file.rs
@@ -32,6 +32,6 @@ impl<'a> ParseCommand<'a> for qXferExecFileRead<'a> {
 
         drop(body);
 
-        Some(qXferExecFileRead {pid, offset, length, buf})
+        Some(qXferExecFileRead { pid, offset, length, buf })
     }
 }

--- a/src/protocol/commands/_vFile_close.rs
+++ b/src/protocol/commands/_vFile_close.rs
@@ -15,7 +15,7 @@ impl<'a> ParseCommand<'a> for vFileClose {
         match body {
             [b':', body @ ..] => {
                 let fd = decode_hex(body).ok()?;
-                Some(vFileClose{fd})
+                Some(vFileClose { fd })
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_fstat.rs
+++ b/src/protocol/commands/_vFile_fstat.rs
@@ -15,7 +15,7 @@ impl<'a> ParseCommand<'a> for vFileFstat {
         match body {
             [b':', body @ ..] => {
                 let fd = decode_hex(body).ok()?;
-                Some(vFileFstat{fd})
+                Some(vFileFstat { fd })
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_open.rs
+++ b/src/protocol/commands/_vFile_open.rs
@@ -22,7 +22,7 @@ impl<'a> ParseCommand<'a> for vFileOpen<'a> {
                 let filename = decode_hex_buf(body.next()?).ok()?;
                 let flags = HostIoOpenFlags::from_bits(decode_hex(body.next()?).ok()?)?;
                 let mode = HostIoOpenMode::from_bits(decode_hex(body.next()?).ok()?)?;
-                Some(vFileOpen{filename, flags, mode})
+                Some(vFileOpen { filename, flags, mode })
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_pread.rs
+++ b/src/protocol/commands/_vFile_pread.rs
@@ -27,7 +27,7 @@ impl<'a> ParseCommand<'a> for vFilePread<'a> {
 
                 drop(body);
 
-                Some(vFilePread{fd, count, offset, buf})
+                Some(vFilePread { fd, count, offset, buf })
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_pwrite.rs
+++ b/src/protocol/commands/_vFile_pwrite.rs
@@ -20,7 +20,7 @@ impl<'a> ParseCommand<'a> for vFilePwrite<'a> {
                 let fd = decode_hex(body.next()?).ok()?;
                 let offset = decode_hex_buf(body.next()?).ok()?;
                 let data = decode_bin_buf(body.next()?).ok()?;
-                Some(vFilePwrite{fd, offset, data})
+                Some(vFilePwrite { fd, offset, data })
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_readlink.rs
+++ b/src/protocol/commands/_vFile_readlink.rs
@@ -20,7 +20,7 @@ impl<'a> ParseCommand<'a> for vFileReadlink<'a> {
         match body {
             [b':', body @ ..] => {
                 let filename = decode_hex_buf(body).ok()?;
-                Some(vFileReadlink{filename, buf})
+                Some(vFileReadlink { filename, buf })
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_setfs.rs
+++ b/src/protocol/commands/_vFile_setfs.rs
@@ -20,7 +20,7 @@ impl<'a> ParseCommand<'a> for vFileSetfs {
                     None => FsKind::Stub,
                     Some(pid) => FsKind::Pid(pid),
                 };
-                Some(vFileSetfs{fs})
+                Some(vFileSetfs { fs })
             },
             _ => None,
         }

--- a/src/protocol/commands/_vFile_unlink.rs
+++ b/src/protocol/commands/_vFile_unlink.rs
@@ -15,7 +15,7 @@ impl<'a> ParseCommand<'a> for vFileUnlink<'a> {
         match body {
             [b':', body @ ..] => {
                 let filename = decode_hex_buf(body).ok()?;
-                Some(vFileUnlink{filename})
+                Some(vFileUnlink { filename })
             },
             _ => None,
         }

--- a/src/target/ext/auxv.rs
+++ b/src/target/ext/auxv.rs
@@ -1,0 +1,16 @@
+//! Access the target’s auxiliary vector.
+use crate::target::{Target, TargetResult};
+
+/// Target Extension - Access the target’s auxiliary vector.
+pub trait Auxv: Target {
+    /// Get auxiliary vector from the target.
+    ///
+    /// Return the number of bytes written into `buf` (which may be less than
+    /// `length`).
+    ///
+    /// If `offset` is greater than the length of the underlying data, return
+    /// `Ok(0)`.
+    fn get_auxv(&self, offset: u64, length: usize, buf: &mut [u8]) -> TargetResult<usize, Self>;
+}
+
+define_ext!(AuxvOps, Auxv);

--- a/src/target/ext/memory_map.rs
+++ b/src/target/ext/memory_map.rs
@@ -3,11 +3,17 @@ use crate::target::{Target, TargetResult};
 
 /// Target Extension - Provide a target memory map.
 pub trait MemoryMap: Target {
-    /// Return the target memory map XML file.
+    /// Get memory map XML file from the target.
     ///
     /// See the [GDB Documentation] for a description of the format.
     ///
     /// [GDB Documentation]: https://sourceware.org/gdb/onlinedocs/gdb/Memory-Map-Format.html
+    ///
+    /// Return the number of bytes written into `buf` (which may be less than
+    /// `length`).
+    ///
+    /// If `offset` is greater than the length of the underlying data, return
+    /// `Ok(0)`.
     fn memory_map_xml(
         &self,
         offset: u64,

--- a/src/target/ext/mod.rs
+++ b/src/target/ext/mod.rs
@@ -256,6 +256,7 @@ macro_rules! define_ext {
     };
 }
 
+pub mod auxv;
 pub mod base;
 pub mod breakpoints;
 pub mod catch_syscalls;

--- a/src/target/ext/target_description_xml_override.rs
+++ b/src/target/ext/target_description_xml_override.rs
@@ -13,6 +13,12 @@ pub trait TargetDescriptionXmlOverride: Target {
     /// Refer to the
     /// [target_description_xml](crate::arch::Arch::target_description_xml)
     /// docs for more info.
+    ///
+    /// Return the number of bytes written into `buf` (which may be less than
+    /// `length`).
+    ///
+    /// If `offset` is greater than the length of the underlying data, return
+    /// `Ok(0)`.
     fn target_description_xml(
         &self,
         offset: u64,

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -369,6 +369,11 @@ pub trait Target {
     fn exec_file(&mut self) -> Option<ext::exec_file::ExecFileOps<Self>> {
         None
     }
+
+    /// Provide auxv
+    fn auxv(&mut self) -> Option<ext::auxv::AuxvOps<Self>> {
+        None
+    }
 }
 
 macro_rules! impl_dyn_target {
@@ -418,6 +423,11 @@ macro_rules! impl_dyn_target {
             #[inline(always)]
             fn memory_map(&mut self) -> Option<ext::memory_map::MemoryMapOps<Self>> {
                 (**self).memory_map()
+            }
+
+            #[inline(always)]
+            fn auxv(&mut self) -> Option<ext::auxv::AuxvOps<Self>> {
+                (**self).auxv()
             }
 
             #[inline(always)]


### PR DESCRIPTION
### Description

<!-- Please include a brief description of what is being added/changed -->

This PR implements the `qXfer:auxv:read` extension, based off the GDB documentation [here](https://sourceware.org/gdb/current/onlinedocs/gdb/General-Query-Packets.html#qXfer-auxiliary-vector-read).

### API Stability

- [x] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
- Documentation
  - [x] rustdoc + approprate inline code comments
  - [ ] Updated CHANGELOG.md
  - [x] (if appropriate) Added feature to "Debugging Features" in README.md
- _If implementing a new protocol extension IDET_
  - [x] Included a basic sample implementation in `examples/armv4t`
  - [x] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [x] Confirmed that IDET can be optimized away (using `./scripts/test_dead_code_elim.sh` and/or `./example_no_std/check_size.sh`)
  - [ ] **OR** Implementation requires adding non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [ ] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- If you are implementing `gdbstub` in an open-source project, consider updating the README.md's "Real World Examples" section to link back to your project! -->

### Validation

<!-- example output, from https://github.com/daniel5151/gdbstub/pull/54 -->

<details>
<summary>GDB output</summary>

```
(gdb) info auxv
0    AT_NULL              End of vector                  0x0
```

</details>

<details>
<summary>armv4t output</summary>

```
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/examples/armv4t`
loading section ".text" into memory from [0x55550000..0x55550078]
Setting PC to 0x55550000
Waiting for a GDB connection on "127.0.0.1:9001"...
Debugger connected from 127.0.0.1:48672
 TRACE gdbstub::protocol::recv_packet > <-- +
 TRACE gdbstub::protocol::recv_packet > <-- $qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;no-resumed+;xmlRegisters=i386#6a
 TRACE gdbstub::protocol::response_writer > --> $PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;ReverseContinue+;ReverseStep+;QDisableRandomization+;QEnvironmentHexEncoded+;QEnvironmentUnset+;QEnvironmentReset+;QStartupWithShell+;QSetWorkingDir+;swbreak+;hwbreak+;QCatchSyscalls+;qXfer:features:read+;qXfer:memory-map:read+;qXfer:exec-file:read+;qXfer:auxv:read+#fa
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $vMustReplyEmpty#3a
 INFO  gdbstub::gdbstub_impl              > Unknown command: Ok("vMustReplyEmpty")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $QStartNoAckMode#b0
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $Hgp0.0#ad
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:0,ffb#79
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<target version="1.0">
    <architecture>armv4t</architecture>
    <feature name="org.gnu.gdb.arm.core">
        <vector id="padding" type="uint32" count="25"/>

        <reg name="r0" bitsize="32" type="uint32"/>
        <reg name="r1" bitsize="32" type="uint32"/>
        <reg name="r2" bitsize="32" type="uint32"/>
        <reg name="r3" bitsize="32" type="uint32"/>
        <reg name="r4" bitsize="32" type="uint32"/>
        <reg name="r5" bitsize="32" type="uint32"/>
        <reg name="r6" bitsize="32" type="uint32"/>
        <reg name="r7" bitsize="32" type="uint32"/>
        <reg name="r8" bitsize="32" type="uint32"/>
        <reg name="r9" bitsize="32" type="uint32"/>
        <reg name="r10" bitsize="32" type="uint32"/>
        <reg name="r11" bitsize="32" type="uint32"/>
        <reg name="r12" bitsize="32" type="uint32"/>
        <reg name="sp" bitsize="32" type="data_ptr"/>
        <reg name="lr" bitsize="32"/>
        <reg name="pc" bitsize="32" type="code_ptr"/>

        <!--
            For some reason, my version of `gdb-multiarch` doesn't seem to
            respect "regnum", and will not parse this custom target.xml unless I
            manually include the padding bytes in the target description.

            On the bright side, AFAIK, there aren't all that many architectures
            that use padding bytes. Heck, the only reason armv4t uses padding is
            for historical reasons (see comment below).

            Odds are if you're defining your own custom arch, you won't run into
            this issue, since you can just lay out all the registers in the
            correct order.
        -->
        <reg name="padding" type="padding" bitsize="32"/>

        <!-- The CPSR is register 25, rather than register 16, because
        the FPA registers historically were placed between the PC
        and the CPSR in the "g" packet. -->
        <reg name="cpsr" bitsize="32" regnum="25"/>
    </feature>
    <feature name="custom-armv4t-extension">
        <!--
            maps to a simple scratch register within the emulator. the GDB
            client can read the register using `p }custom` and set it using
            `set }custom=1337`
        -->
        <reg name="custom" bitsize="32" type="uint32"/>

        <!--
            pseudo-register that return the current time when read.

            notably, i've set up the target to NOT send this register as part of
            the regular register list, which means that GDB will fetch/update
            this register via the 'p' and 'P' packets respectively
        -->
        <reg name="time" bitsize="32" type="uint32"/>
    </feature>
</target>#0f
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:aa4,ffb#3f
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::0,ffb#d8
 TRACE gdbstub::protocol::response_writer > --> $m#bb
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::8,ffb#e0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 INFO  gdbstub::gdbstub_impl              > Unknown command: Ok("qTStatus")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $?#3f
 TRACE gdbstub::protocol::response_writer > --> $S05#b8
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qAttached:1#fa
GDB queried if it was attached to a process with PID 1
 TRACE gdbstub::protocol::response_writer > --> $1#31
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:0,ffb#b7
 TRACE gdbstub::protocol::response_writer > --> $m/test.elf#c1
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:9,ffb#c0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:setfs:0#bf
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:6a7573742070726f62696e67,0,1c0#ed
 TRACE gdbstub::protocol::response_writer > --> $F-1,02#32
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:setfs:1#c0
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746573742e656c66,0,0#1e
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox o�ty    o�l4UU0i        o�pint%
                                                                                                   ?:
                                                                                                     ;
                                                                                                      9
                                                                                                       I@▒�B:
                                                                                                             ;
                                                                                                              9
                                                                                                               I▒
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4   ▒▒
                                                                                 ����|
UUxB�B
B�UUxU  
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox o�ty    o�l4UU0i        o�pint%
                                                                                                   ?:
                                                                                                     ;
                                                                                                      9
                                                                                                       I@▒�B:
                                                                                                             ;
                                                                                                              9
                                                                                                               I▒
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4   ▒▒
                                                                                 ����|
UUxB�B
B�UUxU  
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox o�ty    o�l4UU0i        o�pint%
                                                                                                   ?:
                                                                                                     ;
                                                                                                      9
                                                                                                       I@▒�B:
                                                                                                             ;
                                                                                                              9
                                                                                                               I▒
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4   ▒▒
                                                                                 ����|
UUxB�B
B�UUxU  
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox o�ty    o�l4UU0i        o�pint%
                                                                                                   ?:
                                                                                                     ;
                                                                                                      9
                                                                                                       I@▒�B:
                                                                                                             ;
                                                                                                              9
                                                                                                               I▒
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4   ▒▒
                                                                                 ����|
UUxB�B
B�UUxU  
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,102fc#1b
 TRACE gdbstub::protocol::response_writer > --> $F0474;UUxU  
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#31
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746573742e656c66,0,0#1e
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox o�ty    o�l4UU0i        o�pint%
                                                                                                   ?:
                                                                                                     ;
                                                                                                      9
                                                                                                       I@▒�B:
                                                                                                             ;
                                                                                                              9
                                                                                                               I▒
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4   ▒▒
                                                                                 ����|
UUxB�B
B�UUxU  
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox o�ty    o�l4UU0i        o�pint%
                                                                                                   ?:
                                                                                                     ;
                                                                                                      9
                                                                                                       I@▒�B:
                                                                                                             ;
                                                                                                              9
                                                                                                               I▒
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4   ▒▒
                                                                                 ����|
UUxB�B
B�UUxU  
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox o�ty    o�l4UU0i        o�pint%
                                                                                                   ?:
                                                                                                     ;
                                                                                                      9
                                                                                                       I@▒�B:
                                                                                                             ;
                                                                                                              9
                                                                                                               I▒
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4   ▒▒
                                                                                 ����|
UUxB�B
B�UUxU  
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox o�ty    o�l4UU0i        o�pint%
                                                                                                   ?:
                                                                                                     ;
                                                                                                      9
                                                                                                       I@▒�B:
                                                                                                             ;
                                                                                                              9
                                                                                                               I▒
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4   ▒▒
                                                                                 ����|
UUxB�B
B�UUxU  
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,102fc#1b
 TRACE gdbstub::protocol::response_writer > --> $F0474;UUxU  
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#31
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox o�ty    o�l4UU0i        o�pint%
                                                                                                   ?:
                                                                                                     ;
                                                                                                      9
                                                                                                       I@▒�B:
                                                                                                             ;
                                                                                                              9
                                                                                                               I▒
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4   ▒▒
                                                                                 ����|
UUxB�B
B�UUxU  
�UU
   xUU▒xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $qSymbol::#5b
 INFO  gdbstub::gdbstub_impl              > Unknown command: Ok("qSymbol::")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:0,ffb#b7
 TRACE gdbstub::protocol::response_writer > --> $m/test.elf#c1
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:9,ffb#c0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $Hc-1#09
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qC#b4
 INFO  gdbstub::gdbstub_impl              > Unknown command: Ok("qC")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qOffsets#4b
 TRACE gdbstub::protocol::response_writer > --> $Text=00;Data=00;Bss=00#94
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000107856341200005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1000000078563412#0a
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::0,ffb#d8
 TRACE gdbstub::protocol::response_writer > --> $m#bb
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::8,ffb#e0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::0,ffb#18
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE memory-map
    PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN"
            "http://sourceware.org/gdb/gdb-memory-map.dtd">
<memory-map>
    <memory type="ram" start="0x0" length="0x100000000"/>
</memory-map>#76
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::f4,ffb#82
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffe,2#35
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,2#33
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffe,2#35
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,2#33
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26

```
</details>
