### PR TITLE
Add support for qThreadExtraInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Of course, most use-cases will want to support additional debugging features as 
     -   Access the remote target's filesystem to read/write file
     -   Can be used to automatically read the remote executable on attach (using `ExecFile`)
 -   Read auxiliary vector (`info auxv`)
+-   Extra thread info (`info threads`)
 
 _Note:_ GDB features are implemented on an as-needed basis by `gdbstub`'s contributors. If there's a missing GDB feature that you'd like `gdbstub` to implement, please file an issue and/or open a PR!
 

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -92,6 +92,7 @@ macro_rules! commands {
                     fn support_reverse_step(&mut self) -> Option<()>;
                     fn support_reverse_cont(&mut self) -> Option<()>;
                     fn support_x_upcase_packet(&mut self) -> Option<()>;
+                    fn support_thread_extra_info(&mut self) -> Option<()>;
                 }
 
                 impl<T: Target> Hack for T {
@@ -144,6 +145,14 @@ macro_rules! commands {
                             Some(())
                         } else {
                             None
+                        }
+                    }
+
+                    fn support_thread_extra_info(&mut self) -> Option<()> {
+                        use crate::target::ext::base::BaseOps;
+                        match self.base_ops() {
+                            BaseOps::SingleThread(_) => None,
+                            BaseOps::MultiThread(ops) => ops.support_thread_extra_info().map(drop),
                         }
                     }
                 }
@@ -287,5 +296,9 @@ commands! {
 
     catch_syscalls use 'a {
         "QCatchSyscalls" => _QCatchSyscalls::QCatchSyscalls<'a>,
+    }
+
+    thread_extra_info use 'a {
+        "qThreadExtraInfo" => _qThreadExtraInfo::qThreadExtraInfo<'a>,
     }
 }

--- a/src/protocol/commands/_qThreadExtraInfo.rs
+++ b/src/protocol/commands/_qThreadExtraInfo.rs
@@ -1,0 +1,32 @@
+use super::prelude::*;
+
+use crate::protocol::common::thread_id::ThreadId;
+use crate::protocol::ConcreteThreadId;
+
+#[derive(Debug)]
+pub struct qThreadExtraInfo<'a> {
+    pub id: ConcreteThreadId,
+
+    pub buf: &'a mut [u8],
+}
+
+impl<'a> ParseCommand<'a> for qThreadExtraInfo<'a> {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let (buf, body_range) = buf.into_raw_buf();
+        let body = buf.get(body_range.start..body_range.end)?;
+
+        if body.is_empty() {
+            return None;
+        }
+
+        match body {
+            [b',', body @ ..] => {
+                let id = ConcreteThreadId::try_from(ThreadId::try_from(body).ok()?).ok()?;
+
+                Some(qThreadExtraInfo { id, buf })
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/protocol/common/thread_id.rs
+++ b/src/protocol/common/thread_id.rs
@@ -125,3 +125,37 @@ impl TryFrom<ThreadId> for SpecificThreadId {
         })
     }
 }
