### PR TITLE
vAttach: get vAttach working with multi-process

### DIFF
--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -228,6 +228,7 @@ commands! {
         "M" => _m_upcase::M<'a>,
         "qAttached" => _qAttached::qAttached,
         "qfThreadInfo" => _qfThreadInfo::qfThreadInfo,
+        "qC" => _qC::qC,
         "QStartNoAckMode" => _QStartNoAckMode::QStartNoAckMode,
         "qsThreadInfo" => _qsThreadInfo::qsThreadInfo,
         "qSupported" => _qSupported::qSupported<'a>,

--- a/src/protocol/commands/_qC.rs
+++ b/src/protocol/commands/_qC.rs
@@ -1,0 +1,14 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct qC;
+
+impl<'a> ParseCommand<'a> for qC {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        if !buf.into_body().is_empty() {
+            return None;
+        }
+        Some(qC)
+    }
+}

--- a/src/stub/core_impl/base.rs
+++ b/src/stub/core_impl/base.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 use crate::protocol::commands::ext::Base;
 
 use crate::arch::{Arch, Registers};
-use crate::common::Tid;
+use crate::common::{Pid, Tid};
 use crate::protocol::{IdKind, SpecificIdKind, SpecificThreadId};
 use crate::target::ext::base::{BaseOps, ResumeOps};
 use crate::{FAKE_PID, SINGLE_THREAD_TID};
@@ -32,6 +32,16 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             }
         };
         Ok(tid)
+    }
+
+    pub(crate) fn get_sane_current_pid(
+        &mut self,
+        target: &mut T,
+    ) -> Result<Pid, Error<T::Error, C::Error>> {
+        match target.base_ops() {
+            BaseOps::SingleThread(_) => Ok(FAKE_PID),
+            BaseOps::MultiThread(ops) => ops.active_pid().map_err(Error::TargetError),
+        }
     }
 
     pub(crate) fn handle_base(
@@ -167,7 +177,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                         pid: self
                             .features
                             .multiprocess()
-                            .then_some(SpecificIdKind::WithId(FAKE_PID)),
+                            .then_some(SpecificIdKind::WithId(self.get_sane_current_pid(target)?)),
                         tid: SpecificIdKind::WithId(tid),
                     })?;
                 } else {
@@ -332,15 +342,59 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 }
                 HandlerStatus::NeedsOk
             }
