### PR TITLE
Make single-stepping optional (removing ResumeAction)

### DIFF
--- a/example_no_std/src/gdb.rs
+++ b/example_no_std/src/gdb.rs
@@ -1,6 +1,6 @@
 use gdbstub::common::Tid;
 use gdbstub::target;
-use gdbstub::target::ext::base::multithread::{MultiThreadOps, ResumeAction};
+use gdbstub::target::ext::base::multithread::MultiThreadOps;
 use gdbstub::target::{Target, TargetResult};
 
 use crate::print_str::print_str;
@@ -52,8 +52,12 @@ impl MultiThreadOps for DummyTarget {
     }
 
     #[inline(never)]
-    fn set_resume_action(&mut self, _tid: Tid, _action: ResumeAction) -> Result<(), Self::Error> {
-        print_str("> set_resume_action");
+    fn set_resume_action_continue(
+        &mut self,
+        _tid: Tid,
+        _signal: Option<u8>,
+    ) -> Result<(), Self::Error> {
+        print_str("> set_resume_action_continue");
         Ok(())
     }
 

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -2,9 +2,7 @@ use core::convert::{TryFrom, TryInto};
 
 use armv4t_emu::{reg, Memory};
 use gdbstub::target;
-use gdbstub::target::ext::base::singlethread::{
-    ResumeAction, SingleThreadOps, SingleThreadReverseContOps, SingleThreadReverseStepOps,
-};
+use gdbstub::target::ext::base::singlethread::SingleThreadOps;
 use gdbstub::target::{Target, TargetError, TargetResult};
 use gdbstub_arch::arm::reg::id::ArmCoreRegId;
 
@@ -136,7 +134,7 @@ impl Target for Emu {
 }
 
 impl SingleThreadOps for Emu {
-    fn resume(&mut self, action: ResumeAction) -> Result<(), Self::Error> {
+    fn resume(&mut self, signal: Option<u8>) -> Result<(), Self::Error> {
         // Upon returning from the `resume` method, the target being debugged should be
         // configured to run according to whatever resume actions the GDB client has
         // specified (as specified by `set_resume_action`, `resume_range_step`,
@@ -150,11 +148,11 @@ impl SingleThreadOps for Emu {
         // external "orchestration" to set it's execution mode (e.g: modifying the
         // target's process state via platform specific debugging syscalls).
 
-        self.exec_mode = match action {
-            ResumeAction::Continue => ExecMode::Continue,
-            ResumeAction::Step => ExecMode::Step,
-            _ => return Err("cannot resume with signal"),
-        };
+        if signal.is_some() {
+            return Err("no support for continuing with signal");
+        }
+
+        self.exec_mode = ExecMode::Continue;
 
         Ok(())
     }
@@ -216,20 +214,43 @@ impl SingleThreadOps for Emu {
     }
 
     #[inline(always)]
-    fn support_reverse_cont(&mut self) -> Option<SingleThreadReverseContOps<Self>> {
+    fn support_reverse_cont(
+        &mut self,
+    ) -> Option<target::ext::base::singlethread::SingleThreadReverseContOps<Self>> {
         Some(self)
     }
 
     #[inline(always)]
-    fn support_reverse_step(&mut self) -> Option<SingleThreadReverseStepOps<Self>> {
+    fn support_reverse_step(
+        &mut self,
+    ) -> Option<target::ext::base::singlethread::SingleThreadReverseStepOps<Self>> {
         Some(self)
     }
 
     #[inline(always)]
-    fn support_resume_range_step(
+    fn support_single_step(
+        &mut self,
+    ) -> Option<target::ext::base::singlethread::SingleThreadSingleStepOps<Self>> {
+        Some(self)
+    }
+
+    #[inline(always)]
+    fn support_range_step(
         &mut self,
     ) -> Option<target::ext::base::singlethread::SingleThreadRangeSteppingOps<Self>> {
         Some(self)
+    }
+}
+
+impl target::ext::base::singlethread::SingleThreadSingleStep for Emu {
+    fn step(&mut self, signal: Option<u8>) -> Result<(), Self::Error> {
+        if signal.is_some() {
+            return Err("no support for stepping with signal");
+        }
+
+        self.exec_mode = ExecMode::Step;
+
+        Ok(())
     }
 }
 

--- a/src/target/ext/base/mod.rs
+++ b/src/target/ext/base/mod.rs
@@ -20,29 +20,6 @@ pub enum BaseOps<'a, A, E> {
     MultiThread(&'a mut dyn multithread::MultiThreadOps<Arch = A, Error = E>),
 }
 
-/// Describes how the target should be resumed.
-///
-/// Due to a quirk / bug in the mainline GDB client, targets are required to
-/// handle the `WithSignal` variants of `Step` and `Continue` regardless of
-/// whether or not they have a concept of "signals".
-///
-/// If your target does not support signals (e.g: the target is a bare-metal
-/// microcontroller / emulator), the recommended behavior is to either return a
-/// target-specific fatal error, or to handle `{Step,Continue}WithSignal` the
-/// same way as their non-`WithSignal` variants.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ResumeAction {
-    /// Continue execution, stopping once a
-    /// [`StopReason`](singlethread::StopReason) occurs.
-    Continue,
-    /// Step execution.
-    Step,
-    /// Continue with signal.
-    ContinueWithSignal(u8),
-    /// Step with signal.
-    StepWithSignal(u8),
-}
-
 /// Describes the point reached in a replay log for the corresponding stop
 /// reason.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/target/ext/base/multithread.rs
+++ b/src/target/ext/base/multithread.rs
@@ -8,21 +8,39 @@ use crate::target::{Target, TargetResult};
 
 use super::{ReplayLogPosition, SingleRegisterAccessOps};
 
-// Convenient re-exports
-pub use super::ResumeAction;
-
 /// Base debugging operations for multi threaded targets.
 pub trait MultiThreadOps: Target {
     /// Resume execution on the target.
     ///
     /// Prior to calling `resume`, `gdbstub` will call `clear_resume_actions`,
-    /// followed by zero or more calls to `set_resume_action`, specifying any
-    /// thread-specific resume actions.
+    /// followed by zero or more calls to the `set_resume_action_XXX` methods,
+    /// specifying any thread-specific resume actions.
     ///
     /// Upon returning from the `resume` method, the target being debugged
     /// should be configured to run according to whatever resume actions the
-    /// GDB client had specified using any of the `set_resume_action`,
-    /// `set_resume_range_step`, `set_reverse_{step, continue}`, etc... methods
+    /// GDB client had specified using any of the `set_resume_action_XXX`
+    /// methods.
+    ///
+    /// Any thread that wasn't explicitly resumed by a `set_resume_action_XXX`
+    /// method should be resumed as though it was resumed with
+    /// `set_resume_action_continue`.
+    ///
+    /// A basic target implementation only needs to implement support for
+    /// `set_resume_action_continue`, with all other resume actions requiring
+    /// their corresponding protocol extension to be implemented:
+    ///
+    /// Action                      | Protocol Extension
+    /// ----------------------------|------------------------------
+    /// Optimized [Single Stepping] | See [`support_single_step()`]
+    /// Optimized [Range Stepping]  | See [`support_range_step()`]
+    /// "Stop"                      | Used in "Non-Stop" mode \*
+    ///
+    /// \* "Non-Stop" mode is currently unimplemented in `gdbstub`
+    ///
+    /// [Single stepping]: https://sourceware.org/gdb/current/onlinedocs/gdb/Continuing-and-Stepping.html#index-stepi
+    /// [Range Stepping]: https://sourceware.org/gdb/current/onlinedocs/gdb/Continuing-and-Stepping.html#range-stepping
+    /// [`support_single_step()`]: Self::support_single_step
+    /// [`support_range_step()`]: Self::support_range_step
     ///
     /// # Additional Considerations
     ///
@@ -49,41 +67,33 @@ pub trait MultiThreadOps: Target {
     ///
     /// In this case, the `Tid` argument of `read/write_addrs` becomes quite
     /// relevant, as different cores may have different memory maps.
-    ///
-    /// ### Running in "Non-stop" mode
-    ///
-    /// At the moment, `gdbstub` only supports GDB's
-    /// ["All-Stop" mode](https://sourceware.org/gdb/current/onlinedocs/gdb/All_002dStop-Mode.html),
-    /// whereby _all_ threads must be stopped when returning from `resume`
-    /// (not just the thread associated with the `ThreadStopReason`).
     fn resume(&mut self) -> Result<(), Self::Error>;
 
     /// Clear all previously set resume actions.
     fn clear_resume_actions(&mut self) -> Result<(), Self::Error>;
 
-    /// Specify what action each thread should take when
-    /// [`resume`](Self::resume) is called.
+    /// Continue the specified thread.
     ///
     /// See the [`resume`](Self::resume) docs for information on when this is
     /// called.
     ///
-    /// Aside from the four "base" resume actions handled by this method (i.e:
-    /// `Step`, `Continue`, `StepWithSignal`, and `ContinueWithSignal`),
-    /// there are also two additional resume actions which are only set if the
-    /// target implements their corresponding protocol extension:
-    ///
-    /// Action                     | Protocol Extension
-    /// ---------------------------|---------------------------
-    /// Optimized [Range Stepping] | See [`support_range_step()`]
-    /// "Stop"                     | Used in "Non-Stop" mode \*
-    ///
-    /// \* "Non-Stop" mode is currently unimplemented
-    ///
-    /// [Range Stepping]: https://sourceware.org/gdb/current/onlinedocs/gdb/Continuing-and-Stepping.html#range-stepping
-    /// [`support_range_step()`]: Self::support_range_step
-    fn set_resume_action(&mut self, tid: Tid, action: ResumeAction) -> Result<(), Self::Error>;
+    /// The GDB client may also include a `signal` which should be passed to the
+    /// target.
+    fn set_resume_action_continue(
+        &mut self,
+        tid: Tid,
+        signal: Option<u8>,
+    ) -> Result<(), Self::Error>;
 
-    /// Support for the optimized [range stepping] resume action.
+    /// Support for optimized [single stepping].
+    ///
+    /// [single stepping]: https://sourceware.org/gdb/current/onlinedocs/gdb/Continuing-and-Stepping.html#index-stepi
+    #[inline(always)]
+    fn support_single_step(&mut self) -> Option<MultiThreadSingleStepOps<Self>> {
+        None
+    }
+
+    /// Support for optimized [range stepping].
     ///
     /// [range stepping]: https://sourceware.org/gdb/current/onlinedocs/gdb/Continuing-and-Stepping.html#range-stepping
     #[inline(always)]
@@ -189,50 +199,74 @@ pub trait MultiThreadOps: Target {
     }
 }
 
-/// Target Extension - [Reverse continue] for multi threaded targets.
-///
-/// Reverse continue allows the target to run backwards until it reaches the end
-/// of the replay log.
-///
-/// [Reverse continue]: https://sourceware.org/gdb/current/onlinedocs/gdb/Reverse-Execution.html
+/// Target Extension - Reverse continue for multi threaded targets.
+/// See [`MultiThreadOps::support_reverse_cont`].
 pub trait MultiThreadReverseCont: Target + MultiThreadOps {
-    /// Reverse-continue the target.
+    /// [Reverse continue] the target.
+    ///
+    /// Reverse continue allows the target to run backwards until it reaches the
+    /// end of the replay log.
+    ///
+    /// [Reverse continue]: https://sourceware.org/gdb/current/onlinedocs/gdb/Reverse-Execution.html
     fn reverse_cont(&mut self) -> Result<(), Self::Error>;
 }
 
 define_ext!(MultiThreadReverseContOps, MultiThreadReverseCont);
 
-/// Target Extension - [Reverse stepping] for multi threaded targets.
-///
-/// Reverse stepping allows the target to run backwards by one step.
-///
-/// [Reverse stepping]: https://sourceware.org/gdb/current/onlinedocs/gdb/Reverse-Execution.html
+/// Target Extension - Reverse stepping for multi threaded targets.
+/// See [`MultiThreadOps::support_reverse_step`].
 pub trait MultiThreadReverseStep: Target + MultiThreadOps {
-    /// Reverse-step the specified [`Tid`].
+    /// [Reverse step] the specified [`Tid`].
+    ///
+    /// Reverse stepping allows the target to run backwards by one "step" -
+    /// typically a single instruction.
+    ///
+    /// [Reverse step]: https://sourceware.org/gdb/current/onlinedocs/gdb/Reverse-Execution.html
     fn reverse_step(&mut self, tid: Tid) -> Result<(), Self::Error>;
 }
 
 define_ext!(MultiThreadReverseStepOps, MultiThreadReverseStep);
 
-/// Target Extension - Optimized [range stepping] for multi threaded targets.
+/// Target Extension - Optimized single stepping for multi threaded targets.
+/// See [`MultiThreadOps::support_single_step`].
+pub trait MultiThreadSingleStep: Target + MultiThreadOps {
+    /// [Single step] the specified target thread.
+    ///
+    /// Single stepping will step the target a single "step" - typically a
+    /// single instruction.
+    ///
+    /// The GDB client may also include a `signal` which should be passed to the
+    /// target.
+    ///
+    /// If your target does not support signals (e.g: the target is a bare-metal
+    /// microcontroller / emulator), the recommended behavior is to return a
+    /// target-specific fatal error
+    ///
+    /// [Single step]: https://sourceware.org/gdb/current/onlinedocs/gdb/Continuing-and-Stepping.html#index-stepi
+    fn set_resume_action_step(&mut self, tid: Tid, signal: Option<u8>) -> Result<(), Self::Error>;
+}
+
+define_ext!(MultiThreadSingleStepOps, MultiThreadSingleStep);
+
+/// Target Extension - Optimized range stepping for multi threaded targets.
 /// See [`MultiThreadOps::support_range_step`].
-///
-/// Range Stepping will step the target once, and keep stepping the target as
-/// long as execution remains between the specified start (inclusive) and end
-/// (exclusive) addresses, or another stop condition is met (e.g: a breakpoint
-/// it hit).
-///
-/// If the range is empty (`start` == `end`), then the action becomes
-/// equivalent to the ‘s’ action. In other words, single-step once, and
-/// report the stop (even if the stepped instruction jumps to start).
-///
-/// _Note:_ A stop reply may be sent at any point even if the PC is still
-/// within the stepping range; for example, it is valid to implement range
-/// stepping in a degenerate way as a single instruction step operation.
-///
-/// [range stepping]: https://sourceware.org/gdb/current/onlinedocs/gdb/Continuing-and-Stepping.html#range-stepping
 pub trait MultiThreadRangeStepping: Target + MultiThreadOps {
-    /// See [`MultiThreadOps::set_resume_action`].
+    /// [Range step] the specified target thread.
+    ///
+    /// Range Stepping will step the target once, and keep stepping the target
+    /// as long as execution remains between the specified start (inclusive)
+    /// and end (exclusive) addresses, or another stop condition is met
+    /// (e.g: a breakpoint it hit).
+    ///
+    /// If the range is empty (`start` == `end`), then the action becomes
+    /// equivalent to the ‘s’ action. In other words, single-step once, and
+    /// report the stop (even if the stepped instruction jumps to start).
+    ///
+    /// _Note:_ A stop reply may be sent at any point even if the PC is still
+    /// within the stepping range; for example, it is valid to implement range
+    /// stepping in a degenerate way as a single instruction step operation.
+    ///
+    /// [Range step]: https://sourceware.org/gdb/current/onlinedocs/gdb/Continuing-and-Stepping.html#range-stepping
     fn set_resume_action_range_step(
         &mut self,
         tid: Tid,


### PR DESCRIPTION
Closes #59

See the associated issue for context and rationale.

This is definitely a big API change, but one that is important to make. Single stepping should _not_ be required by the base protocol, as while it's trivial to implement on some targets (e.g: emulators), it is _not_ trivial to implement in others.

The GDB client is able to spoof single-stepping by setting temporary breakpoint instructions in the guest. While this is undoubtedly slower than an optimized single-stepping implementation, it has the key benefit of working "out-of-the-box", without any explicit effort required by the `gdbstub` user to get it working.