### PR TITLE
check_size.sh: Allow running script from other dirs

### DIFF
--- a/example_no_std/check_size.sh
+++ b/example_no_std/check_size.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+cd "$(dirname "$(realpath $0)")"
+
 # checks the size of the resulting --release level binary (that's been stripped)
 
 cargo build --release


### PR DESCRIPTION
### Description

As shown in https://github.com/daniel5151/gdbstub/pull/107#issuecomment-1191802780, it was easy to misinterpret the instructions as running the script from the root of the directory (which would break). Make it possible to do so.