### PR TITLE
Rework vAttach + custom pid reporting

### DIFF
--- a/examples/armv4t/emu.rs
+++ b/examples/armv4t/emu.rs
@@ -2,6 +2,7 @@ use armv4t_emu::{reg, Cpu, ExampleMem, Memory, Mode};
 
 use crate::mem_sniffer::{AccessKind, MemSniffer};
 use crate::DynResult;
+use gdbstub::common::Pid;
 
 const HLE_RETURN_ADDR: u32 = 0x12345678;
 
@@ -35,6 +36,8 @@ pub struct Emu {
     pub(crate) watchpoints: Vec<u32>,
     pub(crate) breakpoints: Vec<u32>,
     pub(crate) files: Vec<Option<std::fs::File>>,
+
+    pub(crate) reported_pid: Pid,
 }
 
 impl Emu {
@@ -85,6 +88,8 @@ impl Emu {
             watchpoints: Vec::new(),
             breakpoints: Vec::new(),
             files: Vec::new(),
+
+            reported_pid: Pid::new(1).unwrap(),
         })
     }
 

--- a/examples/armv4t/gdb/extended_mode.rs
+++ b/examples/armv4t/gdb/extended_mode.rs
@@ -31,8 +31,11 @@ impl target::ext::extended_mode::ExtendedMode for Emu {
     }
 
     fn attach(&mut self, pid: Pid) -> TargetResult<(), Self> {
-        eprintln!("GDB tried to attach to a process with PID {}", pid);
-        Err(().into()) // non-specific failure
+        eprintln!("GDB attached to a process with PID {}", pid);
+        // stub implementation: just report the same code, but running under a
+        // different pid.
+        self.reported_pid = pid;
+        Ok(())
     }
 
     fn run(&mut self, filename: Option<&[u8]>, args: Args<'_, '_>) -> TargetResult<Pid, Self> {
@@ -96,6 +99,13 @@ impl target::ext::extended_mode::ExtendedMode for Emu {
     ) -> Option<target::ext::extended_mode::ConfigureWorkingDirOps<'_, Self>> {
         Some(self)
     }
