### PR TITLE
X packets contains `, || :` in the payload

### DIFF
--- a/src/protocol/commands/_x_upcase.rs
+++ b/src/protocol/commands/_x_upcase.rs
@@ -14,7 +14,7 @@ impl<'a> ParseCommand<'a> for X<'a> {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
         let body = buf.into_body();
 
-        let mut body = body.split_mut(|&b| b == b',' || b == b':');
+        let mut body = body.splitn_mut(3, |&b| b == b',' || b == b':');
         let addr = decode_hex_buf(body.next()?).ok()?;
         let len = decode_hex(body.next()?).ok()?;
         let val = decode_bin_buf(body.next()?)?;


### PR DESCRIPTION
### Description

Hi, I noticed my binary file isn't fully loaded into the target and I could not find anything went wrong with my side of code.

So I investigated alittle on how the X command packets are treated, and discovered the no. of parts supposed to be splited into was unspecified(as you can see in the original code).

The bug:(`val = 104` is the length of the variable `val`, the `trace!` was removed before commit)
![gdbstub_bug_01](https://user-images.githubusercontent.com/8848056/220810712-07102f0e-8e74-4197-bca0-ec5df7346264.png)

This PR fixes that by adding the no. of parts should be splitted into, as you can see in the commit.

After fix:
![gdbstub_fix_01](https://user-images.githubusercontent.com/8848056/220810961-f846581e-b309-4d2e-9235-9fd6fa1f2145.png)

### API Stability

- [x] This PR does not require a breaking API change

### Checklist

<!-- CI takes care of a lot of things, but there are some things that have yet to be automated -->

- Documentation
  - [x] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [ ] (if appropriate) Added feature to "Debugging Features" in README.md
- Validation
  - [x] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [x] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below

### Validation

<!-- example output, from https://github.com/daniel5151/gdbstub/pull/54 -->

<details>
<summary>GDB output</summary>

```
(gdb) info mem
Using memory regions provided by the target.
Num Enb Low Addr   High Addr  Attrs 
0   y   0x00000000 0x100000000 rw nocache 
```

</details>

<details>
<summary>armv4t output</summary>

```
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/examples/armv4t`
loading section ".text" into memory from [0x55550000..0x55550078]
Setting PC to 0x55550000
Waiting for a GDB connection on "127.0.0.1:9001"...
Debugger connected from 127.0.0.1:45720
 TRACE gdbstub::protocol::recv_packet > <-- +
 TRACE gdbstub::protocol::recv_packet > <-- $qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;no-resumed+;xmlRegisters=i386#6a
 TRACE gdbstub::protocol::response_writer > --> $PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;ReverseContinue+;ReverseStep+;QDisableRandomization+;QEnvironmentHexEncoded+;QEnvironmentUnset+;QEnvironmentReset+;QStartupWithShell+;QSetWorkingDir+;swbreak+;hwbreak+;QCatchSyscalls+;qXfer:features:read+;qXfer:memory-map:read+;qXfer:exec-file:read+;qXfer:auxv:read+#fa
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $vMustReplyEmpty#3a
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("vMustReplyEmpty")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $QStartNoAckMode#b0
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $Hgp0.0#ad
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:0,ffb#79
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<target version="1.0">
    <architecture>armv4t</architecture>
    <feature name="org.gnu.gdb.arm.core">
        <vector id="padding" type="uint32" count="25"/>

        <reg name="r0" bitsize="32" type="uint32"/>
        <reg name="r1" bitsize="32" type="uint32"/>
        <reg name="r2" bitsize="32" type="uint32"/>
        <reg name="r3" bitsize="32" type="uint32"/>
        <reg name="r4" bitsize="32" type="uint32"/>
        <reg name="r5" bitsize="32" type="uint32"/>
        <reg name="r6" bitsize="32" type="uint32"/>
        <reg name="r7" bitsize="32" type="uint32"/>
        <reg name="r8" bitsize="32" type="uint32"/>
        <reg name="r9" bitsize="32" type="uint32"/>
        <reg name="r10" bitsize="32" type="uint32"/>
        <reg name="r11" bitsize="32" type="uint32"/>
        <reg name="r12" bitsize="32" type="uint32"/>
        <reg name="sp" bitsize="32" type="data_ptr"/>
        <reg name="lr" bitsize="32"/>
        <reg name="pc" bitsize="32" type="code_ptr"/>

        <!--
            For some reason, my version of `gdb-multiarch` doesn't seem to
            respect "regnum", and will not parse this custom target.xml unless I
            manually include the padding bytes in the target description.

            On the bright side, AFAIK, there aren't all that many architectures
            that use padding bytes. Heck, the only reason armv4t uses padding is
            for historical reasons (see comment below).

            Odds are if you're defining your own custom arch, you won't run into
            this issue, since you can just lay out all the registers in the
            correct order.
        -->
        <reg name="padding" type="padding" bitsize="32"/>

        <!-- The CPSR is register 25, rather than register 16, because
        the FPA registers historically were placed between the PC
        and the CPSR in the "g" packet. -->
        <reg name="cpsr" bitsize="32" regnum="25"/>
    </feature>
    <xi:include href="extra.xml"/>
</target>#38
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:80d,ffb#15
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:extra.xml:0,ffb#16
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<feature name="custom-armv4t-extension">
    <!--
        maps to a simple scratch register within the emulator. the GDB
        client can read the register using `p }custom` and set it using
        `set }custom=1337`
    -->
    <reg name="custom" bitsize="32" type="uint32"/>

    <!--
        pseudo-register that return the current time when read.

        notably, i've set up the target to NOT send this register as part of
        the regular register list, which means that GDB will fetch/update
        this register via the 'p' and 'P' packets respectively
    -->
    <reg name="time" bitsize="32" type="uint32"/>

    <!--
        pseudo-register that is always unavailable.

        it is supposed to be reported as 'x'-ed bytes in replies to 'p' packets
        and shown by the GDB client as "<unavailable>".
    -->
    <reg name="unavailable" bitsize="32" type="uint32"/>
</feature>#7d
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:extra.xml:3c5,ffb#b1
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::0,ffb#d8
 TRACE gdbstub::protocol::response_writer > --> $m#bb
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::8,ffb#e0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qTStatus")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $?#3f
 TRACE gdbstub::protocol::response_writer > --> $T05thread:p01.01;#06
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qAttached:1#fa
GDB queried if it was attached to a process with PID 1
 TRACE gdbstub::protocol::response_writer > --> $1#31
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:0,ffb#b7
 TRACE gdbstub::protocol::response_writer > --> $m/test.elf#c1
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:9,ffb#c0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:setfs:0#bf
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:6a7573742070726f62696e67,0,1c0#ed
 TRACE gdbstub::protocol::response_writer > --> $F-1,02#32
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:setfs:1#c0
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746573742e656c66,0,0#1e
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T
                                                                ����|
UUxB�B
B�UUxUU
�UU
   xUUxUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746573742e656c66,0,0#1e
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#cc
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#d8
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T
                                                                ����|
UUxB�B
B�UUxUU
�UU
   xUUxUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,102fc#1b
 TRACE gdbstub::protocol::response_writer > --> $F0474;UUxUU
�UU
   xUUxUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#31
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox    o�ty    o�l4UU0i        o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU        gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T
                                                                ����|
UUxB�B
B�UUxUU
�UU
   xUUxUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
        Lf��#90
 TRACE gdbstub::protocol::recv_packet     > <-- $qSymbol::#5b
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qSymbol::")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:0,ffb#b7
 TRACE gdbstub::protocol::response_writer > --> $m/test.elf#c1
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:9,ffb#c0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $Hc-1#09
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qOffsets#4b
 TRACE gdbstub::protocol::response_writer > --> $Text=00;Data=00;Bss=00#94
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000107856341200005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1000000078563412#0a
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::0,ffb#d8
 TRACE gdbstub::protocol::response_writer > --> $m#bb
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::8,ffb#e0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::0,ffb#18
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE memory-map
    PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN"
            "http://sourceware.org/gdb/gdb-memory-map.dtd">
<memory-map>
    <memory type="ram" start="0x0" length="0x100000000"/>
</memory-map>#76
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::f4,ffb#82
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $m0,1#fa
 TRACE gdbstub::protocol::response_writer > --> $00#60
 TRACE gdbstub::protocol::recv_packet     > <-- $m0,1#fa
 TRACE gdbstub::protocol::response_writer > --> $00#60
 TRACE gdbstub::protocol::recv_packet     > <-- $m0,40#2d
 TRACE gdbstub::protocol::response_writer > --> $00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $m0,8#01
 TRACE gdbstub::protocol::response_writer > --> $0000000000000000#86
 TRACE gdbstub::protocol::recv_packet     > <-- $m0,7#00
 TRACE gdbstub::protocol::response_writer > --> $00000000000000#84
```
</details>

<details>
<summary>Before/After `./example_no_std/check_size.sh` output</summary>

### Before

```
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     792
.note.gnu.property      32     824
.note.gnu.build-id      36     856
.note.ABI-tag           32     892
.gnu.hash               36     928
.dynsym                360     968
.dynstr                204    1328
.gnu.version            30    1532
.gnu.version_r          64    1568
.rela.dyn              408    1632
.init                   23    4096
.plt                    16    4128
.plt.got                 8    4144
.text                14714    4160
.fini                    9   18876
.rodata                946   20480
.eh_frame_hdr          260   21428
.eh_frame             1340   21688
.init_array              8   28072
.fini_array              8   28080
.dynamic               448   28088
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                39       0
Total                19201

```

### After

```
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     792
.note.gnu.property      32     824
.note.gnu.build-id      36     856
.note.ABI-tag           32     892
.gnu.hash               36     928
.dynsym                360     968
.dynstr                204    1328
.gnu.version            30    1532
.gnu.version_r          64    1568
.rela.dyn              408    1632
.init                   23    4096
.plt                    16    4128
.plt.got                 8    4144
.text                14714    4160
.fini                    9   18876
.rodata                946   20480
.eh_frame_hdr          260   21428
.eh_frame             1340   21688
.init_array              8   28072
.fini_array              8   28080
.dynamic               448   28088
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                39       0
Total                19201
```

</details>