-            Base::qfThreadInfo(_) => {
-                res.write_str("m")?;
+            Base::qC(_) => {
+                res.write_str("QC")?;
+                let pid = self.get_sane_current_pid(target)?;
 
                 match target.base_ops() {
                     BaseOps::SingleThread(_) => res.write_specific_thread_id(SpecificThreadId {
                         pid: self
                             .features
                             .multiprocess()
-                            .then_some(SpecificIdKind::WithId(FAKE_PID)),
+                            .then_some(SpecificIdKind::WithId(pid)),
+                        tid: SpecificIdKind::WithId(SINGLE_THREAD_TID),
+                    })?,
+                    BaseOps::MultiThread(ops) => {
+                        let mut err: Result<_, Error<T::Error, C::Error>> = Ok(());
+                        let mut first = true;
+                        ops.list_active_threads(&mut |tid| {
+                            // TODO: replace this with a try block (once stabilized)
+                            let e = (|| {
+                                if !first {
+                                    return Ok(());
+                                }
+                                first = false;
+                                res.write_specific_thread_id(SpecificThreadId {
+                                    pid: self
+                                        .features
+                                        .multiprocess()
+                                        .then_some(SpecificIdKind::WithId(pid)),
+                                    tid: SpecificIdKind::WithId(tid),
+                                })?;
+                                Ok(())
+                            })();
+
+                            if let Err(e) = e {
+                                err = Err(e)
+                            }
+                        })
+                        .map_err(Error::TargetError)?;
+                        err?;
+                    }
+                }
+
+                HandlerStatus::Handled
+            }
+            Base::qfThreadInfo(_) => {
+                res.write_str("m")?;
+                let pid = self.get_sane_current_pid(target)?;
+
+                match target.base_ops() {
+                    BaseOps::SingleThread(_) => res.write_specific_thread_id(SpecificThreadId {
+                        pid: self
+                            .features
+                            .multiprocess()
+                            .then_some(SpecificIdKind::WithId(pid)),
                         tid: SpecificIdKind::WithId(SINGLE_THREAD_TID),
                     })?,
                     BaseOps::MultiThread(ops) => {
@@ -357,7 +411,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                                     pid: self
                                         .features
                                         .multiprocess()
-                                        .then_some(SpecificIdKind::WithId(FAKE_PID)),
+                                        .then_some(SpecificIdKind::WithId(pid)),
                                     tid: SpecificIdKind::WithId(tid),
                                 })?;
                                 Ok(())

--- a/src/stub/core_impl/extended_mode.rs
+++ b/src/stub/core_impl/extended_mode.rs
@@ -26,8 +26,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             }
             ExtendedMode::vAttach(cmd) => {
                 ops.attach(cmd.pid).handle_error()?;
-
-                // TODO: sends OK when running in Non-Stop mode
+                res.write_str("S00")?;
                 HandlerStatus::Handled
             }
             ExtendedMode::vRun(cmd) => {

--- a/src/stub/core_impl/extended_mode.rs
+++ b/src/stub/core_impl/extended_mode.rs
@@ -26,8 +26,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             }
             ExtendedMode::vAttach(cmd) => {
                 ops.attach(cmd.pid).handle_error()?;
-                res.write_str("S00")?;
-                HandlerStatus::Handled
+                self.report_reasonable_stop_reason(res, target)?
             }
             ExtendedMode::vRun(cmd) => {
                 use crate::target::ext::extended_mode::Args;

--- a/src/target/ext/base/multithread.rs
+++ b/src/target/ext/base/multithread.rs
@@ -120,10 +120,13 @@ pub trait MultiThreadBase: Target {
     /// process.
     ///
     /// This should reflect the currently-debugged process which should be
-    /// updated when switching processes after calling `attach()`.
+    /// updated when switching processes after calling [`attach()`].
     ///
     /// This function is only useful if your target implements multiple
     /// processes.
+    ///
+    /// [`attach()`]:
+    /// crate::target::ext::extended_mode::ExtendedMode::attach
     #[inline(always)]
     fn active_pid(&mut self) -> Result<Pid, Self::Error> {
         Ok(FAKE_PID)

--- a/src/target/ext/base/multithread.rs
+++ b/src/target/ext/base/multithread.rs
@@ -2,8 +2,9 @@
 
 use crate::arch::Arch;
 use crate::common::Signal;
-use crate::common::Tid;
+use crate::common::{Pid, Tid};
 use crate::target::{Target, TargetResult};
+use crate::FAKE_PID;
 
 /// Base required debugging operations for multi threaded targets.
 pub trait MultiThreadBase: Target {
@@ -109,6 +110,23 @@ pub trait MultiThreadBase: Target {
         &mut self,
     ) -> Option<crate::target::ext::thread_extra_info::ThreadExtraInfoOps<'_, Self>> {
         None
+    }
+
+    /// Override the reported PID when running in multithread mode (default: 1)
+    ///
+    /// When implementing gdbstub on a platform that supports multiple
+    /// processes, the active PID needs to match the attached process.
+    /// Failing to do so will cause GDB to fail to attach to the target
+    /// process.
+    ///
+    /// This should reflect the currently-debugged process which should be
+    /// updated when switching processes after calling `attach()`.
+    ///
+    /// This function is only useful if your target implements multiple
+    /// processes.
+    #[inline(always)]
+    fn active_pid(&mut self) -> Result<Pid, Self::Error> {
+        Ok(FAKE_PID)
     }
 }
 

--- a/src/target/ext/extended_mode.rs
+++ b/src/target/ext/extended_mode.rs
@@ -95,9 +95,6 @@ pub trait ExtendedMode: Target {
     /// In all-stop mode, all threads in the attached process are stopped; in
     /// non-stop mode, it may be attached without being stopped (if that is
     /// supported by the target).
-    ///
-    /// After this method resolves, GDB will immediately request a stop reason.
-    /// It is up to the implementation to ensure the stop reason is accurate.
     fn attach(&mut self, pid: Pid) -> TargetResult<(), Self>;
 
     /// Query if specified PID was spawned by the target (via `run`), or if the

--- a/src/target/ext/extended_mode.rs
+++ b/src/target/ext/extended_mode.rs
@@ -95,6 +95,9 @@ pub trait ExtendedMode: Target {
     /// In all-stop mode, all threads in the attached process are stopped; in
     /// non-stop mode, it may be attached without being stopped (if that is
     /// supported by the target).
+    ///
+    /// After this method resolves, GDB will immediately request a stop reason.
+    /// It is up to the implementation to ensure the stop reason is accurate.
     fn attach(&mut self, pid: Pid) -> TargetResult<(), Self>;
 
     /// Query if specified PID was spawned by the target (via `run`), or if the


### PR DESCRIPTION
### Description

<!-- Please include a brief description of what is being added/changed -->

This PR implements one possible approach to getting `vAttach` working with multiple processes. With this, it is now possible to attach to a given process, for example by issuing `attach 7` to attach to PID 7.

### API Stability

- [X] This PR does not require a breaking API change

### Checklist

<!-- CI takes care of a lot of things, but there are some things that have yet to be automated -->

- Documentation
  - [X] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [X] (if appropriate) Added feature to "Debugging Features" in README.md
- Validation
  - [ ] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [ ] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below

<!-- Oh, and if you're integrating `gdbstub` in an open-source project, do consider updating the README.md's "Real World Examples" section to link back to your project! -->

### Validation

<details>
<summary>GDB output</summary>

```
(gdb) tar ext :3456
Remote debugging using :3456
[remote] start_remote_1: enter
  [remote] Sending packet: $qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;no-resumed+;memory-tagging+#ec
  [remote] Received Ack
  [remote] Packet received: PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;qXfer:features:read+
  [remote] packet_ok: Packet qSupported (supported-packets) is supported
  [remote] Sending packet: $vMustReplyEmpty#3a
  [remote] Received Ack
  [remote] Packet received:
  [remote] Sending packet: $QStartNoAckMode#b0
  [remote] Received Ack
  [remote] Packet received: OK
  [remote] Sending packet: $!#21
  [remote] Packet received: OK
  [remote] Sending packet: $Hgp0.0#ad
  [remote] Packet received: E01
  [remote] Sending packet: $qXfer:features:read:target.xml:0,ffb#79
  [remote] Packet received: m<target version="1.0"><architecture>riscv:rv32</architecture></target>
  [remote] Sending packet: $qXfer:features:read:target.xml:46,ffb#b3
  [remote] Packet received: l
  [remote] Sending packet: $qTStatus#49
  [remote] Packet received:
  [remote] packet_ok: Packet qTStatus (trace-status) is NOT supported
  [remote] Sending packet: $?#3f
  [remote] Packet received: W00;
[remote] start_remote_1: exit
(gdb) att 2
Attaching to program: E:\Code\Xous\Core\target\riscv32imac-unknown-xous-elf\release\xous-ticktimer, process 2
[remote] Sending packet: $vAttach;2#38
[remote] Packet received: S00
[remote] packet_ok: Packet vAttach (attach) is supported
[remote] Sending packet: $qC#b4
[remote] Packet received: QCp02.02
[remote] Sending packet: $Hgp2.2#b1
[remote] Packet received: OK
[remote] Sending packet: $qXfer:features:read:target.xml:0,ffb#79
[remote] Packet received: m<target version="1.0"><architecture>riscv:rv32</architecture></target>
[remote] Sending packet: $qXfer:features:read:target.xml:46,ffb#b3
[remote] Packet received: l
[remote] wait: enter
  [remote] select_thread_for_ambiguous_stop_reply: enter
    [remote] select_thread_for_ambiguous_stop_reply: process_wide_stop = 0
    [remote] select_thread_for_ambiguous_stop_reply: first resumed thread is Thread 2.2
    [remote] select_thread_for_ambiguous_stop_reply: is this guess ambiguous? = 0
  [remote] select_thread_for_ambiguous_stop_reply: exit
[remote] wait: exit
[remote] Sending packet: $g#67
[remote] Packet received: 00000000b431030090f5ff7f00000000000000601000000038550300bcf5ff7f90f6ff7f050000000f0000007469636b74696d65722d736572766572000000000000000000000000000000004a010000f8faff7f680400200500000001000000feffffff040000000f0f0f0f0101010101000000040000000000000090000020c8310300
[remote] Sending packet: $qOffsets#4b
[remote] Packet received:
[remote] Sending packet: $qSymbol::#5b
[remote] Packet received:
[remote] packet_ok: Packet qSymbol (symbol-lookup) is NOT supported
[remote] Sending packet: $qfThreadInfo#bb
[remote] Packet received: mp02.02,p02.03
[remote] Sending packet: $qsThreadInfo#c8
[remote] Packet received: l
[New Thread 2.3]
0x000331c8 in xous::syscall::receive_message ()
(gdb) c
Continuing.
[remote] Sending packet: $vCont?#49
[remote] Packet received: vCont;c;C;s;S
[remote] packet_ok: Packet vCont (verbose-resume) is supported
[remote] Sending packet: $vCont;c:p2.-1#10
[remote] wait: enter
[remote] wait: exit
[remote] pass_ctrlc: enter
  [remote] interrupt: enter
  [remote] interrupt: exit
[remote] pass_ctrlc: exit
[remote] wait: enter
  [remote] Packet received: S02
  [remote] select_thread_for_ambiguous_stop_reply: enter
    [remote] select_thread_for_ambiguous_stop_reply: process_wide_stop = 0
    [remote] select_thread_for_ambiguous_stop_reply: first resumed thread is Thread 2.2
    [remote] select_thread_for_ambiguous_stop_reply: is this guess ambiguous? = 1
warning: multi-threaded target stopped without sending a thread-id, using first non-exited thread
  [remote] select_thread_for_ambiguous_stop_reply: exit
[remote] wait: exit
[remote] Sending packet: $g#67
[remote] Packet received: 00000000ac33030030f6ff7f00000000000000600200000038550300bcf5ff7ff0faff7f0400000029000000460020170000000041161d00000000000000000000000000020000000000000041161d00f8faff7f680400200400000001000000feffffff040000000f0f0f0f0101010101000000030000000000000090000020c0330300
[remote] Sending packet: $qfThreadInfo#bb
[remote] Packet received: mp02.02,p02.03
[remote] Sending packet: $qsThreadInfo#c8
[remote] Packet received: l

Thread 1 received signal SIGINT, Interrupt.
0x000333c0 in xous::syscall::reply_and_receive_next_legacy ()
(gdb) c
Continuing.
[remote] Sending packet: $vCont;c:p2.-1#10
Remote communication error.  Target disconnected.: No error.
(gdb) tar ext :3456
Remote debugging using :3456
[remote] start_remote_1: enter
  [remote] Sending packet: $qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;no-resumed+;memory-tagging+#ec
  [remote] Received Ack
  [remote] Packet received: PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;qXfer:features:read+
  [remote] packet_ok: Packet qSupported (supported-packets) is supported
  [remote] Sending packet: $vMustReplyEmpty#3a
  [remote] Received Ack
  [remote] Packet received:
  [remote] Sending packet: $QStartNoAckMode#b0
  [remote] Received Ack
  [remote] Packet received: OK
  [remote] Sending packet: $!#21
  [remote] Packet received: OK
  [remote] Sending packet: $Hgp0.0#ad
  [remote] Packet received: E01
  [remote] Sending packet: $qXfer:features:read:target.xml:0,ffb#79
  [remote] Packet received: m<target version="1.0"><architecture>riscv:rv32</architecture></target>
  [remote] Sending packet: $qXfer:features:read:target.xml:46,ffb#b3
  [remote] Packet received: l
  [remote] Sending packet: $qTStatus#49
  [remote] Packet received:
  [remote] packet_ok: Packet qTStatus (trace-status) is NOT supported
  [remote] Sending packet: $?#3f
  [remote] Packet received: W00;
[remote] start_remote_1: exit
(gdb) att 2
Attaching to program: E:\Code\Xous\Core\target\riscv32imac-unknown-xous-elf\release\xous-ticktimer, process 2
[remote] Sending packet: $vAttach;2#38
[remote] Packet received: S00
[remote] packet_ok: Packet vAttach (attach) is supported
[remote] Sending packet: $qC#b4
[remote] Packet received: QCp02.02
[remote] Sending packet: $Hgp2.2#b1
[remote] Packet received: OK
[remote] Sending packet: $qXfer:features:read:target.xml:0,ffb#79
[remote] Packet received: m<target version="1.0"><architecture>riscv:rv32</architecture></target>
[remote] Sending packet: $qXfer:features:read:target.xml:46,ffb#b3
[remote] Packet received: l
[remote] wait: enter
  [remote] select_thread_for_ambiguous_stop_reply: enter
    [remote] select_thread_for_ambiguous_stop_reply: process_wide_stop = 0
    [remote] select_thread_for_ambiguous_stop_reply: first resumed thread is Thread 2.2
    [remote] select_thread_for_ambiguous_stop_reply: is this guess ambiguous? = 0
  [remote] select_thread_for_ambiguous_stop_reply: exit
[remote] wait: exit
[remote] Sending packet: $g#67
[remote] Packet received: 00000000ac33030030f6ff7f00000000000000600200000038550300bcf5ff7ff0faff7f04000000290000000b00230d00000000a72300000000000000000000000000000200000000000000a7230000f8faff7f680400200400000001000000feffffff040000000f0f0f0f0101010101000000030000000000000090000020c0330300
[remote] Sending packet: $qOffsets#4b
[remote] Packet received:
[remote] Sending packet: $qSymbol::#5b
[remote] Packet received:
[remote] packet_ok: Packet qSymbol (symbol-lookup) is NOT supported
[remote] Sending packet: $qfThreadInfo#bb
[remote] Packet received: mp02.02,p02.03
[remote] Sending packet: $qsThreadInfo#c8
[remote] Packet received: l
[New Thread 2.3]

Thread 1 stopped.
0x000333c0 in xous::syscall::reply_and_receive_next_legacy ()
(gdb) att 3
A program is being debugged already.  Kill it? (y or n) y
[remote] Sending packet: $vKill;2#6f
[remote] Packet received: OK
[remote] packet_ok: Packet vKill (kill) is supported
Attaching to program: E:\Code\Xous\Core\target\riscv32imac-unknown-xous-elf\release\xous-ticktimer, process 3
[remote] Sending packet: $vAttach;3#39
[remote] Packet received: S00
[remote] Sending packet: $qC#b4
[remote] Packet received: QCp03.02
[remote] Sending packet: $Hgp3.2#b2
[remote] Packet received: OK
[remote] Sending packet: $qXfer:features:read:target.xml:0,ffb#79
[remote] Packet received: m<target version="1.0"><architecture>riscv:rv32</architecture></target>
[remote] Sending packet: $qXfer:features:read:target.xml:46,ffb#b3
[remote] Packet received: l
[remote] wait: enter
  [remote] select_thread_for_ambiguous_stop_reply: enter
    [remote] select_thread_for_ambiguous_stop_reply: process_wide_stop = 0
    [remote] select_thread_for_ambiguous_stop_reply: first resumed thread is Thread 3.2
    [remote] select_thread_for_ambiguous_stop_reply: is this guess ambiguous? = 0
  [remote] select_thread_for_ambiguous_stop_reply: exit
[remote] wait: exit
[remote] Sending packet: $g#67
[remote] Packet received: 00000000a663010010ffff7f000000000000006000000000d07f01007831020020ffff7f40ffff7f09000000000000000000000000000000000000000000000000000000000000001cffff7f09000000010000000000000000000000000000000000000000000000000000000000000078330200000000000000000000000000d0670100
[remote] Sending packet: $qOffsets#4b
[remote] Packet received:
[remote] Sending packet: $qfThreadInfo#bb
[remote] Packet received: mp03.02,p03.03
[remote] Sending packet: $qsThreadInfo#c8
[remote] Packet received: l
[New Thread 3.3]

Thread 1 stopped.
0x000167d0 in ?? ()
(gdb) att 4
A program is being debugged already.  Kill it? (y or n) y
[remote] Sending packet: $vKill;3#70
[remote] Packet received: OK
Attaching to program: E:\Code\Xous\Core\target\riscv32imac-unknown-xous-elf\release\xous-ticktimer, process 4
[remote] Sending packet: $vAttach;4#3a
[remote] Packet received: S00
[remote] Sending packet: $qC#b4
[remote] Packet received: QCp04.02
[remote] Sending packet: $Hgp4.2#b3
[remote] Packet received: OK
[remote] Sending packet: $qXfer:features:read:target.xml:0,ffb#79
[remote] Packet received: m<target version="1.0"><architecture>riscv:rv32</architecture></target>
[remote] Sending packet: $qXfer:features:read:target.xml:46,ffb#b3
[remote] Packet received: l
[remote] wait: enter
  [remote] select_thread_for_ambiguous_stop_reply: enter
    [remote] select_thread_for_ambiguous_stop_reply: process_wide_stop = 0
    [remote] select_thread_for_ambiguous_stop_reply: first resumed thread is Thread 4.2
    [remote] select_thread_for_ambiguous_stop_reply: is this guess ambiguous? = 0
  [remote] select_thread_for_ambiguous_stop_reply: exit
[remote] wait: exit
[remote] Sending packet: $g#67
[remote] Packet received: 00000000b4aa010040fcff7f000000000000006010000000dcbc02004cfaff7f04000000180000000f000000786f75732d6e616d652d73657276657200000000000000000000000005000000652d736500f00200384c465c786f7573808080807c000000060000002d6e616d333333337c00000015d8c6f0756d65206d616e61269c0100
[remote] Sending packet: $qOffsets#4b
[remote] Packet received:
[remote] Sending packet: $qfThreadInfo#bb
[remote] Packet received: mp04.02
[remote] Sending packet: $qsThreadInfo#c8
[remote] Packet received: l

Program stopped.
0x00019c26 in xous_ticktimer::main ()
(gdb)
```

</details>