### PR TITLE
Update bitflags to 2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools::debugging", "embedded", "emulators", "network-
 exclude = ["examples/**/*.elf", "examples/**/*.o"]
 
 [dependencies]
-bitflags = "1.3"
+bitflags = "2.4"
 cfg-if = "1.0"
 log = "0.4"
 managed = { version = "0.8", default-features = false }

--- a/src/target/ext/host_io.rs
+++ b/src/target/ext/host_io.rs
@@ -11,6 +11,7 @@ bitflags! {
     /// [Open Flags](https://sourceware.org/gdb/current/onlinedocs/gdb/Open-Flags.html#Open-Flags),
     /// and the LLDB source code at
     /// [`lldb/include/lldb/Host/File.h`](https://github.com/llvm/llvm-project/blob/ec642ceebc1aacc8b16249df7734b8cf90ae2963/lldb/include/lldb/Host/File.h#L47-L66)
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct HostIoOpenFlags: u32 {
         /// A read-only file.
         const O_RDONLY = 0x0;
@@ -43,6 +44,7 @@ bitflags! {
     ///
     /// Extracted from the GDB documentation at
     /// [mode_t Values](https://sourceware.org/gdb/current/onlinedocs/gdb/mode_005ft-Values.html#mode_005ft-Values)
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct HostIoOpenMode: u32 {
         /// A regular file.
         const S_IFREG = 0o100000;


### PR DESCRIPTION
### Description

This pull request simply updates bitflags to the latest version. 
The reason why this is important is that the Android Open Source Project uses gdbstub amongst other crates. Currently, AOSP both depends on bitflags 1.x.x and bitflags 2.x.x, and I'm trying to bring everything to v2.
Thanks!

### API Stability

No API change

### Checklist

- Documentation
  - [x] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [-] (if appropriate) Added feature to "Debugging Features" in README.md
- Validation
  - [-] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [x] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below
- _If implementing a new protocol extension IDET_
  - [-] Included a basic sample implementation in `examples/armv4t`
  - [-] IDET can be optimized out (confirmed via `./example_no_std/check_size.sh`)
  - [-] **OR** implementation requires introducing non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [-] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- Oh, and if you're integrating `gdbstub` in an open-source project, do consider updating the README.md's "Real World Examples" section to link back to your project! -->

### Validation

<details>
<summary>Before/After `./example_no_std/check_size.sh` output</summary>

### Before

```
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     792
.note.gnu.property      32     824
.note.gnu.build-id      36     856
.note.ABI-tag           32     892
.gnu.hash               36     928
.dynsym                360     968
.dynstr                204    1328
.gnu.version            30    1532
.gnu.version_r          64    1568
.rela.dyn              408    1632
.init                   23    4096
.plt                    16    4128
.plt.got                 8    4144
.text                16206    4160
.fini                    9   20368
.rodata                922   20480
.eh_frame_hdr          260   21404
.eh_frame             1380   21664
.init_array              8   28072
.fini_array              8   28080
.dynamic               448   28088
.got                   136   28536
.data                    8   28672
.bss                     8   28680
.comment                30       0
Total                20700
```

### After

```
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     792
.note.gnu.property      32     824
.note.gnu.build-id      36     856
.note.ABI-tag           32     892
.gnu.hash               36     928
.dynsym                360     968
.dynstr                204    1328
.gnu.version            30    1532
.gnu.version_r          64    1568
.rela.dyn              408    1632
.init                   23    4096
.plt                    16    4128
.plt.got                 8    4144
.text                16770    4160
.fini                    9   20932
.rodata               1178   24576
.eh_frame_hdr          268   25756
.eh_frame             1436   26024
.init_array              8   32168
.fini_array              8   32176
.dynamic               448   32184
.got                   136   32632
.data                    8   32768
.bss                     8   32776
.comment                30       0
Total                21584
```

</details>