### PR TITLE
add qRegisterInfo packet support

### DIFF
--- a/examples/armv4t/gdb/register_info_override.rs
+++ b/examples/armv4t/gdb/register_info_override.rs
@@ -1,0 +1,106 @@
+use gdbstub::arch::lldb::{Encoding, Format, Generic, Register};
+use gdbstub::arch::RegId;
+use gdbstub::target;
+use gdbstub::target::ext::register_info_override::{Callback, CallbackToken};
+use gdbstub_arch::arm::reg::id::ArmCoreRegId;
+
+use crate::gdb::custom_arch::ArmCoreRegIdCustom;
+use crate::gdb::Emu;
+
+// (LLDB extension) This implementation is for illustrative purposes only.
+//
+// Note: In this implementation, we have r0-pc from 0-16 but cpsr is at offset
+// 25*4 in the 'g'/'G' packets, so we add 8 padding registers here. Please see
+// gdbstub/examples/armv4t/gdb/target_description_xml_override.rs for more info.
+impl target::ext::register_info_override::RegisterInfoOverride for Emu {
+    fn register_info<'a>(
+        &mut self,
+        reg_id: usize,
+        reg_info: Callback<'a>,
+    ) -> Result<CallbackToken<'a>, Self::Error> {
+        // Fix for missing 24 => Self::Fps in ArmCoreRegId::from_raw_id
+        let id = if reg_id == 24 { 23 } else { reg_id };
+
+        match ArmCoreRegIdCustom::from_raw_id(id) {
+            Some((_, None)) | None => Ok(reg_info.done()),
+            Some((r, Some(size))) => {
+                let name: String = match r {
+                    // For the purpose of demonstration, we end the qRegisterInfo packet exchange
+                    // when reaching the Time register id, so that this register can only be
+                    // explicitly queried via the single-register read packet.
+                    ArmCoreRegIdCustom::Time => return Ok(reg_info.done()),
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Gpr(i)) => match i {
+                        0 => "r0",
+                        1 => "r1",
+                        2 => "r2",
+                        3 => "r3",
+                        4 => "r4",
+                        5 => "r5",
+                        6 => "r6",
+                        7 => "r7",
+                        8 => "r8",
+                        9 => "r9",
+                        10 => "r10",
+                        11 => "r11",
+                        12 => "r12",
+                        _ => "unknown",
+                    },
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Sp) => "sp",
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Lr) => "lr",
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Pc) => "pc",
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Fpr(_i)) => "padding",
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Fps) => "padding",
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Cpsr) => "cpsr",
+                    ArmCoreRegIdCustom::Custom => "custom",
+                    _ => "unknown",
+                }
+                .into();
+                let encoding = match r {
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Gpr(_i)) => Encoding::Uint,
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Sp)
+                    | ArmCoreRegIdCustom::Core(ArmCoreRegId::Pc)
+                    | ArmCoreRegIdCustom::Core(ArmCoreRegId::Cpsr)
+                    | ArmCoreRegIdCustom::Custom => Encoding::Uint,
+                    _ => Encoding::Vector,
+                };
+                let format = match r {
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Gpr(_i)) => Format::Hex,
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Sp)
+                    | ArmCoreRegIdCustom::Core(ArmCoreRegId::Pc)
+                    | ArmCoreRegIdCustom::Core(ArmCoreRegId::Cpsr)
+                    | ArmCoreRegIdCustom::Custom => Format::Hex,
+                    _ => Format::VectorUInt8,
+                };
+                let set: String = match r {
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Gpr(_i)) => "General Purpose Registers",
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Sp)
+                    | ArmCoreRegIdCustom::Core(ArmCoreRegId::Pc)
+                    | ArmCoreRegIdCustom::Core(ArmCoreRegId::Cpsr)
+                    | ArmCoreRegIdCustom::Custom => "General Purpose Registers",
+                    _ => "Floating Point Registers",
+                }
+                .into();
+                let generic = match r {
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Sp) => Some(Generic::Sp),
+                    ArmCoreRegIdCustom::Core(ArmCoreRegId::Pc) => Some(Generic::Pc),
+                    _ => None,
+                };
+                let reg = Register {
+                    name: &name,
+                    alt_name: None,
+                    bitsize: (usize::from(size)) * 8,
+                    offset: id * (usize::from(size)),
+                    encoding,
+                    format,
+                    set: &set,
+                    gcc: None,
+                    dwarf: Some(id),
+                    generic,
+                    container_regs: None,
+                    invalidate_regs: None,
+                };
+                Ok(reg_info.write(reg))
+            }
+        }
+    }
+}

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -87,6 +87,7 @@ macro_rules! commands {
                 trait Hack {
                     fn support_base(&mut self) -> Option<()>;
                     fn support_target_xml(&mut self) -> Option<()>;
+                    fn support_register_info(&mut self) -> Option<()>;
                     fn support_resume(&mut self) -> Option<()>;
                     fn support_single_register_access(&mut self) -> Option<()>;
                     fn support_reverse_step(&mut self) -> Option<()>;
@@ -111,6 +112,18 @@ macro_rules! commands {
                             None
                         }
                     }
+
+                    fn support_register_info(&mut self) -> Option<()> {
+                        use crate::arch::Arch;
+			if self.use_register_info()
+                            && (T::Arch::register_info(usize::max_value()).is_some()
+                                || self.support_register_info_override().is_some())
+                        {
+                            Some(())
+                        } else {
+                            None
+                        }
+		    }
 
                     fn support_resume(&mut self) -> Option<()> {
                         self.base_ops().resume_ops().map(drop)
@@ -300,5 +313,9 @@ commands! {
 
     thread_extra_info use 'a {
         "qThreadExtraInfo" => _qThreadExtraInfo::qThreadExtraInfo<'a>,
+    }
+
+    register_info {
+        "qRegisterInfo" => _qRegisterInfo::qRegisterInfo,
     }
 }

--- a/src/protocol/commands/_qRegisterInfo.rs
+++ b/src/protocol/commands/_qRegisterInfo.rs
@@ -1,0 +1,17 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct qRegisterInfo {
+    pub reg_id: usize,
+}
+
+impl<'a> ParseCommand<'a> for qRegisterInfo {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let body = buf.into_body();
+
+        let reg_id = decode_hex(body).ok()?; 
+      
+        Some(qRegisterInfo { reg_id })
+    }
+}

