### PR TITLE
Toggle support for `QStartNoAckMode`

### DIFF
--- a/example_no_std/src/gdb.rs
+++ b/example_no_std/src/gdb.rs
@@ -22,6 +22,12 @@ impl Target for DummyTarget {
         target::ext::base::BaseOps::MultiThread(self)
     }
 
+    // disable `QStartNoAckMode`
+    #[inline(always)]
+    fn use_no_ack_mode(&self) -> bool {
+        false
+    }
+
     // disable X packet optimization in order to save space
     #[inline(always)]
     fn use_x_upcase_packet(&self) -> bool {

--- a/example_no_std/src/gdb.rs
+++ b/example_no_std/src/gdb.rs
@@ -22,7 +22,7 @@ impl Target for DummyTarget {
         target::ext::base::BaseOps::MultiThread(self)
     }
 
-    // disable `QStartNoAckMode`
+    // disable `QStartNoAckMode` in order to save space
     #[inline(always)]
     fn use_no_ack_mode(&self) -> bool {
         false

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -91,6 +91,7 @@ macro_rules! commands {
                     fn support_single_register_access(&mut self) -> Option<()>;
                     fn support_reverse_step(&mut self) -> Option<()>;
                     fn support_reverse_cont(&mut self) -> Option<()>;
+                    fn support_no_ack_mode(&mut self) -> Option<()>;
                     fn support_x_upcase_packet(&mut self) -> Option<()>;
                     fn support_thread_extra_info(&mut self) -> Option<()>;
                 }
@@ -154,6 +155,14 @@ macro_rules! commands {
 
                     fn support_x_upcase_packet(&mut self) -> Option<()> {
                         if self.use_x_upcase_packet() {
+                            Some(())
+                        } else {
+                            None
+                        }
+                    }
+
+                    fn support_no_ack_mode(&mut self) -> Option<()> {
+                        if self.use_no_ack_mode() {
                             Some(())
                         } else {
                             None
@@ -229,7 +238,6 @@ commands! {
         "qAttached" => _qAttached::qAttached,
         "qfThreadInfo" => _qfThreadInfo::qfThreadInfo,
         "qC" => _qC::qC,
-        "QStartNoAckMode" => _QStartNoAckMode::QStartNoAckMode,
         "qsThreadInfo" => _qsThreadInfo::qsThreadInfo,
         "qSupported" => _qSupported::qSupported<'a>,
         "T" => _t_upcase::T,
@@ -248,6 +256,10 @@ commands! {
 
     x_upcase_packet use 'a {
         "X" => _x_upcase::X<'a>,
+    }
+
+    no_ack_mode {
+        "QStartNoAckMode" => _QStartNoAckMode::QStartNoAckMode,
     }
 
     single_register_access use 'a {

--- a/src/stub/core_impl.rs
+++ b/src/stub/core_impl.rs
@@ -31,6 +31,7 @@ mod host_io;
 mod lldb_register_info;
 mod memory_map;
 mod monitor_cmd;
+mod no_ack_mode;
 mod resume;
 mod reverse_exec;
 mod section_offsets;
@@ -194,6 +195,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Command::Base(cmd) => self.handle_base(res, target, cmd),
             Command::TargetXml(cmd) => self.handle_target_xml(res, target, cmd),
             Command::Resume(cmd) => self.handle_stop_resume(res, target, cmd),
+            Command::NoAckMode(cmd) => self.handle_no_ack_mode(res, target, cmd),
             Command::XUpcasePacket(cmd) => self.handle_x_upcase_packet(res, target, cmd),
             Command::SingleRegisterAccess(cmd) => {
                 self.handle_single_register_access(res, target, cmd)

--- a/src/stub/core_impl/base.rs
+++ b/src/stub/core_impl/base.rs
@@ -184,10 +184,6 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
                 HandlerStatus::Handled
             }
-            Base::QStartNoAckMode(_) => {
-                self.features.set_no_ack_mode(true);
-                HandlerStatus::NeedsOk
-            }
 
             // -------------------- "Core" Functionality -------------------- //
             // TODO: Improve the '?' response based on last-sent stop reason.

--- a/src/stub/core_impl/base.rs
+++ b/src/stub/core_impl/base.rs
@@ -100,11 +100,11 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 res.write_num(cmd.packet_buffer_len)?;
 
                 // these are the few features that gdbstub unconditionally supports
-                res.write_str(concat!(
-                    ";vContSupported+",
-                    ";multiprocess+",
-                    ";QStartNoAckMode+",
-                ))?;
+                res.write_str(concat!(";vContSupported+", ";multiprocess+",))?;
+
+                if target.use_no_ack_mode() {
+                    res.write_str(";QStartNoAckMode+")?;
+                }
 
                 if let Some(resume_ops) = target.base_ops().resume_ops() {
                     let (reverse_cont, reverse_step) = match resume_ops {

--- a/src/stub/core_impl/no_ack_mode.rs
+++ b/src/stub/core_impl/no_ack_mode.rs
@@ -1,0 +1,25 @@
+use super::prelude::*;
+use crate::protocol::commands::ext::NoAckMode;
+
+impl<T: Target, C: Connection> GdbStubImpl<T, C> {
+    pub(crate) fn handle_no_ack_mode(
+        &mut self,
+        _res: &mut ResponseWriter<'_, C>,
+        target: &mut T,
+        command: NoAckMode,
+    ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
+        if !target.use_no_ack_mode() {
+            return Ok(HandlerStatus::Handled);
+        }
+
+        crate::__dead_code_marker!("no_ack_mode", "impl");
+
+        let handler_status = match command {
+            NoAckMode::QStartNoAckMode(_) => {
+                self.features.set_no_ack_mode(true);
+                HandlerStatus::NeedsOk
+            }
+        };
+        Ok(handler_status)
+    }
+}

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -543,6 +543,14 @@ pub trait Target {
         true
     }
 
+    /// Enable/disable `QStartNoAckMode`
+    ///
+    /// By default, this method returns `true`.
+    #[inline(always)]
+    fn use_no_ack_mode(&self) -> bool {
+        true
+    }
+
     /// Whether `gdbstub` should provide a "stub" `resume` implementation on
     /// targets without support for resumption.
     ///
@@ -728,6 +736,7 @@ macro_rules! impl_dyn_target {
             __delegate!(fn guard_rail_single_step_gdb_behavior(&self) -> SingleStepGdbBehavior);
 
             __delegate!(fn use_x_upcase_packet(&self) -> bool);
+            __delegate!(fn use_no_ack_mode(&self) -> bool);
             __delegate!(fn use_resume_stub(&self) -> bool);
             __delegate!(fn use_rle(&self) -> bool);
             __delegate!(fn use_target_description_xml(&self) -> bool);

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -530,6 +530,14 @@ pub trait Target {
         <Self::Arch as Arch>::single_step_gdb_behavior()
     }
 
+    /// Enable/disable `QStartNoAckMode`
+    ///
+    /// By default, this method returns `true`.
+    #[inline(always)]
+    fn use_no_ack_mode(&self) -> bool {
+        true
+    }
+
     /// Enable/disable using the more efficient `X` packet to write to target
     /// memory (as opposed to the basic `M` packet).
     ///
@@ -540,14 +548,6 @@ pub trait Target {
     /// optimization enabled.
     #[inline(always)]
     fn use_x_upcase_packet(&self) -> bool {
-        true
-    }
-
-    /// Enable/disable `QStartNoAckMode`
-    ///
-    /// By default, this method returns `true`.
-    #[inline(always)]
-    fn use_no_ack_mode(&self) -> bool {
         true
     }
 
@@ -735,8 +735,8 @@ macro_rules! impl_dyn_target {
             __delegate!(fn guard_rail_implicit_sw_breakpoints(&self) -> bool);
             __delegate!(fn guard_rail_single_step_gdb_behavior(&self) -> SingleStepGdbBehavior);
 
-            __delegate!(fn use_x_upcase_packet(&self) -> bool);
             __delegate!(fn use_no_ack_mode(&self) -> bool);
+            __delegate!(fn use_x_upcase_packet(&self) -> bool);
             __delegate!(fn use_resume_stub(&self) -> bool);
             __delegate!(fn use_rle(&self) -> bool);
             __delegate!(fn use_target_description_xml(&self) -> bool);


### PR DESCRIPTION
### Description

<!-- Please include a brief description of what is being added/changed -->

This PR makes the feature `QStartNoAckMode` toggleable.

Closes #134

### API Stability

- [x] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

### Checklist

<!-- CI takes care of a lot of things, but there are some things that have yet to be automated -->

- Documentation
  - [x] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [ ] (if appropriate) Added feature to "Debugging Features" in README.md
- Validation
  - [ ] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [x] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below
- _If implementing a new protocol extension IDET_
  - [ ] Included a basic sample implementation in `examples/armv4t`
  - [x] IDET can be optimized out (confirmed via `./example_no_std/check_size.sh`)
  - [ ] **OR** implementation requires introducing non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [ ] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- Oh, and if you're integrating `gdbstub` in an open-source project, do consider updating the README.md's "Real World Examples" section to link back to your project! -->

### Validation

<details>
<summary>Before/After `./example_no_std/check_size.sh` output</summary>

### Before

```
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     792
.note.gnu.property      32     824
.note.gnu.build-id      36     856
.note.ABI-tag           32     892
.gnu.hash               28     928
.dynsym                360     960
.dynstr                204    1320
.gnu.version            30    1524
.gnu.version_r          64    1560
.rela.dyn              408    1624
.init                   27    4096
.text                15158    4128
.fini                   13   19288
.rodata                954   20480
.eh_frame_hdr          244   21436
.eh_frame             1252   21680
.init_array              8   28088
.fini_array              8   28096
.dynamic               432   28104
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                27       0
Total                19497
```

### After 2bc3d4ff1de138d1fa028ecbc2f29aa18d40fc77

```
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     792
.note.gnu.property      32     824
.note.gnu.build-id      36     856
.note.ABI-tag           32     892
.gnu.hash               28     928
.dynsym                360     960
.dynstr                204    1320
.gnu.version            30    1524
.gnu.version_r          64    1560
.rela.dyn              408    1624
.init                   27    4096
.text                15158    4128
.fini                   13   19288
.rodata                930   20480
.eh_frame_hdr          244   21412
.eh_frame             1252   21656
.init_array              8   28088
.fini_array              8   28096
.dynamic               432   28104
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                27       0
Total                19473
```

### After 3e7e6a8a71b9af51ca99a463e0d9c4c2fe6ce141

```
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     792
.note.gnu.property      32     824
.note.gnu.build-id      36     856
.note.ABI-tag           32     892
.gnu.hash               28     928
.dynsym                360     960
.dynstr                204    1320
.gnu.version            30    1524
.gnu.version_r          64    1560
.rela.dyn              408    1624
.init                   27    4096
.text                14949    4128
.fini                   13   19080
.rodata                930   20480
.eh_frame_hdr          244   21412
.eh_frame             1252   21656
.init_array              8   28088
.fini_array              8   28096
.dynamic               432   28104
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                27       0
Total                19264
```
</details>
