### PR TITLE
riscv: mark arch as SingleStepGdbBehavior::Required

### DIFF
--- a/gdbstub_arch/src/riscv/mod.rs
+++ b/gdbstub_arch/src/riscv/mod.rs
@@ -24,7 +24,7 @@ impl Arch for Riscv32 {
 
     #[inline(always)]
     fn single_step_gdb_behavior() -> SingleStepGdbBehavior {
-        SingleStepGdbBehavior::Ignored
+        SingleStepGdbBehavior::Required
     }
 }
 
@@ -40,6 +40,6 @@ impl Arch for Riscv64 {
 
     #[inline(always)]
     fn single_step_gdb_behavior() -> SingleStepGdbBehavior {
-        SingleStepGdbBehavior::Ignored
+        SingleStepGdbBehavior::Required
     }
 }


### PR DESCRIPTION
GDB on Risc-V seems to unconditionally ask for single-stepping even if we advertise that we don't support it.