--- a/src/stub/core_impl.rs
+++ b/src/stub/core_impl.rs
@@ -30,6 +30,7 @@ mod extended_mode;
 mod host_io;
 mod memory_map;
 mod monitor_cmd;
+mod register_info;
 mod resume;
 mod reverse_exec;
 mod section_offsets;
@@ -209,6 +210,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Command::ExecFile(cmd) => self.handle_exec_file(res, target, cmd),
             Command::Auxv(cmd) => self.handle_auxv(res, target, cmd),
             Command::ThreadExtraInfo(cmd) => self.handle_thread_extra_info(res, target, cmd),
+            Command::RegisterInfo(cmd) => self.handle_register_info(res, target, cmd),
             // in the worst case, the command could not be parsed...
             Command::Unknown(cmd) => {
                 // HACK: if the user accidentally sends a resume command to a

--- a/src/stub/core_impl/register_info.rs
+++ b/src/stub/core_impl/register_info.rs
@@ -1,0 +1,138 @@
+use super::prelude::*;
+use crate::protocol::commands::ext::RegisterInfo;
+
+use crate::arch::lldb::{Encoding, Format, Generic, Register, RegisterInfo as LLDBRegisterInfo};
+use crate::arch::Arch;
+
+impl<T: Target, C: Connection> GdbStubImpl<T, C> {
+    pub(crate) fn handle_register_info(
+        &mut self,
+        res: &mut ResponseWriter<'_, C>,
+        target: &mut T,
+        command: RegisterInfo,
+    ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
+        if !target.use_register_info() {
+            return Ok(HandlerStatus::Handled);
+        }
+
+        let handler_status = match command {
+            RegisterInfo::qRegisterInfo(cmd) => {
+                let mut err = Ok(());
+                let cb = &mut |reg: Option<Register<'_>>| {
+                    let res = match reg {
+                        // TODO: replace this with a try block (once stabilized)
+                        Some(reg) => (|| {
+                            res.write_str("name:")?;
+                            res.write_str(reg.name)?;
+                            if let Some(alt_name) = reg.alt_name {
+                                res.write_str(";alt-name:")?;
+                                res.write_str(alt_name)?;
+                            }
+                            res.write_str(";bitsize:")?;
+                            res.write_dec(reg.bitsize)?;
+                            res.write_str(";offset:")?;
+                            res.write_dec(reg.offset)?;
+                            res.write_str(";encoding:")?;
+                            res.write_str(match reg.encoding {
+                                Encoding::Uint => "uint",
+                                Encoding::Sint => "sint",
+                                Encoding::IEEE754 => "ieee754",
+                                Encoding::Vector => "vector",
+                            })?;
+                            res.write_str(";format:")?;
+                            res.write_str(match reg.format {
+                                Format::Binary => "binary",
+                                Format::Decimal => "decimal",
+                                Format::Hex => "hex",
+                                Format::Float => "float",
+                                Format::VectorSInt8 => "vector-sint8",
+                                Format::VectorUInt8 => "vector-uint8",
+                                Format::VectorSInt16 => "vector-sint16",
+                                Format::VectorUInt16 => "vector-uint16",
+                                Format::VectorSInt32 => "vector-sint32",
+                                Format::VectorUInt32 => "vector-uint32",
+                                Format::VectorFloat32 => "vector-float32",
+                                Format::VectorUInt128 => "vector-uint128",
+                            })?;
+                            res.write_str(";set:")?;
+                            res.write_str(reg.set)?;
+                            if let Some(gcc) = reg.gcc {
+                                res.write_str(";gcc:")?;
+                                res.write_dec(gcc)?;
+                            }
+                            if let Some(dwarf) = reg.dwarf {
+                                res.write_str(";dwarf:")?;
+                                res.write_dec(dwarf)?;
+                            }
+                            if let Some(generic) = reg.generic {
+                                res.write_str(";generic:")?;
+                                res.write_str(match generic {
+                                    Generic::Pc => "pc",
+                                    Generic::Sp => "sp",
+                                    Generic::Fp => "fp",
+                                    Generic::Ra => "ra",
+                                    Generic::Flags => "flags",
+                                    Generic::Arg1 => "arg1",
+                                    Generic::Arg2 => "arg2",
+                                    Generic::Arg3 => "arg3",
+                                    Generic::Arg4 => "arg4",
+                                    Generic::Arg5 => "arg5",
+                                    Generic::Arg6 => "arg6",
+                                    Generic::Arg7 => "arg7",
+                                    Generic::Arg8 => "arg8",
+                                })?;
+                            }
+                            if let Some(c_regs) = reg.container_regs {
+                                res.write_str(";container-regs:")?;
+                                res.write_num(c_regs[0])?;
+                                for reg in c_regs.iter().skip(1) {
+                                    res.write_str(",")?;
+                                    res.write_num(*reg)?;
+                                }
+                            }
+                            if let Some(i_regs) = reg.invalidate_regs {
+                                res.write_str(";invalidate-regs:")?;
+                                res.write_num(i_regs[0])?;
+                                for reg in i_regs.iter().skip(1) {
+                                    res.write_str(",")?;
+                                    res.write_num(*reg)?;
+                                }
+                            }
+                            res.write_str(";")
+                        })(),
+                        // In fact, this doesn't has to be E45! It could equally well be any
+                        // other error code or even an eOk, eAck or eNack! It turns out that
+                        // 0x45 == 69, so presumably the LLDB people were just having some fun
+                        // here. For a little discussion on this and LLDB source code pointers,
+                        // see https://github.com/daniel5151/gdbstub/pull/103#discussion_r888590197
+                        _ => res.write_str("E45"),
+                    };
+                    if let Err(e) = res {
+                        err = Err(e);
+                    }
+                };
+                if let Some(ops) = target.support_register_info_override() {
+                    use crate::target::ext::register_info_override::{Callback, CallbackToken};
+
+                    ops.register_info(
+                        cmd.reg_id,
+                        Callback {
+                            cb,
+                            token: CallbackToken(core::marker::PhantomData),
+                        },
+                    )
+                    .map_err(Error::TargetError)?;
+                    err?;
+                } else if let Some(reg) = T::Arch::register_info(cmd.reg_id) {
+                    match reg {
+                        LLDBRegisterInfo::Register(reg) => cb(Some(reg)),
+                        LLDBRegisterInfo::Done => cb(None),
+                    };
+                }
+                HandlerStatus::Handled
+            }
+        };
+
+        Ok(handler_status)
+    }
+}

