### PR TITLE
SingleRegisterAccess: Support unavailable regs

### DIFF
--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -314,6 +314,7 @@ impl target::ext::base::single_register_access::SingleRegisterAccess<()> for Emu
                 );
                 Ok(buf.len())
             }
+            custom_arch::ArmCoreRegIdCustom::Unavailable => Ok(0),
         }
     }
 
@@ -341,7 +342,8 @@ impl target::ext::base::single_register_access::SingleRegisterAccess<()> for Emu
                 Ok(())
             }
             // ignore writes
-            custom_arch::ArmCoreRegIdCustom::Time => Ok(()),
+            custom_arch::ArmCoreRegIdCustom::Unavailable
+            | custom_arch::ArmCoreRegIdCustom::Time => Ok(()),
         }
     }
 }
@@ -460,6 +462,8 @@ mod custom_arch {
         // not sent as part of `struct ArmCoreRegsCustom`, and only accessible via the single
         // register read/write functions
         Time,
+        /// This pseudo-register is valid but never available
+        Unavailable,
     }
 
     impl RegId for ArmCoreRegIdCustom {
@@ -467,6 +471,7 @@ mod custom_arch {
             let reg = match id {
                 26 => Self::Custom,
                 27 => Self::Time,
+                28 => Self::Unavailable,
                 _ => {
                     let (reg, size) = ArmCoreRegId::from_raw_id(id)?;
                     return Some((Self::Core(reg), size));
@@ -530,6 +535,7 @@ mod custom_arch {
                         ArmCoreRegIdCustom::Core(ArmCoreRegId::Fps) => "padding",
                         ArmCoreRegIdCustom::Core(ArmCoreRegId::Cpsr) => "cpsr",
                         ArmCoreRegIdCustom::Custom => "custom",
+                        ArmCoreRegIdCustom::Unavailable => "Unavailable",
                         _ => "unknown",
                     };
                     let encoding = match r {
@@ -537,6 +543,7 @@ mod custom_arch {
                         ArmCoreRegIdCustom::Core(ArmCoreRegId::Sp)
                         | ArmCoreRegIdCustom::Core(ArmCoreRegId::Pc)
                         | ArmCoreRegIdCustom::Core(ArmCoreRegId::Cpsr)
+                        | ArmCoreRegIdCustom::Unavailable
                         | ArmCoreRegIdCustom::Custom => Encoding::Uint,
                         _ => Encoding::Vector,
                     };
@@ -545,6 +552,7 @@ mod custom_arch {
                         ArmCoreRegIdCustom::Core(ArmCoreRegId::Sp)
                         | ArmCoreRegIdCustom::Core(ArmCoreRegId::Pc)
                         | ArmCoreRegIdCustom::Core(ArmCoreRegId::Cpsr)
+                        | ArmCoreRegIdCustom::Unavailable
                         | ArmCoreRegIdCustom::Custom => Format::Hex,
                         _ => Format::VectorUInt8,
                     };
@@ -555,6 +563,7 @@ mod custom_arch {
                         ArmCoreRegIdCustom::Core(ArmCoreRegId::Sp)
                         | ArmCoreRegIdCustom::Core(ArmCoreRegId::Pc)
                         | ArmCoreRegIdCustom::Core(ArmCoreRegId::Cpsr)
+                        | ArmCoreRegIdCustom::Unavailable
                         | ArmCoreRegIdCustom::Custom => "General Purpose Registers",
                         _ => "Floating Point Registers",
                     };

--- a/examples/armv4t/gdb/target_description_xml_override.rs
+++ b/examples/armv4t/gdb/target_description_xml_override.rs
@@ -96,5 +96,13 @@ const EXTRA_XML: &str = r#"
         this register via the 'p' and 'P' packets respectively
     -->
     <reg name="time" bitsize="32" type="uint32"/>
+
+    <!--
+        pseudo-register that is always unavailable.
+
+        it is supposed to be reported as 'x'-ed bytes in replies to 'p' packets
+        and shown by the GDB client as "<unavailable>".
+    -->
+    <reg name="unavailable" bitsize="32" type="uint32"/>
 </feature>
 "#;

--- a/src/target/ext/base/single_register_access.rs
+++ b/src/target/ext/base/single_register_access.rs
@@ -29,7 +29,8 @@ where
     /// Implementations should write the value of the register using target's
     /// native byte order in the buffer `buf`.
     ///
-    /// Return the number of bytes written into `buf`.
+    /// Return the number of bytes written into `buf` or `0` if the register is
+    /// valid but unavailable.
     ///
     /// If the requested register could not be accessed, an appropriate
     /// non-fatal error should be returned.


### PR DESCRIPTION
### Description

Make gdbstub report to the GDB client the state of an unavailable (but valid) register by following the [registers packet protocol](https://sourceware.org/gdb/onlinedocs/gdb/Packets.html#read-registers-packet):

> [...] the stub may also return a string of literal `x`s in place of
> the register data digits, to indicate that the corresponding register
> has not been collected, thus its value is unavailable.

### API Stability

- [x] This PR does not require a breaking API change but it would probably benefit from introducing an `Option` instead of the C-ish approach of giving special meaning to `0`

### Checklist

- Documentation
  - [x] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [x] (if appropriate) Added feature to "Debugging Features" in README.md
- Validation
  - [x] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [x] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below

### Validation

<details>
<summary>GDB output</summary>

```
(gdb) info registers SPSR_EL3
SPSR_EL3       <unavailable>
```

</details>

<details>
<summary>examples/armv4t</summary>

```
$ RUST_LOG=trace cargo run --example armv4t
   Compiling gdbstub v0.6.2 (/usr/local/google/home/ptosi/src/gdbstub)
    Finished dev [unoptimized + debuginfo] target(s) in 1.76s
     Running `target/debug/examples/armv4t`
loading section ".text" into memory from [0x55550000..0x55550078]
Setting PC to 0x55550000
Waiting for a GDB connection on "127.0.0.1:9001"...
```
then
```
(gdb) target remote localhost:9001
```
makes the GDB client learn about the `Unavailable` register through the XML:
```
Debugger connected from 127.0.0.1:33718
 TRACE gdbstub::protocol::recv_packet > <-- +
 TRACE gdbstub::protocol::recv_packet > <-- $qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;no-resumed+;xmlRegisters=i386#6a
 TRACE gdbstub::protocol::response_writer > --> $PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;ReverseContinue+;ReverseStep+;QDisableRandomization+;QEnvironmentHexEncoded+;QEnvironmentUnset+;QEnvironmentReset+;QStartupWithShell+;QSetWorkingDir+;swbreak+;hwbreak+;QCatchSyscalls+;qXfer:features:read+;qXfer:memory-map:read+;qXfer:exec-file:read+;qXfer:auxv:read+#fa

[...]

 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:extra.xml:0,ffb#16
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<feature name="custom-armv4t-extension">

[...]

    <!--
        pseudo-register that is always unavailable.

        it is supposed to be reported as 'x'-ed bytes in replies to 'p' packets
        and shown by the GDB client as "<unavailable>".
    -->
    <reg name="unavailable" bitsize="32" type="uint32"/>
</feature>#7d
```
Then requesting
```
(gdb) info registers unavailable
```
shows the appropriate request (`0x1c` = 28) and response (`xxxxxxxx` = 4 unknown bytes):
```
 TRACE gdbstub::protocol::recv_packet     > <-- $p1c#04
 TRACE gdbstub::protocol::response_writer > --> $xxxxxxxx#c6
```
which the GDB client reports:
```
(gdb) info registers unavailable
unavailable    <unavailable>
```
</details>

<details>
<summary>Before/After `./example_no_std/check_size.sh` output</summary>

### Before

```
File  .text    Size             Crate Name
2.9%  72.7% 10.9KiB         [Unknown] main
0.2%   4.6%    706B           gdbstub gdbstub::stub::state_machine::GdbStubStateMachineInner<gdbstub::stub::state_machine::state::Running,T,C>::report_stop
0.1%   2.0%    310B           gdbstub gdbstub::protocol::commands::breakpoint::BasicBreakpoint::from_slice
0.1%   1.7%    268B           gdbstub gdbstub::protocol::common::hex::decode_hex_buf
0.1%   1.7%    259B           gdbstub <gdbstub::protocol::common::thread_id::ThreadId as core::convert::TryFrom<&[u8]>>::try_from
0.1%   1.6%    253B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_specific_thread_id
0.1%   1.6%    249B           gdbstub gdbstub::stub::core_impl::resume::<impl gdbstub::stub::core_impl::GdbStubImpl<T,C>>::write_stop_common
0.1%   1.3%    207B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write
0.0%   0.8%    130B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::inner_write
0.0%   0.8%    127B           gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.7%    114B           gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.7%    111B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::flush
0.0%   0.7%    104B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.7%    103B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.7%    102B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_addrs
0.0%   0.6%     96B           gdbstub <gdbstub::protocol::common::thread_id::IdKind as core::convert::TryFrom<&[u8]>>::try_from
0.0%   0.6%     93B         [Unknown] __libc_csu_init
0.0%   0.6%     88B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_hex
0.0%   0.5%     79B           gdbstub <usize as gdbstub::internal::be_bytes::BeBytes>::from_be_bytes
0.0%   0.5%     77B           gdbstub <u32 as gdbstub::internal::be_bytes::BeBytes>::from_be_bytes
0.0%   0.4%     65B      gdbstub_arch <gdbstub_arch::arm::reg::arm_core::ArmCoreRegs as gdbstub::arch::Registers>::gdb_deserialize
0.0%   0.4%     65B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_addrs
0.0%   0.4%     65B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_registers
0.0%   0.4%     65B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_registers
0.0%   0.4%     57B compiler_builtins __rust_probestack
0.0%   0.3%     50B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::set_resume_action_continue
0.0%   0.3%     50B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::clear_resume_actions
0.0%   0.3%     50B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::resume
0.0%   0.3%     43B         [Unknown] _start
0.0%   0.0%      6B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>::remove_sw_breakpoint
0.0%   0.0%      6B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>::add_sw_breakpoint
0.0%   0.0%      1B         [Unknown] __libc_csu_fini
0.0%   0.0%      0B                   And 0 smaller methods. Use -n N to show more.
4.1% 100.0% 15.0KiB                   .text section size, the file size is 369.6KiB
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     792
.note.gnu.property      32     824
.note.gnu.build-id      36     856
.note.ABI-tag           32     892
.gnu.hash               36     928
.dynsym                360     968
.dynstr                193    1328
.gnu.version            30    1522
.gnu.version_r          48    1552
.rela.dyn              408    1600
.init                   23    4096
.plt                    16    4128
.plt.got                 8    4144
.text                15345    4160
.fini                    9   19508
.rodata                914   20480
.eh_frame_hdr          284   21396
.eh_frame             1472   21680
.init_array              8   28072
.fini_array              8   28080
.dynamic               448   28088
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                30       0
Total                19920
```

### After

```
File  .text    Size             Crate Name
2.9%  72.7% 10.9KiB         [Unknown] main
0.2%   4.6%    706B           gdbstub gdbstub::stub::state_machine::GdbStubStateMachineInner<gdbstub::stub::state_machine::state::Running,T,C>::report_stop
0.1%   2.0%    310B           gdbstub gdbstub::protocol::commands::breakpoint::BasicBreakpoint::from_slice
0.1%   1.7%    268B           gdbstub gdbstub::protocol::common::hex::decode_hex_buf
0.1%   1.7%    259B           gdbstub <gdbstub::protocol::common::thread_id::ThreadId as core::convert::TryFrom<&[u8]>>::try_from
0.1%   1.6%    253B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_specific_thread_id
0.1%   1.6%    249B           gdbstub gdbstub::stub::core_impl::resume::<impl gdbstub::stub::core_impl::GdbStubImpl<T,C>>::write_stop_common
0.1%   1.3%    207B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write
0.0%   0.8%    130B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::inner_write
0.0%   0.8%    127B           gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.7%    114B           gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.7%    111B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::flush
0.0%   0.7%    104B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.7%    103B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.7%    102B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_addrs
0.0%   0.6%     96B           gdbstub <gdbstub::protocol::common::thread_id::IdKind as core::convert::TryFrom<&[u8]>>::try_from
0.0%   0.6%     93B         [Unknown] __libc_csu_init
0.0%   0.6%     88B           gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_hex
0.0%   0.5%     79B           gdbstub <usize as gdbstub::internal::be_bytes::BeBytes>::from_be_bytes
0.0%   0.5%     77B           gdbstub <u32 as gdbstub::internal::be_bytes::BeBytes>::from_be_bytes
0.0%   0.4%     65B      gdbstub_arch <gdbstub_arch::arm::reg::arm_core::ArmCoreRegs as gdbstub::arch::Registers>::gdb_deserialize
0.0%   0.4%     65B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_addrs
0.0%   0.4%     65B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_registers
0.0%   0.4%     65B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_registers
0.0%   0.4%     57B compiler_builtins __rust_probestack
0.0%   0.3%     50B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::set_resume_action_continue
0.0%   0.3%     50B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::clear_resume_actions
0.0%   0.3%     50B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::resume
0.0%   0.3%     43B         [Unknown] _start
0.0%   0.0%      6B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>::remove_sw_breakpoint
0.0%   0.0%      6B    gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>::add_sw_breakpoint
0.0%   0.0%      1B         [Unknown] __libc_csu_fini
0.0%   0.0%      0B                   And 0 smaller methods. Use -n N to show more.
4.1% 100.0% 15.0KiB                   .text section size, the file size is 369.6KiB
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     792
.note.gnu.property      32     824
.note.gnu.build-id      36     856
.note.ABI-tag           32     892
.gnu.hash               36     928
.dynsym                360     968
.dynstr                193    1328
.gnu.version            30    1522
.gnu.version_r          48    1552
.rela.dyn              408    1600
.init                   23    4096
.plt                    16    4128
.plt.got                 8    4144
.text                15345    4160
.fini                    9   19508
.rodata                914   20480
.eh_frame_hdr          284   21396
.eh_frame             1472   21680
.init_array              8   28072
.fini_array              8   28080
.dynamic               448   28088
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                30       0
Total                19920
```

</details>