+
+    #[inline(always)]
+    fn support_current_active_pid(
+        &mut self,
+    ) -> Option<target::ext::extended_mode::CurrentActivePidOps<'_, Self>> {
+        Some(self)
+    }
 }
 
 impl target::ext::extended_mode::ConfigureAslr for Emu {
@@ -156,5 +166,11 @@ impl target::ext::extended_mode::ConfigureWorkingDir for Emu {
         }
 
         Ok(())
+    }
+}
+
+impl target::ext::extended_mode::CurrentActivePid for Emu {
+    fn current_active_pid(&mut self) -> Result<Pid, Self::Error> {
+        Ok(self.reported_pid)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,8 @@ macro_rules! unwrap {
 
 /// (Internal) The fake Tid that's used when running in single-threaded mode.
 const SINGLE_THREAD_TID: common::Tid = unwrap!(common::Tid::new(1));
-/// (Internal) The fake Pid reported to GDB when running in multi-threaded mode.
+/// (Internal) The fake Pid reported to GDB when the target hasn't opted into
+/// reporting a custom Pid itself.
 const FAKE_PID: common::Pid = unwrap!(common::Pid::new(1));
 
 pub(crate) mod is_valid_tid {

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -114,7 +114,7 @@ macro_rules! commands {
 
                     fn support_lldb_register_info(&mut self) -> Option<()> {
                         use crate::arch::Arch;
-			            if self.use_lldb_register_info()
+                        if self.use_lldb_register_info()
                             && (T::Arch::lldb_register_info(usize::max_value()).is_some()
                                 || self.support_lldb_register_info_override().is_some())
                         {
@@ -122,7 +122,7 @@ macro_rules! commands {
                         } else {
                             None
                         }
-		    }
+                    }
 
                     fn support_resume(&mut self) -> Option<()> {
                         self.base_ops().resume_ops().map(drop)
@@ -228,7 +228,6 @@ commands! {
         "M" => _m_upcase::M<'a>,
         "qAttached" => _qAttached::qAttached,
         "qfThreadInfo" => _qfThreadInfo::qfThreadInfo,
-        "qC" => _qC::qC,
         "QStartNoAckMode" => _QStartNoAckMode::QStartNoAckMode,
         "qsThreadInfo" => _qsThreadInfo::qsThreadInfo,
         "qSupported" => _qSupported::qSupported<'a>,
@@ -257,6 +256,7 @@ commands! {
 
     extended_mode use 'a {
         "!" => exclamation_mark::ExclamationMark,
+        "qC" => _qC::qC,
         "QDisableRandomization" => _QDisableRandomization::QDisableRandomization,
         "QEnvironmentHexEncoded" => _QEnvironmentHexEncoded::QEnvironmentHexEncoded<'a>,
         "QEnvironmentReset" => _QEnvironmentReset::QEnvironmentReset,

--- a/src/stub/core_impl/base.rs
+++ b/src/stub/core_impl/base.rs
@@ -34,17 +34,26 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
         Ok(tid)
     }
 
-    pub(crate) fn get_sane_current_pid(
+    pub(crate) fn get_current_pid(
         &mut self,
         target: &mut T,
     ) -> Result<Pid, Error<T::Error, C::Error>> {
-        match target.base_ops() {
-            BaseOps::SingleThread(_) => Ok(FAKE_PID),
-            BaseOps::MultiThread(ops) => ops.active_pid().map_err(Error::TargetError),
+        if let Some(ops) = target
+            .support_extended_mode()
+            .and_then(|ops| ops.support_current_active_pid())
+        {
+            ops.current_active_pid().map_err(Error::TargetError)
+        } else {
+            Ok(FAKE_PID)
         }
     }
 
-    #[inline(always)]
+    // Used by `?` and `vAttach` to return a "reasonable" stop reason.
+    //
+    // This is a bit of an implementation wart, since this is really something
+    // the user ought to be able to customize.
+    //
+    // Works fine for now though...
     pub(crate) fn report_reasonable_stop_reason(
         &mut self,
         res: &mut ResponseWriter<'_, C>,
@@ -58,7 +67,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 pid: self
                     .features
                     .multiprocess()
-                    .then_some(SpecificIdKind::WithId(self.get_sane_current_pid(target)?)),
+                    .then_some(SpecificIdKind::WithId(self.get_current_pid(target)?)),
                 tid: SpecificIdKind::WithId(tid),
             })?;
         } else {
@@ -190,9 +199,11 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             }
 
             // -------------------- "Core" Functionality -------------------- //
-            // TODO: Improve the '?' response based on last-sent stop reason.
-            // this will be particularly relevant when working on non-stop mode.
-            Base::QuestionMark(_) => self.report_reasonable_stop_reason(res, target)?,
+            Base::QuestionMark(_) => {
+                // TODO: Improve the '?' response.
+                // this will be particularly relevant when working on non-stop mode.
+                self.report_reasonable_stop_reason(res, target)?
+            }
             Base::qAttached(cmd) => {
                 let is_attached = match target.support_extended_mode() {
                     // when _not_ running in extended mode, just report that we're attaching to an
@@ -349,62 +360,9 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 }
                 HandlerStatus::NeedsOk
             }
-            Base::qC(_) => {
-                res.write_str("QC")?;
-                let pid = self.get_sane_current_pid(target)?;
-
-                match target.base_ops() {
-                    BaseOps::SingleThread(_) => res.write_specific_thread_id(SpecificThreadId {
-                        pid: self
-                            .features
-                            .multiprocess()
-                            .then_some(SpecificIdKind::WithId(pid)),
-                        tid: SpecificIdKind::WithId(SINGLE_THREAD_TID),
-                    })?,
-                    BaseOps::MultiThread(ops) => {
-                        if self.current_mem_tid == SINGLE_THREAD_TID {
-                            let mut err: Result<_, Error<T::Error, C::Error>> = Ok(());
-                            let mut first = true;
-                            ops.list_active_threads(&mut |tid| {
-                                // TODO: replace this with a try block (once stabilized)
-                                let e = (|| {
-                                    if !first {
-                                        return Ok(());
-                                    }
-                                    first = false;
-                                    res.write_specific_thread_id(SpecificThreadId {
-                                        pid: self
-                                            .features
-                                            .multiprocess()
-                                            .then_some(SpecificIdKind::WithId(pid)),
-                                        tid: SpecificIdKind::WithId(tid),
-                                    })?;
-                                    Ok(())
-                                })();
-
-                                if let Err(e) = e {
-                                    err = Err(e)
-                                }
-                            })
-                            .map_err(Error::TargetError)?;
-                            err?
-                        } else {
-                            res.write_specific_thread_id(SpecificThreadId {
-                                pid: self
-                                    .features
-                                    .multiprocess()
-                                    .then_some(SpecificIdKind::WithId(pid)),
-                                tid: SpecificIdKind::WithId(self.current_mem_tid),
-                            })?;
-                        }
-                    }
-                }
-
-                HandlerStatus::Handled
-            }
             Base::qfThreadInfo(_) => {
                 res.write_str("m")?;
-                let pid = self.get_sane_current_pid(target)?;
+                let pid = self.get_current_pid(target)?;
 
                 match target.base_ops() {
                     BaseOps::SingleThread(_) => res.write_specific_thread_id(SpecificThreadId {

--- a/src/stub/core_impl/resume.rs
+++ b/src/stub/core_impl/resume.rs
@@ -272,7 +272,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 pid: self
                     .features
                     .multiprocess()
-                    .then_some(SpecificIdKind::WithId(self.get_sane_current_pid(target)?)),
+                    .then_some(SpecificIdKind::WithId(self.get_current_pid(target)?)),
                 tid: SpecificIdKind::WithId(tid),
             })?;
             res.write_str(";")?;

--- a/src/stub/error.rs
+++ b/src/stub/error.rs
@@ -61,6 +61,16 @@ pub enum GdbStubError<T, C> {
     /// [`Target::guard_rail_single_step_gdb_behavior`]:
     /// crate::target::Target::guard_rail_single_step_gdb_behavior
     SingleStepGdbBehavior(SingleStepGdbBehavior),
+    /// GDB client attempted to attach to a new process, but the target has not
+    /// implemented [`ExtendedMode::support_current_active_pid`].
+    ///
+    /// [`ExtendedMode::support_current_active_pid`]:
+    ///     crate::target::ext::extended_mode::ExtendedMode::support_current_active_pid
+    // DEVNOTE: this is a temporary workaround for something that can and should
+    // be caught at compile time via IDETs. That said, since i'm not sure when
+    // I'll find the time to cut a breaking release of gdbstub, I'd prefer to
+    // push out this feature as a non-breaking change now.
+    MissingCurrentActivePidImpl,
 
     // Internal - A non-fatal error occurred (with errno-style error code)
     //
@@ -119,6 +129,7 @@ where
                 )?;
                 write!(f, "See `Target::guard_rail_single_step_gdb_behavior` for more information.")
             },
+            MissingCurrentActivePidImpl => write!(f, "GDB client attempted to attach to a new process, but the target has not implemented support for `ExtendedMode::support_current_active_pid`"),
 
             NonFatalError(_) => write!(f, "Internal non-fatal error. End users should never see this! Please file an issue if you do!"),
         }

--- a/src/target/ext/base/multithread.rs
+++ b/src/target/ext/base/multithread.rs
@@ -2,9 +2,8 @@
 
 use crate::arch::Arch;
 use crate::common::Signal;
-use crate::common::{Pid, Tid};
+use crate::common::Tid;
 use crate::target::{Target, TargetResult};
-use crate::FAKE_PID;
 
 /// Base required debugging operations for multi threaded targets.
 pub trait MultiThreadBase: Target {
@@ -110,26 +109,6 @@ pub trait MultiThreadBase: Target {
         &mut self,
     ) -> Option<crate::target::ext::thread_extra_info::ThreadExtraInfoOps<'_, Self>> {
         None
-    }
-
-    /// Override the reported PID when running in multithread mode (default: 1)
-    ///
-    /// When implementing gdbstub on a platform that supports multiple
-    /// processes, the active PID needs to match the attached process.
-    /// Failing to do so will cause GDB to fail to attach to the target
-    /// process.
-    ///
-    /// This should reflect the currently-debugged process which should be
-    /// updated when switching processes after calling [`attach()`].
-    ///
-    /// This function is only useful if your target implements multiple
-    /// processes.
-    ///
-    /// [`attach()`]:
-    /// crate::target::ext::extended_mode::ExtendedMode::attach
-    #[inline(always)]
-    fn active_pid(&mut self) -> Result<Pid, Self::Error> {
-        Ok(FAKE_PID)
     }
 }
 


### PR DESCRIPTION
### Description

Follow up to #129 

Spent some time reworking the implementation in order to:
1. crunch down the binary size of targets uninterested in this functionality.
2. allow using vAttach on single-threaded targets

There are some "warts" in this implementation, owing to the fact that I'd like to land this as part of a non-breaking `0.6.x` release. Namely: the runtime bound that only allows using `attach` if `CurrentActivePid` is implemented.

Assuming we're happy with this PR, I'll open a follow-up tracking issue to resolve these API warts in 0.7.x.

### API Stability

- [x] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

### Checklist

<!-- CI takes care of a lot of things, but there are some things that have yet to be automated -->

- Documentation
  - [x] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
- Validation
  - [x] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [x] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below
- _If implementing a new protocol extension IDET_
  - [x] Included a basic sample implementation in `examples/armv4t`
  - [x] IDET can be optimized out (confirmed via `./example_no_std/check_size.sh`)

### Validation

<!-- example output, from https://github.com/daniel5151/gdbstub/pull/54 -->

<details>
<summary>GDB output</summary>

```
(gdb) target extended-remote :9001
Remote debugging using :9001
Reading /test.elf from remote target...
warning: File transfers from remote targets can be slow. Use "set sysroot" to access files locally instead.
Reading /test.elf from remote target...
Reading symbols from target:/test.elf...
main () at test.c:1
1       int main() {
(gdb) s
2           int x = 4;
(gdb) attach 7
A program is being debugged already.  Kill it? (y or n) y
Attaching to program: target:/test.elf, process 7
`target:/test.elf' has disappeared; keeping its symbols.
main () at test.c:2
2           int x = 4;
(gdb)
```

</details>

<details>
<summary>armv4t output</summary>

```
... snip ...
 TRACE gdbstub::protocol::recv_packet     > <-- $vKill;1#6e
GDB sent a kill request for pid Some(1)
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $vAttach;7#3d
GDB attached to a process with PID 7
 TRACE gdbstub::protocol::response_writer > --> $T05thread:p07.01;#0c
 TRACE gdbstub::protocol::recv_packet     > <-- $qC#b4
 TRACE gdbstub::protocol::response_writer > --> $QCp07.01#fa
 TRACE gdbstub::protocol::recv_packet     > <-- $Hgp7.1#b5
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:0,ffb#79
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<target version="1.0">
    <architecture>armv4t</architecture>
    <feature name="org.gnu.gdb.arm.core">
        <vector id="padding" type="uint32" count="25"/>

        <reg name="r0" bitsize="32" type="uint32"/>
        <reg name="r1" bitsize="32" type="uint32"/>
        <reg name="r2" bitsize="32" type="uint32"/>
        <reg name="r3" bitsize="32" type="uint32"/>
        <reg name="r4" bitsize="32" type="uint32"/>
        <reg name="r5" bitsize="32" type="uint32"/>
        <reg name="r6" bitsize="32" type="uint32"/>
        <reg name="r7" bitsize="32" type="uint32"/>
        <reg name="r8" bitsize="32" type="uint32"/>
        <reg name="r9" bitsize="32" type="uint32"/>
        <reg name="r10" bitsize="32" type="uint32"/>
        <reg name="r11" bitsize="32" type="uint32"/>
        <reg name="r12" bitsize="32" type="uint32"/>
        <reg name="sp" bitsize="32" type="data_ptr"/>
        <reg name="lr" bitsize="32"/>
        <reg name="pc" bitsize="32" type="code_ptr"/>

        <!--
            For some reason, my version of `gdb-multiarch` doesn't seem to
            respect "regnum", and will not parse this custom target.xml unless I
            manually include the padding bytes in the target description.

            On the bright side, AFAIK, there aren't all that many architectures
            that use padding bytes. Heck, the only reason armv4t uses padding is
            for historical reasons (see comment below).

            Odds are if you're defining your own custom arch, you won't run into
            this issue, since you can just lay out all the registers in the
            correct order.
        -->
        <reg name="padding" type="padding" bitsize="32"/>

        <!-- The CPSR is register 25, rather than register 16, because
        the FPA registers historically were placed between the PC
        and the CPSR in the "g" packet. -->
        <reg name="cpsr" bitsize="32" regnum="25"/>
    </feature>
    <xi:include href="extra.xml"/>
</target>#38
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:80d,ffb#15
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:extra.xml:0,ffb#16
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<feature name="custom-armv4t-extension">
    <!--
        maps to a simple scratch register within the emulator. the GDB
        client can read the register using `p }custom` and set it using
        `set }custom=1337`
    -->
    <reg name="custom" bitsize="32" type="uint32"/>

    <!--
        pseudo-register that return the current time when read.

        notably, i've set up the target to NOT send this register as part of
        the regular register list, which means that GDB will fetch/update
        this register via the 'p' and 'P' packets respectively
    -->
    <reg name="time" bitsize="32" type="uint32"/>

    <!--
        pseudo-register that is always unavailable.

        it is supposed to be reported as 'x'-ed bytes in replies to 'p' packets
        and shown by the GDB client as "<unavailable>".
    -->
    <reg name="unavailable" bitsize="32" type="uint32"/>
</feature>#7d
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:extra.xml:3c5,ffb#b1
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fcffff0f00000000e8ffff0f785634120c005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1000000078563412#06
 TRACE gdbstub::protocol::recv_packet     > <-- $qOffsets#4b
 TRACE gdbstub::protocol::response_writer > --> $Text=00;Data=00;Bss=00#94
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::0,ffb#d8
 TRACE gdbstub::protocol::response_writer > --> $m#bb
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::8,ffb#e0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp07.01#d3
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::0,ffb#18
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE memory-map
    PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN"
            "http://sourceware.org/gdb/gdb-memory-map.dtd">
<memory-map>
    <memory type="ram" start="0x0" length="0x100000000"/>
</memory-map>#76
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::f4,ffb#82
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,4#69
 TRACE gdbstub::protocol::response_writer > --> $14d04de2#28
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,4#69
 TRACE gdbstub::protocol::response_writer > --> $14d04de2#28
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,2#92
 TRACE gdbstub::protocol::response_writer > --> $0430#c7
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000a,2#90
 TRACE gdbstub::protocol::response_writer > --> $4de2#2f
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,2#67
 TRACE gdbstub::protocol::response_writer > --> $14d0#f9
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,2#92
 TRACE gdbstub::protocol::response_writer > --> $0430#c7
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000a,2#90
 TRACE gdbstub::protocol::response_writer > --> $4de2#2f
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,2#67
 TRACE gdbstub::protocol::response_writer > --> $14d0#f9
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,4#69
 TRACE gdbstub::protocol::response_writer > --> $14d04de2#28
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,4#69
 TRACE gdbstub::protocol::response_writer > --> $14d04de2#28
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
```
</details>

<details>
<summary>Before/After `./example_no_std/check_size.sh` output</summary>

### Before #129 

```
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     680
.note.gnu.build-id      36     708
.note.ABI-tag           32     744
.gnu.hash               36     776
.dynsym                360     816
.dynstr                193    1176
.gnu.version            30    1370
.gnu.version_r          48    1400
.rela.dyn              408    1448
.init                   27    4096
.plt                    16    4128
.plt.got                 8    4144
.text                14853    4160
.fini                   13   19016
.rodata                946   20480
.eh_frame_hdr          276   21428
.eh_frame             1408   21704
.init_array              8   28072
.fini_array              8   28080
.dynamic               448   28088
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                43       0
Total                19377
```

### After #129 

```
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     680
.note.gnu.build-id      36     708
.note.ABI-tag           32     744
.gnu.hash               36     776
.dynsym                360     816
.dynstr                193    1176
.gnu.version            30    1370
.gnu.version_r          48    1400
.rela.dyn              408    1448
.init                   27    4096
.plt                    16    4128
.plt.got                 8    4144
.text                15429    4160
.fini                   13   19592
.rodata                954   20480
.eh_frame_hdr          276   21436
.eh_frame             1408   21712
.init_array              8   28072
.fini_array              8   28080
.dynamic               448   28088
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                43       0
Total                19961
```

### This PR

```
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     680
.note.gnu.build-id      36     708
.note.ABI-tag           32     744
.gnu.hash               36     776
.dynsym                360     816
.dynstr                193    1176
.gnu.version            30    1370
.gnu.version_r          48    1400
.rela.dyn              408    1448
.init                   27    4096
.plt                    16    4128
.plt.got                 8    4144
.text                14853    4160
.fini                   13   19016
.rodata                946   20480
.eh_frame_hdr          276   21428
.eh_frame             1408   21704
.init_array              8   28072
.fini_array              8   28080
.dynamic               448   28088
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                43       0
Total                19377
```

</details>