--- a/src/target/ext/mod.rs
+++ b/src/target/ext/mod.rs
@@ -267,6 +267,7 @@ pub mod extended_mode;
 pub mod host_io;
 pub mod memory_map;
 pub mod monitor_cmd;
+pub mod register_info_override;
 pub mod section_offsets;
 pub mod target_description_xml_override;
 pub mod thread_extra_info;

--- a/src/target/ext/register_info_override.rs
+++ b/src/target/ext/register_info_override.rs
@@ -1,0 +1,54 @@
+//! (LLDB extension) Override the register info specified by `Target::Arch`.
+use crate::arch::lldb::Register;
+use crate::target::Target;
+
+/// If your target is using the `qRegisterInfo` packet, this
+/// token hast to be returned from the `register_info` function to guarantee
+/// that the callback function to write the register info has been invoked.
+pub struct CallbackToken<'a>(pub(crate) core::marker::PhantomData<&'a *mut ()>);
+
+/// This struct is used internally by `gdbstub` to wrap a
+/// callback function which has to be used to direct the `qRegisterInfo` query.
+pub struct Callback<'a> {
+    /// The callback function that is directing the `qRegisterInfo` query.
+    pub(crate) cb: &'a mut dyn FnMut(Option<Register<'_>>),
+    /// A token to guarantee the callback has been used.
+    pub(crate) token: CallbackToken<'a>,
+}
+
+impl<'a> Callback<'a> {
+    /// The `qRegisterInfo` query shall be concluded.
+    #[inline(always)]
+    pub fn done(self) -> CallbackToken<'a> {
+        (self.cb)(None);
+        self.token
+    }
+
+    /// Write the register info of a single register.
+    #[inline(always)]
+    pub fn write(self, reg: Register<'_>) -> CallbackToken<'a> {
+        (self.cb)(Some(reg));
+        self.token
+    }
+}
+
+/// Target Extension - Override the target register info
+/// specified by `Target::Arch`.
+///
+/// _Note:_ Unless you're working with a particularly dynamic,
+/// runtime-configurable target, it's unlikely that you'll need to implement
+/// this extension.
+pub trait RegisterInfoOverride: Target {
+    /// Invoke `reg_info.write(reg)` where `reg` is a [`Register`
+    /// ](crate::arch::lldb::Register) struct to write information of
+    /// a single register or `reg_info.done()` if you want to end the
+    /// `qRegisterInfo` packet exchange. These two methods will return a
+    /// `CallbackToken`, which has to be returned from this method.
+    fn register_info<'a>(
+        &mut self,
+        reg_id: usize,
+        reg_info: Callback<'a>,
+    ) -> Result<CallbackToken<'a>, Self::Error>;
+}
+
+define_ext!(RegisterInfoOverrideOps, RegisterInfoOverride);

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -597,6 +597,21 @@ pub trait Target {
         true
     }
 
