### PR TITLE
do not fail on unknown HostIoOpenFlags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 0.6.1
+
+- ignore unknown vFile:open flags
+
 # 0.6.0
 
 After over a half-year of development, `gdbstub` 0.6 has finally been released!

--- a/src/protocol/commands/_vFile_open.rs
+++ b/src/protocol/commands/_vFile_open.rs
@@ -20,8 +20,8 @@ impl<'a> ParseCommand<'a> for vFileOpen<'a> {
             [b':', body @ ..] => {
                 let mut body = body.splitn_mut_no_panic(3, |b| *b == b',');
                 let filename = decode_hex_buf(body.next()?).ok()?;
-                let flags = HostIoOpenFlags::from_bits(decode_hex(body.next()?).ok()?)?;
-                let mode = HostIoOpenMode::from_bits(decode_hex(body.next()?).ok()?)?;
+                let flags = HostIoOpenFlags::from_bits_truncate(decode_hex(body.next()?).ok()?);
+                let mode = HostIoOpenMode::from_bits_truncate(decode_hex(body.next()?).ok()?);
                 Some(vFileOpen { filename, flags, mode })
             },
             _ => None,


### PR DESCRIPTION
### Description

<!-- Please include a brief description of what is being added/changed -->

gdbstub fails when unknown file open flags are passed with:
```
gdbstub encountered a fatal error: Could not parse the packet into a valid command: MalformedCommand
```

This bug appeared with lldb sending `platform put-file` command, appending following `File:open` arguments:
`612e6f7574,40000601,000001ed`


The simple solution is to use `from_bits_truncate` to ignore unknown flags.

### API Stability

- [x] This PR does not require a breaking API change

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
 
- Documentation
  - [x] Updated CHANGELOG.md

