### PR TITLE
add lldb-specific HostIoOpenFlags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 0.6.1
+
+- add LLDB-specific HostIoOpenFlags [\#100](https://github.com/daniel5151/gdbstub/pull/100) ([mrk](https://github.com/mrk-its))
+
 # 0.6.0
 
 After over a half-year of development, `gdbstub` 0.6 has finally been released!

--- a/src/target/ext/host_io.rs
+++ b/src/target/ext/host_io.rs
@@ -24,6 +24,18 @@ bitflags! {
         const O_TRUNC = 0x400;
         /// Exclusive access.
         const O_EXCL = 0x800;
+
+        // LLDB-specific flags, as documented at:
+        // https://github.com/llvm/llvm-project/blob/ec642ceebc1aacc8b16249df7734b8cf90ae2963/lldb/include/lldb/Host/File.h#L47-L66
+
+        /// Do not block
+        const O_NONBLOCK = 1 << 28;
+        /// Do not follow symlinks
+        const O_DONT_FOLLOW_SYMLINKS = 1 << 29;
+        /// Close the file when executing a new process
+        const O_CLOSE_ON_EXEC = 1 << 30;
+        /// Invalid value
+        const O_INVALID = 1 << 31;
     }
 }
 

--- a/src/target/ext/host_io.rs
+++ b/src/target/ext/host_io.rs
@@ -8,7 +8,9 @@ bitflags! {
     /// Host flags for opening files.
     ///
     /// Extracted from the GDB documentation at
-    /// [Open Flags](https://sourceware.org/gdb/current/onlinedocs/gdb/Open-Flags.html#Open-Flags)
+    /// [Open Flags](https://sourceware.org/gdb/current/onlinedocs/gdb/Open-Flags.html#Open-Flags),
+    /// and the LLDB source code at
+    /// [`lldb/include/lldb/Host/File.h`](https://github.com/llvm/llvm-project/blob/ec642ceebc1aacc8b16249df7734b8cf90ae2963/lldb/include/lldb/Host/File.h#L47-L66)
     pub struct HostIoOpenFlags: u32 {
         /// A read-only file.
         const O_RDONLY = 0x0;
@@ -25,16 +27,13 @@ bitflags! {
         /// Exclusive access.
         const O_EXCL = 0x800;
 
-        // LLDB-specific flags, as documented at:
-        // https://github.com/llvm/llvm-project/blob/ec642ceebc1aacc8b16249df7734b8cf90ae2963/lldb/include/lldb/Host/File.h#L47-L66
-
-        /// Do not block
+        /// LLDB extension: Do not block.
         const O_NONBLOCK = 1 << 28;
-        /// Do not follow symlinks
+        /// LLDB extension: Do not follow symlinks.
         const O_DONT_FOLLOW_SYMLINKS = 1 << 29;
-        /// Close the file when executing a new process
+        /// LLDB extension: Close the file when executing a new process.
         const O_CLOSE_ON_EXEC = 1 << 30;
-        /// Invalid value
+        /// LLDB extension: Invalid value.
         const O_INVALID = 1 << 31;
     }
 }


### PR DESCRIPTION
### Description

This PR adds lldb-specific HostIoOpenFlags, as proposed in #99

### API Stability

- [x] This PR does not require a breaking API change

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
- Documentation
  - [x] rustdoc + approprate inline code comments
  - [x] Updated CHANGELOG.md