+    /// (LLDB extension) Whether to send register information to the client.
+    ///
+    /// Setting this to `false` will override both
+    /// [`Target::support_register_info_override`] and the associated
+    /// [`Arch::register_info`].
+    ///
+    /// _Author's note:_ Having the LLDB client autodetect your target's
+    /// register set is really useful, so unless you're _really_ trying to
+    /// squeeze `gdbstub` onto a particularly resource-constrained platform, you
+    /// may as well leave this enabled.
+    #[inline(always)]
+    fn use_register_info(&self) -> bool {
+        true
+    }
+
     /// Support for setting / removing breakpoints.
     #[inline(always)]
     fn support_breakpoints(&mut self) -> Option<ext::breakpoints::BreakpointsOps<'_, Self>> {
@@ -631,6 +646,15 @@ pub trait Target {
         &mut self,
     ) -> Option<ext::target_description_xml_override::TargetDescriptionXmlOverrideOps<'_, Self>>
     {
+        None
+    }
+
+    /// (LLDB extension) Support for overriding the register info specified by
+    /// `Target::Arch`.
+    #[inline(always)]
+    fn support_register_info_override(
+        &mut self,
+    ) -> Option<ext::register_info_override::RegisterInfoOverrideOps<'_, Self>> {
         None
     }
 
