### PR TITLE
`read_addrs()` can return fewer bytes than requested

### DIFF
--- a/example_no_std/src/gdb.rs
+++ b/example_no_std/src/gdb.rs
@@ -71,10 +71,10 @@ impl MultiThreadBase for DummyTarget {
         _start_addr: u32,
         data: &mut [u8],
         _tid: Tid, // same address space for each core
-    ) -> TargetResult<(), Self> {
+    ) -> TargetResult<usize, Self> {
         print_str("> read_addrs");
         data.iter_mut().for_each(|b| *b = 0x55);
-        Ok(())
+        Ok(data.len())
     }
 
     #[inline(never)]

--- a/examples/armv4t_multicore/gdb.rs
+++ b/examples/armv4t_multicore/gdb.rs
@@ -92,11 +92,11 @@ impl MultiThreadBase for Emu {
         start_addr: u32,
         data: &mut [u8],
         _tid: Tid, // same address space for each core
-    ) -> TargetResult<(), Self> {
+    ) -> TargetResult<usize, Self> {
         for (addr, val) in (start_addr..).zip(data.iter_mut()) {
             *val = self.mem.r8(addr)
         }
-        Ok(())
+        Ok(data.len())
     }
 
     fn write_addrs(

--- a/src/stub/core_impl/base.rs
+++ b/src/stub/core_impl/base.rs
@@ -238,7 +238,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
                     let addr = addr + NumCast::from(i).ok_or(Error::TargetMismatch)?;
                     let data = &mut buf[..chunk_size];
-                    match target.base_ops() {
+                    let data_len = match target.base_ops() {
                         BaseOps::SingleThread(ops) => ops.read_addrs(addr, data),
                         BaseOps::MultiThread(ops) => {
                             ops.read_addrs(addr, data, self.current_mem_tid)
@@ -249,6 +249,8 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     n -= chunk_size;
                     i += chunk_size;
 
+                    // TODO: add more specific error variant?
+                    let data = data.get(..data_len).ok_or(Error::PacketBufferOverflow)?;
                     res.write_hex_buf(data)?;
                 }
                 HandlerStatus::Handled

--- a/src/target/ext/base/multithread.rs
+++ b/src/target/ext/base/multithread.rs
@@ -43,17 +43,25 @@ pub trait MultiThreadBase: Target {
         None
     }
 
-    /// Read bytes from the specified address range.
+    /// Read bytes from the specified address range and return the number of
+    /// bytes that were read.
     ///
-    /// If the requested address range could not be accessed (e.g: due to
-    /// MMU protection, unhanded page fault, etc...), an appropriate non-fatal
-    /// error should be returned.
+    /// Implementations may return a number `n` that is less than `data.len()`
+    /// to indicate that memory starting at `start_addr + n` cannot be
+    /// accessed.
+    ///
+    /// Implemenations may also return an appropriate non-fatal error if the
+    /// requested address range could not be accessed (e.g: due to MMU
+    /// protection, unhanded page fault, etc...).
+    ///
+    /// Implementations must guarantee that the returned number is less than or
+    /// equal `data.len()`.
     fn read_addrs(
         &mut self,
         start_addr: <Self::Arch as Arch>::Usize,
         data: &mut [u8],
         tid: Tid,
-    ) -> TargetResult<(), Self>;
+    ) -> TargetResult<usize, Self>;
 
     /// Write bytes to the specified address range.
     ///

--- a/src/target/ext/base/singlethread.rs
+++ b/src/target/ext/base/singlethread.rs
@@ -32,16 +32,24 @@ pub trait SingleThreadBase: Target {
         None
     }
 
-    /// Read bytes from the specified address range.
+    /// Read bytes from the specified address range and return the number of
+    /// bytes that were read.
     ///
-    /// If the requested address range could not be accessed (e.g: due to
-    /// MMU protection, unhanded page fault, etc...), an appropriate
-    /// non-fatal error should be returned.
+    /// Implementations may return a number `n` that is less than `data.len()`
+    /// to indicate that memory starting at `start_addr + n` cannot be
+    /// accessed.
+    ///
+    /// Implemenations may also return an appropriate non-fatal error if the
+    /// requested address range could not be accessed (e.g: due to MMU
+    /// protection, unhanded page fault, etc...).
+    ///
+    /// Implementations must guarantee that the returned number is less than or
+    /// equal `data.len()`.
     fn read_addrs(
         &mut self,
         start_addr: <Self::Arch as Arch>::Usize,
         data: &mut [u8],
-    ) -> TargetResult<(), Self>;
+    ) -> TargetResult<usize, Self>;
 
     /// Write bytes to the specified address range.
     ///

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -151,7 +151,7 @@
 //!         &mut self,
 //!         start_addr: u32,
 //!         data: &mut [u8],
-//!     ) -> TargetResult<(), Self> { todo!() }
+//!     ) -> TargetResult<usize, Self> { todo!() }
 //!
 //!     fn write_addrs(
 //!         &mut self,
@@ -409,7 +409,7 @@ pub trait Target {
     /// #       &mut self,
     /// #       start_addr: u32,
     /// #       data: &mut [u8],
-    /// #   ) -> TargetResult<(), Self> { todo!() }
+    /// #   ) -> TargetResult<usize, Self> { todo!() }
     /// #
     /// #   fn write_addrs(
     /// #       &mut self,


### PR DESCRIPTION
### Description

<!-- Please include a brief description of what is being added/changed -->

The `read_addrs()` method for targets now returns a number of bytes that were read. This allows a target to gracefully signal the client that memory at an address range is not accessible.

I’ve implemented this functionality for the armv4t example to be able to test it.

Closes #111.

### API Stability

This PR requires a breaking API change.

### Checklist

- Implementation
  - [x] `cargo build` compiles without `errors` or `warnings`
  - [x] `cargo clippy` runs without `errors` or `warnings`
  - [x] `cargo fmt` was run
  - [x] All tests pass
- Documentation
  - [x] rustdoc + approprate inline code comments
  - [ ] Updated CHANGELOG.md
  - ~~(if appropriate) Added feature to "Debugging Features" in README.md~~
- ~~_If implementing a new protocol extension IDET_~~
- ~~_If upstreaming an `Arch` implementation_~~

I’m not sure how to update the changelog.

### Validation

<!-- example output, from https://github.com/daniel5151/gdbstub/pull/54 -->

#### Read before accessible area

```
(gdb) x 0x00
0x0:    Cannot access memory at address 0x0
```

```
TRACE gdbstub::protocol::recv_packet     > <-- $m0,4#fd
TRACE gdbstub::protocol::response_writer > --> $#00
```

#### Read partially accessible memory

```
(gdb) x/4xb 0x6554fffe
0x6554fffe:     0x00    0x00    Cannot access memory at address 0x65550000
```

```
TRACE gdbstub::protocol::recv_packet     > <-- $m6554fffe,1#35
TRACE gdbstub::protocol::response_writer > --> $00#60
TRACE gdbstub::protocol::recv_packet     > <-- $m6554ffff,1#36
TRACE gdbstub::protocol::response_writer > --> $00#60
TRACE gdbstub::protocol::recv_packet     > <-- $m65550000,1#5f
TRACE gdbstub::protocol::response_writer > --> $#00
```

#### Read after accessible area

```
(gdb) x 0x6555000e
0x6555000e:     Cannot access memory at address 0x6555000e
```

```
TRACE gdbstub::protocol::recv_packet     > <-- $m6555000e,4#97
TRACE gdbstub::protocol::response_writer > --> $#00
```