+
+/// Like [`ThreadId`], without the `Any`, or `All` variants.
+#[derive(Debug, Copy, Clone)]
+pub struct ConcreteThreadId {
+    /// Process ID (may or may not be present).
+    pub pid: Option<NonZeroUsize>,
+    /// Thread ID.
+    pub tid: NonZeroUsize,
+}
+
+impl TryFrom<ThreadId> for ConcreteThreadId {
+    type Error = ();
+
+    fn try_from(thread: ThreadId) -> Result<ConcreteThreadId, ()> {
+        Ok(ConcreteThreadId {
+            pid: match thread.pid {
+                None => None,
+                Some(id_kind) => Some(id_kind.try_into()?),
+            },
+            tid: thread.tid.try_into()?,
+        })
+    }
+}
+
+impl TryFrom<IdKind> for NonZeroUsize {
+    type Error = ();
+
+    fn try_from(value: IdKind) -> Result<NonZeroUsize, ()> {
+        match value {
+            IdKind::WithId(v) => Ok(v),
+            _ => Err(()),
+        }
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -11,7 +11,7 @@ mod response_writer;
 pub(crate) mod commands;
 pub(crate) mod recv_packet;
 
-pub(crate) use common::thread_id::{IdKind, SpecificIdKind, SpecificThreadId};
+pub(crate) use common::thread_id::{ConcreteThreadId, IdKind, SpecificIdKind, SpecificThreadId};
 pub(crate) use packet::Packet;
 pub(crate) use response_writer::{Error as ResponseWriterError, ResponseWriter};
 

--- a/src/stub/core_impl.rs
+++ b/src/stub/core_impl.rs
@@ -35,6 +35,7 @@ mod reverse_exec;
 mod section_offsets;
 mod single_register_access;
 mod target_xml;
+mod thread_extra_info;
 mod x_upcase_packet;
 
 pub(crate) use resume::FinishExecStatus;
@@ -207,6 +208,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Command::HostIo(cmd) => self.handle_host_io(res, target, cmd),
             Command::ExecFile(cmd) => self.handle_exec_file(res, target, cmd),
             Command::Auxv(cmd) => self.handle_auxv(res, target, cmd),
+            Command::ThreadExtraInfo(cmd) => self.handle_thread_extra_info(res, target, cmd),
             // in the worst case, the command could not be parsed...
             Command::Unknown(cmd) => {
                 // HACK: if the user accidentally sends a resume command to a

--- a/src/stub/core_impl/thread_extra_info.rs
+++ b/src/stub/core_impl/thread_extra_info.rs
@@ -1,0 +1,37 @@
+use super::prelude::*;
+use crate::protocol::commands::ext::ThreadExtraInfo;
+use crate::target::ext::base::BaseOps;
+
+impl<T: Target, C: Connection> GdbStubImpl<T, C> {
+    pub(crate) fn handle_thread_extra_info<'a>(
+        &mut self,
+        res: &mut ResponseWriter<'_, C>,
+        target: &mut T,
+        command: ThreadExtraInfo<'a>,
+    ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
+        let ops = match target.base_ops() {
+            BaseOps::SingleThread(_) => return Ok(HandlerStatus::Handled),
+            BaseOps::MultiThread(ops) => match ops.support_thread_extra_info() {
+                Some(ops) => ops,
+                None => return Ok(HandlerStatus::Handled),
+            },
+        };
+
+        crate::__dead_code_marker!("thread_extra_info", "impl");
+
+        let handler_status = match command {
+            ThreadExtraInfo::qThreadExtraInfo(info) => {
+                let size = ops
+                    .thread_extra_info(info.id.tid, info.buf)
+                    .map_err(Error::TargetError)?;
+                let data = info.buf.get(..size).ok_or(Error::PacketBufferOverflow)?;
+
+                res.write_hex_buf(data)?;
+
+                HandlerStatus::Handled
+            }
+        };
+
+        Ok(handler_status)
+    }
+}

--- a/src/target/ext/base/multithread.rs
+++ b/src/target/ext/base/multithread.rs
@@ -102,6 +102,14 @@ pub trait MultiThreadBase: Target {
     fn support_resume(&mut self) -> Option<MultiThreadResumeOps<'_, Self>> {
         None
     }
+
+    /// Support for providing thread extra information.
+    #[inline(always)]
+    fn support_thread_extra_info(
+        &mut self,
+    ) -> Option<crate::target::ext::thread_extra_info::ThreadExtraInfoOps<'_, Self>> {
+        None
+    }
 }
 
 /// Target extension - support for resuming multi threaded targets.

--- a/src/target/ext/mod.rs
+++ b/src/target/ext/mod.rs
@@ -269,3 +269,4 @@ pub mod memory_map;
 pub mod monitor_cmd;
 pub mod section_offsets;
 pub mod target_description_xml_override;
+pub mod thread_extra_info;

--- a/src/target/ext/thread_extra_info.rs
+++ b/src/target/ext/thread_extra_info.rs
@@ -1,0 +1,22 @@
+//! Provide extra information for a thread
+use crate::common::Tid;
+use crate::target::Target;
+
+/// Target Extension - Provide extra information for a thread
+pub trait ThreadExtraInfo: Target {
+    /// Provide extra information about a thread
+    ///
+    /// GDB queries for extra information for a thread as part of the
+    /// `info threads` command.  This function will be called once
+    /// for each active thread.
+    ///
+    /// A string can be copied into `buf` that will then be displayed
+    /// to the client.  The string is displayed as `(value)`, such as:
+    ///
+    /// `Thread 1.1 (value)`
+    ///
+    /// Return the number of bytes written into `buf`.
+    fn thread_extra_info(&self, tid: Tid, buf: &mut [u8]) -> Result<usize, Self::Error>;
+}
+
+define_ext!(ThreadExtraInfoOps, ThreadExtraInfo);


### PR DESCRIPTION
### Description

Add a new sub-IDET for `MultiThreadBase` to respond with extra information about a thread.

Closes #104 

### API Stability

- [X] This PR does not require a breaking API change

### Checklist

- Implementation
  - [X] `cargo build` compiles without `errors` or `warnings`
  - [X] `cargo clippy` runs without `errors` or `warnings`
  - [X] `cargo fmt` was run
  - [X] All tests pass
- Documentation
  - [X] rustdoc + approprate inline code comments
  - [X] Updated CHANGELOG.md
  - [X] (if appropriate) Added feature to "Debugging Features" in README.md
- _If implementing a new protocol extension IDET_
  - [X] Included a basic sample implementation in `examples/armv4t`
  - [X] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [X] Confirmed that IDET can be optimized away (using `./scripts/test_dead_code_elim.sh` and/or `./example_no_std/check_size.sh`)

### Validation

<details>
<summary>GDB output</summary>

```
(gdb) info thread
  Id   Target Id            Frame 
* 1    Thread 1.1 (CPU Cpu) 0x55550000 in ?? ()
  2    Thread 1.2 (CPU Cop) 0x55550000 in ?? ()
(gdb) 
```

</details>

<details>
<summary>armv4t output</summary>

```
 TRACE gdbstub::protocol::recv_packet     > <-- $qThreadExtraInfo,p1.1#85
 TRACE gdbstub::protocol::response_writer > --> $43505520437075#d2
 TRACE gdbstub::protocol::recv_packet     > <-- $qThreadExtraInfo,p1.2#86
 TRACE gdbstub::protocol::response_writer > --> $43505520436f70#02
```
</details>
