### PR TITLE
Proof of concept to replace `run_blocking` with something easier to use

### DIFF
--- a/examples/armv4t/emu.rs
+++ b/examples/armv4t/emu.rs
@@ -1,18 +1,14 @@
 use armv4t_emu::{reg, Cpu, ExampleMem, Memory, Mode};
+use gdbstub::common::Signal;
+use gdbstub::stub::run::RunTarget;
+use gdbstub::stub::SingleThreadStopReason;
+use gdbstub::target::ext::breakpoints;
+use gdbstub::target::Target;
 
 use crate::mem_sniffer::{AccessKind, MemSniffer};
 use crate::DynResult;
 
 const HLE_RETURN_ADDR: u32 = 0x12345678;
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Event {
-    DoneStep,
-    Halted,
-    Break,
-    WatchWrite(u32),
-    WatchRead(u32),
-}
 
 pub enum ExecMode {
     Step,
@@ -94,9 +90,12 @@ impl Emu {
         self.cpu.reg_set(Mode::User, reg::PC, self.start_addr);
         self.cpu.reg_set(Mode::User, reg::CPSR, 0x10);
     }
+}
 
-    /// single-step the interpreter
-    pub fn step(&mut self) -> Option<Event> {
+impl RunTarget for Emu {
+    type StopReason = SingleThreadStopReason<u32>;
+
+    fn step(&mut self) -> Result<Option<Self::StopReason>, <Self as Target>::Error> {
         let mut hit_watchpoint = None;
 
         let mut sniffer = MemSniffer::new(&mut self.mem, &self.watchpoints, |access| {
@@ -110,73 +109,42 @@ impl Emu {
             let fixup = if self.cpu.thumb_mode() { 2 } else { 4 };
             self.cpu.reg_set(Mode::User, reg::PC, pc - fixup);
 
-            return Some(match access.kind {
-                AccessKind::Read => Event::WatchRead(access.addr),
-                AccessKind::Write => Event::WatchWrite(access.addr),
-            });
+            return Ok(Some(match access.kind {
+                AccessKind::Read => SingleThreadStopReason::Watch {
+                    tid: (),
+                    kind: breakpoints::WatchKind::Read,
+                    addr: access.addr,
+                },
+                AccessKind::Write => SingleThreadStopReason::Watch {
+                    tid: (),
+                    kind: breakpoints::WatchKind::Write,
+                    addr: access.addr,
+                },
+            }));
         }
 
         if self.breakpoints.contains(&pc) {
-            return Some(Event::Break);
+            return Ok(Some(SingleThreadStopReason::SwBreak(())));
         }
 
         if pc == HLE_RETURN_ADDR {
-            return Some(Event::Halted);
+            return Ok(Some(SingleThreadStopReason::Terminated(Signal::SIGSTOP)));
         }
 
-        None
-    }
-
-    /// run the emulator in accordance with the currently set `ExecutionMode`.
-    ///
-    /// since the emulator runs in the same thread as the GDB loop, the emulator
-    /// will use the provided callback to poll the connection for incoming data
-    /// every 1024 steps.
-    pub fn run(&mut self, mut poll_incoming_data: impl FnMut() -> bool) -> RunEvent {
         match self.exec_mode {
-            ExecMode::Step => RunEvent::Event(self.step().unwrap_or(Event::DoneStep)),
-            ExecMode::Continue => {
-                let mut cycles = 0;
-                loop {
-                    if cycles % 1024 == 0 {
-                        // poll for incoming data
-                        if poll_incoming_data() {
-                            break RunEvent::IncomingData;
-                        }
-                    }
-                    cycles += 1;
-
-                    if let Some(event) = self.step() {
-                        break RunEvent::Event(event);
-                    };
-                }
-            }
-            // just continue, but with an extra PC check
+            ExecMode::Step => Ok(Some(SingleThreadStopReason::DoneStep)),
+            ExecMode::Continue => Ok(None),
             ExecMode::RangeStep(start, end) => {
-                let mut cycles = 0;
-                loop {
-                    if cycles % 1024 == 0 {
-                        // poll for incoming data
-                        if poll_incoming_data() {
-                            break RunEvent::IncomingData;
-                        }
-                    }
-                    cycles += 1;
-
-                    if let Some(event) = self.step() {
-                        break RunEvent::Event(event);
-                    };
-
-                    if !(start..end).contains(&self.cpu.reg_get(self.cpu.mode(), reg::PC)) {
-                        break RunEvent::Event(Event::DoneStep);
-                    }
+                if (start..end).contains(&pc) {
+                    Ok(None)
+                } else {
+                    Ok(Some(SingleThreadStopReason::DoneStep))
                 }
             }
         }
     }
-}
 
-pub enum RunEvent {
-    IncomingData,
-    Event(Event),
+    fn interrupt_received(&mut self) -> Result<Option<Self::StopReason>, <Self as Target>::Error> {
+        Ok(Some(SingleThreadStopReason::Signal(Signal::SIGINT)))
+    }
 }

--- a/src/stub/mod.rs
+++ b/src/stub/mod.rs
@@ -11,6 +11,7 @@ mod core_impl;
 mod error;
 mod stop_reason;
 
+pub mod run;
 pub mod state_machine;
 
 pub use builder::{GdbStubBuilder, GdbStubBuilderError};

--- a/src/stub/run.rs
+++ b/src/stub/run.rs
@@ -1,0 +1,74 @@
+//! TODO
+
+use crate::{conn::ConnectionExt, target::Target};
+
+use super::{
+    state_machine::GdbStubStateMachine, DisconnectReason, GdbStub, GdbStubError, IntoStopReason,
+};
+
+/// TODO
+pub trait RunTarget: Target + Sized {
+    /// TODO
+    type StopReason: IntoStopReason<Self>;
+
+    /// TODO
+    fn step(&mut self) -> Result<Option<Self::StopReason>, <Self as Target>::Error>;
+
+    /// TODO
+    fn interrupt_received(&mut self) -> Result<Option<Self::StopReason>, <Self as Target>::Error>;
+
+    /// TODO
+    fn step_loop_count(&self) -> usize {
+        1024
+    }
+}
+
+/// TODO
+pub fn run<C: ConnectionExt, T: RunTarget>(
+    connection: C,
+    target: &mut T,
+) -> Result<DisconnectReason, GdbStubError<<T as Target>::Error, C::Error>> {
+    let gdb = GdbStub::new(connection);
+    let mut gdb = gdb.run_state_machine(target)?;
+    loop {
+        gdb = match gdb {
+            GdbStubStateMachine::Idle(mut gdb) => {
+                // needs more data, so perform a blocking read on the connection
+                let byte = gdb
+                    .borrow_conn()
+                    .read()
+                    .map_err(GdbStubError::ConnectionRead)?;
+                gdb.incoming_data(target, byte)?
+            }
+
+            GdbStubStateMachine::Disconnected(gdb) => {
+                // run_blocking keeps things simple, and doesn't expose a way to re-use the
+                // state machine
+                break Ok(gdb.get_reason());
+            }
+
+            GdbStubStateMachine::CtrlCInterrupt(gdb) => {
+                let maybe_stop_reason = target
+                    .interrupt_received()
+                    .map_err(GdbStubError::TargetError)?;
+                gdb.interrupt_handled(target, maybe_stop_reason)?
+            }
+
+            GdbStubStateMachine::Running(mut gdb) => {
+                let conn = gdb.borrow_conn();
+                'outer: loop {
+                    for _ in 0..target.step_loop_count() {
+                        let maybe_stop_reason = target.step().map_err(GdbStubError::TargetError)?;
+                        if let Some(stop_reason) = maybe_stop_reason {
+                            break 'outer gdb.report_stop(target, stop_reason)?;
+                        }
+                    }
+                    if conn.peek().map_err(GdbStubError::ConnectionRead)?.is_some() {
+                        let data = conn.read().map_err(GdbStubError::ConnectionRead)?;
+                        break gdb.incoming_data(target, data)?;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a proof of concept to replace the `run_blocking` APIs with something that is easier to implement and use. @daniel5151 If you like the idea I’ll finish up the PR.

### Description

This change is motivated by me trying to implement a run loop for my own target. I took a look at the armv4t and ended up copying the following code to get a working example for my target:
* `EmuGdbEventLoop` with `impl BlockingEventLoop`
* `emu::Event`
* `emu::ExecMode`
* `emu::RunEvent`
* `emu::Emu::step()`
* `emu::Emu::run()`

After I familiarized myself with the code I got it to work by adapting my copies of `step()` and `run()`.

The new `run` API aims to make implementing a run loop easier. The updated example contains less boilerplate code (`EmuGdbEventLoop`, `Event`, `RunEvent`, `Emu::run()`) that has to be copied. Instead, only the `TargetRun` trait has to be implemented with the help of `enum::ExecMode`.

What we loose with the new API is more fine grained control over when to poll the connection. This is only useful targets that run in a different thread and only if the mechanism to select when to interrupt the target is much faster than calling `Connection::peek()`. If necessary, it should be possible to also add the machinery for this use case to this PR.


### API Stability

- [ ] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

### Checklist

<!-- CI takes care of a lot of things, but there are some things that have yet to be automated -->

- Documentation
  - [ ] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [ ] (if appropriate) Added feature to "Debugging Features" in README.md
- Validation
  - [ ] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [ ] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below
- _If implementing a new protocol extension IDET_
  - [ ] Included a basic sample implementation in `examples/armv4t`
  - [ ] IDET can be optimized out (confirmed via `./example_no_std/check_size.sh`)
  - [ ] **OR** implementation requires introducing non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [ ] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- Oh, and if you're integrating `gdbstub` in an open-source project, do consider updating the README.md's "Real World Examples" section to link back to your project! -->

### Validation

<!-- example output, from https://github.com/daniel5151/gdbstub/pull/54 -->

<details>
<summary>GDB output</summary>

```
!!!!! EXAMPLE OUTPUT !!!!!

(gdb) info mem
Using memory regions provided by the target.
Num Enb Low Addr   High Addr  Attrs
0   y  	0x00000000 0x100000000 rw nocache
```

</details>

<details>
<summary>armv4t output</summary>

```
!!!!! EXAMPLE OUTPUT !!!!!

    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/examples/armv4t`
loading section ".text" into memory from [0x55550000..0x55550078]
Setting PC to 0x55550000
Waiting for a GDB connection on "127.0.0.1:9001"...
Debugger connected from 127.0.0.1:37142
 TRACE gdbstub::gdbstub_impl > <-- +
 TRACE gdbstub::gdbstub_impl > <-- $qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;no-resumed+;xmlRegisters=i386#6a
 TRACE gdbstub::protocol::response_writer > --> $PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;ReverseContinue+;ReverseStep+;QDisableRandomization+;QEnvironmentHexEncoded+;QEnvironmentUnset+;QEnvironmentReset+;QStartupWithShell+;QSetWorkingDir+;swbreak+;hwbreak+;qXfer:features:read+;qXfer:memory-map:read+#e4
 TRACE gdbstub::gdbstub_impl              > <-- +
 TRACE gdbstub::gdbstub_impl              > <-- $vMustReplyEmpty#3a
 INFO  gdbstub::gdbstub_impl              > Unknown command: vMustReplyEmpty
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::gdbstub_impl              > <-- +
 TRACE gdbstub::gdbstub_impl              > <-- $QStartNoAckMode#b0
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::gdbstub_impl              > <-- +
 TRACE gdbstub::gdbstub_impl              > <-- $Hgp0.0#ad
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::gdbstub_impl              > <-- $qXfer:features:read:target.xml:0,ffb#79
 TRACE gdbstub::protocol::response_writer > --> $l<target version="1.0"><!-- custom override string --><architecture>armv4t</architecture></target>#bb
 TRACE gdbstub::gdbstub_impl              > <-- $qTStatus#49
 INFO  gdbstub::gdbstub_impl              > Unknown command: qTStatus
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::gdbstub_impl              > <-- $?#3f
 TRACE gdbstub::protocol::response_writer > --> $S05#b8
 TRACE gdbstub::gdbstub_impl              > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::gdbstub_impl              > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::gdbstub_impl              > <-- $qAttached:1#fa
GDB queried if it was attached to a process with PID 1
 TRACE gdbstub::protocol::response_writer > --> $1#31
 TRACE gdbstub::gdbstub_impl              > <-- $Hc-1#09
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::gdbstub_impl              > <-- $qC#b4
 INFO  gdbstub::gdbstub_impl              > Unknown command: qC
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::gdbstub_impl              > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000107856341200005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx10000000#66
 TRACE gdbstub::gdbstub_impl              > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::gdbstub_impl              > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::gdbstub_impl              > <-- $qXfer:memory-map:read::0,ffb#18
 TRACE gdbstub::protocol::response_writer > --> $l<?xml version="1.0"?>
<!DOCTYPE memory-map
    PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN"
            "http://sourceware.org/gdb/gdb-memory-map.dtd">
<memory-map>
    <memory type="ram" start="0x0" length="0x100000000"/>
</memory-map>#75
 TRACE gdbstub::gdbstub_impl              > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::gdbstub_impl              > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::gdbstub_impl              > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::gdbstub_impl              > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::gdbstub_impl              > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::gdbstub_impl              > <-- $m5554fffe,2#35
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::gdbstub_impl              > <-- $m5554fffc,2#33
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::gdbstub_impl              > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::gdbstub_impl              > <-- $m5554fffe,2#35
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::gdbstub_impl              > <-- $m5554fffc,2#33
 TRACE gdbstub::protocol::response_writer > --> $0000#7a
 TRACE gdbstub::gdbstub_impl              > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::gdbstub_impl              > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::gdbstub_impl              > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::gdbstub_impl              > <-- $m5554fffc,4#35
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
 TRACE gdbstub::gdbstub_impl              > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::gdbstub_impl              > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::gdbstub_impl              > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::gdbstub_impl              > <-- $m0,4#fd
 TRACE gdbstub::protocol::response_writer > --> $00000000#7e
```
</details>

<details>
<summary>Before/After `./example_no_std/check_size.sh` output</summary>

### Before

```
!!!!! EXAMPLE OUTPUT !!!!!

target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     680
.note.gnu.build-id      36     708
.note.ABI-tag           32     744
.gnu.hash               36     776
.dynsym                360     816
.dynstr                193    1176
.gnu.version            30    1370
.gnu.version_r          48    1400
.rela.dyn              408    1448
.init                   27    4096
.plt                    16    4128
.plt.got                 8    4144
.text                15253    4160
.fini                   13   19416
.rodata                906   20480
.eh_frame_hdr          284   21388
.eh_frame             1432   21672
.init_array              8   28072
.fini_array              8   28080
.dynamic               448   28088
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                43       0
Total                19769
```

### After

```
!!!!! EXAMPLE OUTPUT !!!!!

target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     680
.note.gnu.build-id      36     708
.note.ABI-tag           32     744
.gnu.hash               36     776
.dynsym                360     816
.dynstr                193    1176
.gnu.version            30    1370
.gnu.version_r          48    1400
.rela.dyn              408    1448
.init                   27    4096
.plt                    16    4128
.plt.got                 8    4144
.text                15253    4160
.fini                   13   19416
.rodata                906   20480
.eh_frame_hdr          284   21388
.eh_frame             1432   21672
.init_array              8   28072
.fini_array              8   28080
.dynamic               448   28088
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                43       0
Total                19769
```

</details>