@@ -704,6 +728,10 @@ macro_rules! impl_dyn_target {
                 (**self).use_target_description_xml()
             }
 
+            fn use_register_info(&self) -> bool {
+                (**self).use_register_info()
+            }
+
             fn support_breakpoints(
                 &mut self,
             ) -> Option<ext::breakpoints::BreakpointsOps<'_, Self>> {
@@ -732,6 +760,12 @@ macro_rules! impl_dyn_target {
                 ext::target_description_xml_override::TargetDescriptionXmlOverrideOps<'_, Self>,
             > {
                 (**self).support_target_description_xml_override()
+            }
+
+            fn support_register_info_override(
+                &mut self,
+            ) -> Option<ext::register_info_override::RegisterInfoOverrideOps<'_, Self>> {
+                (**self).support_register_info_override()
             }
 
             fn support_memory_map(&mut self) -> Option<ext::memory_map::MemoryMapOps<'_, Self>> {


### PR DESCRIPTION
### Description

<!-- Please include a brief description of what is being added/changed -->

This implements the LLDB specifc `qRegisterInfo` packet (documentation [here](https://github.com/llvm/llvm-project/blob/50f2e49924566330ea9aa731908f2864603bf4fb/lldb/docs/lldb-gdb-remote.txt#L583)).

Relates to #99 <!-- if appropriate -->
I was working on a target where I had some trouble getting the .xml target description formatting right so I opted to use the `qRegisterInfo` packet instead which pretty much worked right away. I haven't looked into unifying them as mentioned in the compatibility issue as of now though.
One caveat is that some values in the reply need to be in decimal representation. Due to this I added a `write_dec()` method in the `ResponseWriter` (I'm not sure this was actually necessary). Since this packet is only used by `LLDB` it might be reasonable to just hide it behind a feature flag. Besides that, if enabled, the `Register` struct in `gdbstub/src/target/ext/register_info.rs` has a few `&'static str` members which lead to a bigger binary as well.

### API Stability

- [x] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
- Documentation
  - [x] rustdoc + approprate inline code comments
  - [x] Updated CHANGELOG.md
- _If implementing a new protocol extension IDET_
  - [x] Included a basic sample implementation in `examples/armv4t`
    ->Done but might be better to comment it out because it only applies to `LLDB`
  - [ ] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
    ->attached the LLDB output instead
  - [x] Confirmed that IDET can be optimized away (using `./scripts/test_dead_code_elim.sh` and/or `./example_no_std/check_size.sh`)
  - [x] **OR** Implementation requires adding non-optional binary bloat (please elaborate under "Description")
    ->Additional `write_dec()` method
<!-- If you are implementing `gdbstub` in an open-source project, consider updating the README.md's "Real World Examples" section to link back to your project! -->

### Validation

<!-- example output, from https://github.com/daniel5151/gdbstub/pull/54 -->

<details>
<summary>LLDB output</summary>

```
(lldb) gdb-remote 9001
lldb-10          <   1> send packet: +
lldb-10          history[1] tid=0x769a <   1> send packet: +
lldb-10          <  19> send packet: $QStartNoAckMode#b0
lldb-10          <   1> read packet: +
lldb-10          <   6> read packet: $OK#9a
lldb-10          <   1> send packet: +
lldb-10          <  45> send packet: $qSupported:xmlRegisters=i386,arm,mips,arc#74
lldb-10          < 333> read packet: $PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;ReverseContinue+;ReverseStep+;QDisableRandomization+;QEnvironmentHexEncoded+;QEnvironmentUnset+;QEnvironmentReset+;QStartupWithShell+;QSetWorkingDir+;swbreak+;hwbreak+;QCatchSyscalls+;qXfer:features:read+;qXfer:memory-map:read+;qXfer:exec-file:read+;qXfer:auxv:read+#fa
lldb-10          <  26> send packet: $QThreadSuffixSupported#e4
lldb-10          <   4> read packet: $#00
lldb-10          <  27> send packet: $QListThreadsInStopReply#21
lldb-10          <   4> read packet: $#00
lldb-10          <  13> send packet: $qHostInfo#9b
lldb-10          <   4> read packet: $#00
lldb-10          <  10> send packet: $vCont?#49
lldb-10          <  19> read packet: $vCont;c;C;s;S;r#0f
lldb-10          <  27> send packet: $qVAttachOrWaitSupported#38
lldb-10          <   4> read packet: $#00
lldb-10          <  23> send packet: $QEnableErrorStrings#8c
lldb-10          <   4> read packet: $#00
lldb-10          <  16> send packet: $qProcessInfo#dc
lldb-10          <   4> read packet: $#00
lldb-10          <   6> send packet: $qC#b4
lldb-10          <   4> read packet: $#00
lldb-10          <  16> send packet: $qfThreadInfo#bb
lldb-10          <   7> read packet: $m01#ce
lldb-10          <  16> send packet: $qsThreadInfo#c8
lldb-10          <   5> read packet: $l#6c
lldb-10          <   5> send packet: $?#3f
lldb-10          <   7> read packet: $S05#b8
lldb-10          <  16> send packet: $qProcessInfo#dc
lldb-10          <   4> read packet: $#00
lldb-10          <  18> send packet: $qRegisterInfo0#72
lldb-10          < 107> read packet: $name:r0;alt-name:r0;bitsize:32;offset:0;encoding:uint;format:hex;set:General Purpose Registers;dwarf:0;#bb
lldb-10          <  18> send packet: $qRegisterInfo1#73
lldb-10          < 107> read packet: $name:r1;alt-name:r1;bitsize:32;offset:4;encoding:uint;format:hex;set:General Purpose Registers;dwarf:1;#c2
lldb-10          <  18> send packet: $qRegisterInfo2#74
lldb-10          < 107> read packet: $name:r2;alt-name:r2;bitsize:32;offset:8;encoding:uint;format:hex;set:General Purpose Registers;dwarf:2;#c9
lldb-10          <  18> send packet: $qRegisterInfo3#75
lldb-10          < 108> read packet: $name:r3;alt-name:r3;bitsize:32;offset:12;encoding:uint;format:hex;set:General Purpose Registers;dwarf:3;#f7
lldb-10          <  18> send packet: $qRegisterInfo4#76
lldb-10          < 108> read packet: $name:r4;alt-name:r4;bitsize:32;offset:16;encoding:uint;format:hex;set:General Purpose Registers;dwarf:4;#fe
lldb-10          <  18> send packet: $qRegisterInfo5#77
lldb-10          < 108> read packet: $name:r5;alt-name:r5;bitsize:32;offset:20;encoding:uint;format:hex;set:General Purpose Registers;dwarf:5;#fc
lldb-10          <  18> send packet: $qRegisterInfo6#78
lldb-10          < 108> read packet: $name:r6;alt-name:r6;bitsize:32;offset:24;encoding:uint;format:hex;set:General Purpose Registers;dwarf:6;#03
lldb-10          <  18> send packet: $qRegisterInfo7#79
lldb-10          < 108> read packet: $name:r7;alt-name:r7;bitsize:32;offset:28;encoding:uint;format:hex;set:General Purpose Registers;dwarf:7;#0a
lldb-10          <  18> send packet: $qRegisterInfo8#7a
lldb-10          < 108> read packet: $name:r8;alt-name:r8;bitsize:32;offset:32;encoding:uint;format:hex;set:General Purpose Registers;dwarf:8;#08
lldb-10          <  18> send packet: $qRegisterInfo9#7b
lldb-10          < 108> read packet: $name:r9;alt-name:r9;bitsize:32;offset:36;encoding:uint;format:hex;set:General Purpose Registers;dwarf:9;#0f
lldb-10          <  18> send packet: $qRegisterInfoa#a3
lldb-10          < 111> read packet: $name:r10;alt-name:r10;bitsize:32;offset:40;encoding:uint;format:hex;set:General Purpose Registers;dwarf:10;#82
lldb-10          <  18> send packet: $qRegisterInfob#a4
lldb-10          < 111> read packet: $name:r11;alt-name:r11;bitsize:32;offset:44;encoding:uint;format:hex;set:General Purpose Registers;dwarf:11;#89
lldb-10          <  18> send packet: $qRegisterInfoc#a5
lldb-10          < 111> read packet: $name:r12;alt-name:r12;bitsize:32;offset:48;encoding:uint;format:hex;set:General Purpose Registers;dwarf:12;#90
lldb-10          <  18> send packet: $qRegisterInfod#a6
lldb-10          < 120> read packet: $name:sp;alt-name:sp;bitsize:32;offset:52;encoding:uint;format:hex;set:General Purpose Registers;dwarf:13;generic:sp;#dd
lldb-10          <  18> send packet: $qRegisterInfoe#a7
lldb-10          < 109> read packet: $name:lr;alt-name:lr;bitsize:32;offset:56;encoding:uint;format:hex;set:General Purpose Registers;dwarf:14;#a3
lldb-10          <  18> send packet: $qRegisterInfof#a8
lldb-10          < 120> read packet: $name:pc;alt-name:pc;bitsize:32;offset:60;encoding:uint;format:hex;set:General Purpose Registers;dwarf:15;generic:pc;#ae
lldb-10          <  19> send packet: $qRegisterInfo10#a3
lldb-10          < 129> read packet: $name:padding;alt-name:padding;bitsize:32;offset:64;encoding:vector;format:vector-uint8;set:Floating Point Registers;dwarf:16;#6e
lldb-10          <  19> send packet: $qRegisterInfo11#a4
lldb-10          < 129> read packet: $name:padding;alt-name:padding;bitsize:32;offset:68;encoding:vector;format:vector-uint8;set:Floating Point Registers;dwarf:17;#73
lldb-10          <  19> send packet: $qRegisterInfo12#a5
lldb-10          < 129> read packet: $name:padding;alt-name:padding;bitsize:32;offset:72;encoding:vector;format:vector-uint8;set:Floating Point Registers;dwarf:18;#6f
lldb-10          <  19> send packet: $qRegisterInfo13#a6
lldb-10          < 129> read packet: $name:padding;alt-name:padding;bitsize:32;offset:76;encoding:vector;format:vector-uint8;set:Floating Point Registers;dwarf:19;#74
lldb-10          <  19> send packet: $qRegisterInfo14#a7
lldb-10          < 129> read packet: $name:padding;alt-name:padding;bitsize:32;offset:80;encoding:vector;format:vector-uint8;set:Floating Point Registers;dwarf:20;#67
lldb-10          <  19> send packet: $qRegisterInfo15#a8
lldb-10          < 129> read packet: $name:padding;alt-name:padding;bitsize:32;offset:84;encoding:vector;format:vector-uint8;set:Floating Point Registers;dwarf:21;#6c
lldb-10          <  19> send packet: $qRegisterInfo16#a9
lldb-10          < 129> read packet: $name:padding;alt-name:padding;bitsize:32;offset:88;encoding:vector;format:vector-uint8;set:Floating Point Registers;dwarf:22;#71
lldb-10          <  19> send packet: $qRegisterInfo17#aa
lldb-10          < 129> read packet: $name:padding;alt-name:padding;bitsize:32;offset:92;encoding:vector;format:vector-uint8;set:Floating Point Registers;dwarf:23;#6d
lldb-10          <  19> send packet: $qRegisterInfo18#ab
lldb-10          < 129> read packet: $name:padding;alt-name:padding;bitsize:32;offset:96;encoding:vector;format:vector-uint8;set:Floating Point Registers;dwarf:24;#72
lldb-10          <  19> send packet: $qRegisterInfo19#ac
lldb-10          < 114> read packet: $name:cpsr;alt-name:cpsr;bitsize:32;offset:100;encoding:uint;format:hex;set:General Purpose Registers;dwarf:25;#7f
lldb-10          <  19> send packet: $qRegisterInfo1a#d4
lldb-10          <   7> read packet: $E45#ae
lldb-10          <  16> send packet: $qfThreadInfo#bb
lldb-10          <   7> read packet: $m01#ce
lldb-10          <  16> send packet: $qsThreadInfo#c8
lldb-10          <   5> read packet: $l#6c
lldb-10          <   7> send packet: $Hg1#e0
lldb-10          <   6> read packet: $OK#9a
lldb-10          <   6> send packet: $p0#a0
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <  16> send packet: $qProcessInfo#dc
lldb-10          <   4> read packet: $#00
lldb-10          <  26> send packet: $qStructuredDataPlugins#02
lldb-10          <   4> read packet: $#00
lldb-10          <  13> send packet: $qSymbol::#5b
lldb-10          <   4> read packet: $#00
lldb-10          <  16> send packet: $qfThreadInfo#bb
lldb-10          <   7> read packet: $m01#ce
lldb-10          <  16> send packet: $qsThreadInfo#c8
lldb-10          <   5> read packet: $l#6c
lldb-10          <  16> send packet: $qfThreadInfo#bb
lldb-10          <   7> read packet: $m01#ce
lldb-10          <  16> send packet: $qsThreadInfo#c8
lldb-10          <   5> read packet: $l#6c
lldb-10          <   6> send packet: $pf#d6
lldb-10          <  10> read packet: $0* 5* #f9
lldb-10          <   7> send packet: $p19#da
lldb-10          <  10> read packet: $1000*!#0c
lldb-10          <   6> send packet: $pd#d4
lldb-10          <  10> read packet: $00*!10#0c
lldb-10          <   6> send packet: $pe#d5
lldb-10          <  12> read packet: $78563412#a4
lldb-10          <  30> send packet: $qMemoryRegionInfo:12345678#b8
lldb-10          <   4> read packet: $#00
lldb-10          <   6> send packet: $pb#d2
lldb-10          <   7> read packet: $0*$#7e
dbg.evt-handler  <  16> send packet: $jThreadsInfo#c1
(lldb) dbg.evt-handler  <   4> read packet: $#00
dbg.evt-handler  <  24> send packet: $jThreadExtendedInfo:#b9
dbg.evt-handler  <   4> read packet: $#00
Process 1 stopped
* thread #1, stop reason = signal SIGTRAP
    frame #0: 0x55550000 test.elf`main at test.c:1:12
-> 1   	int main() {
   2   	    int x = 4;
   3   	    int y = 3;
   4
   5   	    x += 1;
   6   	    y += 3;
   7
(lldb) register read
lldb-10          <   6> send packet: $p0#a0
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <   6> send packet: $p1#a1
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <   6> send packet: $p2#a2
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <   6> send packet: $p3#a3
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <   6> send packet: $p4#a4
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <   6> send packet: $p5#a5
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <   6> send packet: $p6#a6
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <   6> send packet: $p7#a7
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <   6> send packet: $p8#a8
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <   6> send packet: $p9#a9
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <   6> send packet: $pa#d1
lldb-10          <   7> read packet: $0*$#7e
lldb-10          <   6> send packet: $pc#d3
lldb-10          <   7> read packet: $0*$#7e
General Purpose Registers:
        r0 = 0x00000000
        r1 = 0x00000000
        r2 = 0x00000000
        r3 = 0x00000000
        r4 = 0x00000000
        r5 = 0x00000000
        r6 = 0x00000000
        r7 = 0x00000000
        r8 = 0x00000000
        r9 = 0x00000000
       r10 = 0x00000000
       r11 = 0x00000000
       r12 = 0x00000000
        sp = 0x10000000
        lr = 0x12345678
        pc = 0x55550000  test.elf`main at test.c:1:12
      cpsr = 0x00000010
```
</details>