### PR TITLE
RISC-V: List all integer registers for lldb compatibility

### DIFF
--- a/gdbstub_arch/src/riscv/mod.rs
+++ b/gdbstub_arch/src/riscv/mod.rs
@@ -15,21 +15,108 @@ pub enum Riscv64 {}
 impl Arch for Riscv32 {
     type Usize = u32;
     type Registers = reg::RiscvCoreRegs<u32>;
-    type RegId = reg::id::RiscvRegId<u32>;
     type BreakpointKind = usize;
+    type RegId = reg::id::RiscvRegId<u32>;
 
     fn target_description_xml() -> Option<&'static str> {
-        Some(r#"<target version="1.0"><architecture>riscv:rv32</architecture></target>"#)
+        // Source: https://github.com/bminor/binutils-gdb/blob/master/gdb/features/riscv/32bit-cpu.xml
+        // <!-- Copyright (C) 2018-2024 Free Software Foundation, Inc.
+        //
+        // Copying and distribution of this file, with or without modification,
+        // are permitted in any medium without royalty provided the copyright
+        // notice and this notice are preserved.  -->
+        Some(r#"<target version="1.0">
+<architecture>riscv:rv32</architecture>
+<feature name="org.gnu.gdb.riscv.cpu">
+  <reg name="zero" bitsize="32" type="int" regnum="0"/>
+  <reg name="ra" bitsize="32" type="code_ptr"/>
+  <reg name="sp" bitsize="32" type="data_ptr"/>
+  <reg name="gp" bitsize="32" type="data_ptr"/>
+  <reg name="tp" bitsize="32" type="data_ptr"/>
+  <reg name="t0" bitsize="32" type="int"/>
+  <reg name="t1" bitsize="32" type="int"/>
+  <reg name="t2" bitsize="32" type="int"/>
+  <reg name="fp" bitsize="32" type="data_ptr"/>
+  <reg name="s1" bitsize="32" type="int"/>
+  <reg name="a0" bitsize="32" type="int"/>
+  <reg name="a1" bitsize="32" type="int"/>
+  <reg name="a2" bitsize="32" type="int"/>
+  <reg name="a3" bitsize="32" type="int"/>
+  <reg name="a4" bitsize="32" type="int"/>
+  <reg name="a5" bitsize="32" type="int"/>
+  <reg name="a6" bitsize="32" type="int"/>
+  <reg name="a7" bitsize="32" type="int"/>
+  <reg name="s2" bitsize="32" type="int"/>
+  <reg name="s3" bitsize="32" type="int"/>
+  <reg name="s4" bitsize="32" type="int"/>
+  <reg name="s5" bitsize="32" type="int"/>
+  <reg name="s6" bitsize="32" type="int"/>
+  <reg name="s7" bitsize="32" type="int"/>
+  <reg name="s8" bitsize="32" type="int"/>
+  <reg name="s9" bitsize="32" type="int"/>
+  <reg name="s10" bitsize="32" type="int"/>
+  <reg name="s11" bitsize="32" type="int"/>
+  <reg name="t3" bitsize="32" type="int"/>
+  <reg name="t4" bitsize="32" type="int"/>
+  <reg name="t5" bitsize="32" type="int"/>
+  <reg name="t6" bitsize="32" type="int"/>
+  <reg name="pc" bitsize="32" type="code_ptr"/>
+</feature>
+</target>"#)
     }
 }
 
 impl Arch for Riscv64 {
     type Usize = u64;
     type Registers = reg::RiscvCoreRegs<u64>;
-    type RegId = reg::id::RiscvRegId<u64>;
     type BreakpointKind = usize;
+    type RegId = reg::id::RiscvRegId<u64>;
 
     fn target_description_xml() -> Option<&'static str> {
-        Some(r#"<target version="1.0"><architecture>riscv:rv64</architecture></target>"#)
+        // Source: https://github.com/bminor/binutils-gdb/blob/master/gdb/features/riscv/64bit-cpu.xml
+        // <!-- Copyright (C) 2018-2024 Free Software Foundation, Inc.
+        //
+        // Copying and distribution of this file, with or without modification,
+        // are permitted in any medium without royalty provided the copyright
+        // notice and this notice are preserved.  -->
+
+        Some(r#"<target version="1.0">
+<architecture>riscv:rv64</architecture>
+<feature name="org.gnu.gdb.riscv.cpu">
+  <reg name="zero" bitsize="64" type="int" regnum="0"/>
+  <reg name="ra" bitsize="64" type="code_ptr"/>
+  <reg name="sp" bitsize="64" type="data_ptr"/>
+  <reg name="gp" bitsize="64" type="data_ptr"/>
+  <reg name="tp" bitsize="64" type="data_ptr"/>
+  <reg name="t0" bitsize="64" type="int"/>
+  <reg name="t1" bitsize="64" type="int"/>
+  <reg name="t2" bitsize="64" type="int"/>
+  <reg name="fp" bitsize="64" type="data_ptr"/>
+  <reg name="s1" bitsize="64" type="int"/>
+  <reg name="a0" bitsize="64" type="int"/>
+  <reg name="a1" bitsize="64" type="int"/>
+  <reg name="a2" bitsize="64" type="int"/>
+  <reg name="a3" bitsize="64" type="int"/>
+  <reg name="a4" bitsize="64" type="int"/>
+  <reg name="a5" bitsize="64" type="int"/>
+  <reg name="a6" bitsize="64" type="int"/>
+  <reg name="a7" bitsize="64" type="int"/>
+  <reg name="s2" bitsize="64" type="int"/>
+  <reg name="s3" bitsize="64" type="int"/>
+  <reg name="s4" bitsize="64" type="int"/>
+  <reg name="s5" bitsize="64" type="int"/>
+  <reg name="s6" bitsize="64" type="int"/>
+  <reg name="s7" bitsize="64" type="int"/>
+  <reg name="s8" bitsize="64" type="int"/>
+  <reg name="s9" bitsize="64" type="int"/>
+  <reg name="s10" bitsize="64" type="int"/>
+  <reg name="s11" bitsize="64" type="int"/>
+  <reg name="t3" bitsize="64" type="int"/>
+  <reg name="t4" bitsize="64" type="int"/>
+  <reg name="t5" bitsize="64" type="int"/>
+  <reg name="t6" bitsize="64" type="int"/>
+  <reg name="pc" bitsize="64" type="code_ptr"/>
+</feature>
+</target>"#)
     }
 }

--- a/gdbstub_arch/src/riscv/mod.rs
+++ b/gdbstub_arch/src/riscv/mod.rs
@@ -19,50 +19,7 @@ impl Arch for Riscv32 {
     type RegId = reg::id::RiscvRegId<u32>;
 
     fn target_description_xml() -> Option<&'static str> {
-        // Source: https://github.com/bminor/binutils-gdb/blob/master/gdb/features/riscv/32bit-cpu.xml
-        // <!-- Copyright (C) 2018-2024 Free Software Foundation, Inc.
-        //
-        // Copying and distribution of this file, with or without modification,
-        // are permitted in any medium without royalty provided the copyright
-        // notice and this notice are preserved.  -->
-        Some(r#"<target version="1.0">
-<architecture>riscv:rv32</architecture>
-<feature name="org.gnu.gdb.riscv.cpu">
-  <reg name="zero" bitsize="32" type="int" regnum="0"/>
-  <reg name="ra" bitsize="32" type="code_ptr"/>
-  <reg name="sp" bitsize="32" type="data_ptr"/>
-  <reg name="gp" bitsize="32" type="data_ptr"/>
-  <reg name="tp" bitsize="32" type="data_ptr"/>
-  <reg name="t0" bitsize="32" type="int"/>
-  <reg name="t1" bitsize="32" type="int"/>
-  <reg name="t2" bitsize="32" type="int"/>
-  <reg name="fp" bitsize="32" type="data_ptr"/>
-  <reg name="s1" bitsize="32" type="int"/>
-  <reg name="a0" bitsize="32" type="int"/>
-  <reg name="a1" bitsize="32" type="int"/>
-  <reg name="a2" bitsize="32" type="int"/>
-  <reg name="a3" bitsize="32" type="int"/>
-  <reg name="a4" bitsize="32" type="int"/>
-  <reg name="a5" bitsize="32" type="int"/>
-  <reg name="a6" bitsize="32" type="int"/>
-  <reg name="a7" bitsize="32" type="int"/>
-  <reg name="s2" bitsize="32" type="int"/>
-  <reg name="s3" bitsize="32" type="int"/>
-  <reg name="s4" bitsize="32" type="int"/>
-  <reg name="s5" bitsize="32" type="int"/>
-  <reg name="s6" bitsize="32" type="int"/>
-  <reg name="s7" bitsize="32" type="int"/>
-  <reg name="s8" bitsize="32" type="int"/>
-  <reg name="s9" bitsize="32" type="int"/>
-  <reg name="s10" bitsize="32" type="int"/>
-  <reg name="s11" bitsize="32" type="int"/>
-  <reg name="t3" bitsize="32" type="int"/>
-  <reg name="t4" bitsize="32" type="int"/>
-  <reg name="t5" bitsize="32" type="int"/>
-  <reg name="t6" bitsize="32" type="int"/>
-  <reg name="pc" bitsize="32" type="code_ptr"/>
-</feature>
-</target>"#)
+        Some(include_str!("rv32i.xml"))
     }
 }
 
@@ -73,50 +30,6 @@ impl Arch for Riscv64 {
     type RegId = reg::id::RiscvRegId<u64>;
 
     fn target_description_xml() -> Option<&'static str> {
-        // Source: https://github.com/bminor/binutils-gdb/blob/master/gdb/features/riscv/64bit-cpu.xml
-        // <!-- Copyright (C) 2018-2024 Free Software Foundation, Inc.
-        //
-        // Copying and distribution of this file, with or without modification,
-        // are permitted in any medium without royalty provided the copyright
-        // notice and this notice are preserved.  -->
-
-        Some(r#"<target version="1.0">
-<architecture>riscv:rv64</architecture>
-<feature name="org.gnu.gdb.riscv.cpu">
-  <reg name="zero" bitsize="64" type="int" regnum="0"/>
-  <reg name="ra" bitsize="64" type="code_ptr"/>
-  <reg name="sp" bitsize="64" type="data_ptr"/>
-  <reg name="gp" bitsize="64" type="data_ptr"/>
-  <reg name="tp" bitsize="64" type="data_ptr"/>
-  <reg name="t0" bitsize="64" type="int"/>
-  <reg name="t1" bitsize="64" type="int"/>
-  <reg name="t2" bitsize="64" type="int"/>
-  <reg name="fp" bitsize="64" type="data_ptr"/>
-  <reg name="s1" bitsize="64" type="int"/>
-  <reg name="a0" bitsize="64" type="int"/>
-  <reg name="a1" bitsize="64" type="int"/>
-  <reg name="a2" bitsize="64" type="int"/>
-  <reg name="a3" bitsize="64" type="int"/>
-  <reg name="a4" bitsize="64" type="int"/>
-  <reg name="a5" bitsize="64" type="int"/>
-  <reg name="a6" bitsize="64" type="int"/>
-  <reg name="a7" bitsize="64" type="int"/>
-  <reg name="s2" bitsize="64" type="int"/>
-  <reg name="s3" bitsize="64" type="int"/>
-  <reg name="s4" bitsize="64" type="int"/>
-  <reg name="s5" bitsize="64" type="int"/>
-  <reg name="s6" bitsize="64" type="int"/>
-  <reg name="s7" bitsize="64" type="int"/>
-  <reg name="s8" bitsize="64" type="int"/>
-  <reg name="s9" bitsize="64" type="int"/>
-  <reg name="s10" bitsize="64" type="int"/>
-  <reg name="s11" bitsize="64" type="int"/>
-  <reg name="t3" bitsize="64" type="int"/>
-  <reg name="t4" bitsize="64" type="int"/>
-  <reg name="t5" bitsize="64" type="int"/>
-  <reg name="t6" bitsize="64" type="int"/>
-  <reg name="pc" bitsize="64" type="code_ptr"/>
-</feature>
-</target>"#)
+        Some(include_str!("rv64i.xml"))
     }
 }

--- a/gdbstub_arch/src/riscv/rv32i.xml
+++ b/gdbstub_arch/src/riscv/rv32i.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2024 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!-- Register numbers are hard-coded in order to maintain backward
+     compatibility with older versions of tools that didn't use xml
+     register descriptions.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.riscv.cpu">
+  <reg name="zero" bitsize="32" type="int" regnum="0"/>
+  <reg name="ra" bitsize="32" type="code_ptr"/>
+  <reg name="sp" bitsize="32" type="data_ptr"/>
+  <reg name="gp" bitsize="32" type="data_ptr"/>
+  <reg name="tp" bitsize="32" type="data_ptr"/>
+  <reg name="t0" bitsize="32" type="int"/>
+  <reg name="t1" bitsize="32" type="int"/>
+  <reg name="t2" bitsize="32" type="int"/>
+  <reg name="fp" bitsize="32" type="data_ptr"/>
+  <reg name="s1" bitsize="32" type="int"/>
+  <reg name="a0" bitsize="32" type="int"/>
+  <reg name="a1" bitsize="32" type="int"/>
+  <reg name="a2" bitsize="32" type="int"/>
+  <reg name="a3" bitsize="32" type="int"/>
+  <reg name="a4" bitsize="32" type="int"/>
+  <reg name="a5" bitsize="32" type="int"/>
+  <reg name="a6" bitsize="32" type="int"/>
+  <reg name="a7" bitsize="32" type="int"/>
+  <reg name="s2" bitsize="32" type="int"/>
+  <reg name="s3" bitsize="32" type="int"/>
+  <reg name="s4" bitsize="32" type="int"/>
+  <reg name="s5" bitsize="32" type="int"/>
+  <reg name="s6" bitsize="32" type="int"/>
+  <reg name="s7" bitsize="32" type="int"/>
+  <reg name="s8" bitsize="32" type="int"/>
+  <reg name="s9" bitsize="32" type="int"/>
+  <reg name="s10" bitsize="32" type="int"/>
+  <reg name="s11" bitsize="32" type="int"/>
+  <reg name="t3" bitsize="32" type="int"/>
+  <reg name="t4" bitsize="32" type="int"/>
+  <reg name="t5" bitsize="32" type="int"/>
+  <reg name="t6" bitsize="32" type="int"/>
+  <reg name="pc" bitsize="32" type="code_ptr"/>
+</feature>

--- a/gdbstub_arch/src/riscv/rv64i.xml
+++ b/gdbstub_arch/src/riscv/rv64i.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2024 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!-- Register numbers are hard-coded in order to maintain backward
+     compatibility with older versions of tools that didn't use xml
+     register descriptions.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.riscv.cpu">
+  <reg name="zero" bitsize="64" type="int" regnum="0"/>
+  <reg name="ra" bitsize="64" type="code_ptr"/>
+  <reg name="sp" bitsize="64" type="data_ptr"/>
+  <reg name="gp" bitsize="64" type="data_ptr"/>
+  <reg name="tp" bitsize="64" type="data_ptr"/>
+  <reg name="t0" bitsize="64" type="int"/>
+  <reg name="t1" bitsize="64" type="int"/>
+  <reg name="t2" bitsize="64" type="int"/>
+  <reg name="fp" bitsize="64" type="data_ptr"/>
+  <reg name="s1" bitsize="64" type="int"/>
+  <reg name="a0" bitsize="64" type="int"/>
+  <reg name="a1" bitsize="64" type="int"/>
+  <reg name="a2" bitsize="64" type="int"/>
+  <reg name="a3" bitsize="64" type="int"/>
+  <reg name="a4" bitsize="64" type="int"/>
+  <reg name="a5" bitsize="64" type="int"/>
+  <reg name="a6" bitsize="64" type="int"/>
+  <reg name="a7" bitsize="64" type="int"/>
+  <reg name="s2" bitsize="64" type="int"/>
+  <reg name="s3" bitsize="64" type="int"/>
+  <reg name="s4" bitsize="64" type="int"/>
+  <reg name="s5" bitsize="64" type="int"/>
+  <reg name="s6" bitsize="64" type="int"/>
+  <reg name="s7" bitsize="64" type="int"/>
+  <reg name="s8" bitsize="64" type="int"/>
+  <reg name="s9" bitsize="64" type="int"/>
+  <reg name="s10" bitsize="64" type="int"/>
+  <reg name="s11" bitsize="64" type="int"/>
+  <reg name="t3" bitsize="64" type="int"/>
+  <reg name="t4" bitsize="64" type="int"/>
+  <reg name="t5" bitsize="64" type="int"/>
+  <reg name="t6" bitsize="64" type="int"/>
+  <reg name="pc" bitsize="64" type="code_ptr"/>
+</feature>


### PR DESCRIPTION
### Description

lldb requires a full list of registers in the target_description_xml (gdb on the other hand seems to ignore the list completely).

The gdb manual sounds like these registers should exist anyway:
> The ‘org.gnu.gdb.riscv.cpu’ feature is required for RISC-V targets. It should contain the registers ‘x0’ through ‘x31’, and ‘pc’.

Therefore it seems reasonable that the RISC-V arch returns the full list.

### API Stability

- [x] This PR does not require a breaking API change

### Checklist

<!-- CI takes care of a lot of things, but there are some things that have yet to be automated -->

- _If upstreaming an `Arch` implementation_
  - [x] I have tested this code in my project, and to the best of my knowledge, it is working as intended (see issue)

### Validation

<!-- example output, from https://github.com/daniel5151/gdbstub/pull/54 -->

<details>
<summary>LLDB output (before this change)</summary>

```
~/source/my_emulator % lldb target/last-image
(lldb) target create "target/last-image"
Current executable set to '/Users/daniel/source/my_emulator/target/last-image' (riscv32).
(lldb) gdb-remote localhost:9002
Process 1 stopped
* thread #1, stop reason = signal SIGTRAP
    frame #0: 0xffffffffffffffff 
Target 0: (last-image) stopped.
```
</details>

<details>
<summary>LLDB output (after this change)</summary>

```
~/source/my_emulator % lldb target/last-image
(lldb) target create "target/last-image"
Current executable set to '/Users/daniel/source/my_emulator/target/last-image' (riscv32).
(lldb) gdb-remote localhost:9002
Process 1 stopped
* thread #1, stop reason = signal SIGTRAP
    frame #0: 0x42000000 last-image
->  0x42000000: auipc  sp, 1039489
    0x42000004: mv     sp, sp
    0x42000008: auipc  a0, 1039490
    0x4200000c: addi   a0, a0, 584
Target 0: (last-image) stopped.
```

</details>

<details>
<summary>trace (before this change)</summary>

```
 TRACE gdbstub::protocol::recv_packet > <-- +
 TRACE gdbstub::protocol::recv_packet > <-- $QStartNoAckMode#b0
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $qSupported:xmlRegisters=i386,arm,mips,arc;multiprocess+;fork-events+;vfork-events+#2e
 TRACE gdbstub::protocol::response_writer > --> $PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;swbreak+;qXfer:features:read+#fd
 TRACE gdbstub::protocol::recv_packet     > <-- $QThreadSuffixSupported#e4
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("QThreadSuffixSupported")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $QListThreadsInStopReply#21
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("QListThreadsInStopReply")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $vCont?#49
 TRACE gdbstub::protocol::response_writer > --> $vCont;c;C;s;S#62
 TRACE gdbstub::protocol::recv_packet     > <-- $qVAttachOrWaitSupported#38
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qVAttachOrWaitSupported")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $QEnableErrorStrings#8c
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("QEnableErrorStrings")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qHostInfo#9b
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qHostInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qProcessInfo#dc
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qProcessInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qC#b4
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qC")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $?#3f
 TRACE gdbstub::protocol::response_writer > --> $T05thread:p01.01;#06
 TRACE gdbstub::protocol::recv_packet     > <-- $qProcessInfo#dc
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qProcessInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:0,fff#7d
 TRACE gdbstub::protocol::response_writer > --> $m<target version="1.0"><architecture>riscv:rv32</architecture></target>#ab
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:46,fff#b7
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qRegisterInfo0#72
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qRegisterInfo0")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $Hg1#e0
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $p0#a0
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("p0")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qProcessInfo#dc
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qProcessInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qProcessInfo#dc
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qProcessInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qProcessInfo#dc
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qProcessInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qOffsets#4b
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qOffsets")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qStructuredDataPlugins#02
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qStructuredDataPlugins")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qSymbol::#5b
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qSymbol::")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $jThreadsInfo#c1
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("jThreadsInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $jThreadExtendedInfo:#b9
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("jThreadExtendedInfo:")
 TRACE gdbstub::protocol::response_writer > --> $#00
```
</details>

<details>
<summary>trace (after this change)</summary>

```
 TRACE gdbstub::protocol::recv_packet > <-- +
 TRACE gdbstub::protocol::recv_packet > <-- $QStartNoAckMode#b0
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $qSupported:xmlRegisters=i386,arm,mips,arc;multiprocess+;fork-events+;vfork-events+#2e
 TRACE gdbstub::protocol::response_writer > --> $PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;swbreak+;qXfer:features:read+#fd
 TRACE gdbstub::protocol::recv_packet     > <-- $QThreadSuffixSupported#e4
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("QThreadSuffixSupported")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $QListThreadsInStopReply#21
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("QListThreadsInStopReply")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $vCont?#49
 TRACE gdbstub::protocol::response_writer > --> $vCont;c;C;s;S#62
 TRACE gdbstub::protocol::recv_packet     > <-- $qVAttachOrWaitSupported#38
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qVAttachOrWaitSupported")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $QEnableErrorStrings#8c
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("QEnableErrorStrings")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qHostInfo#9b
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qHostInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qProcessInfo#dc
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qProcessInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qC#b4
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qC")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $?#3f
 TRACE gdbstub::protocol::response_writer > --> $T05thread:p01.01;#06
 TRACE gdbstub::protocol::recv_packet     > <-- $qProcessInfo#dc
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qProcessInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:0,fff#7d
 TRACE gdbstub::protocol::response_writer > --> $m<target version="1.0">
<architecture>riscv:rv32</architecture>
<feature name="org.gnu.gdb.riscv.cpu">
  <reg name="zero" bitsize="32" type="int" regnum="0"/>
  <reg name="ra" bitsize="32" type="code_ptr"/>
  <reg name="sp" bitsize="32" type="data_ptr"/>
  <reg name="gp" bitsize="32" type="data_ptr"/>
  <reg name="tp" bitsize="32" type="data_ptr"/>
  <reg name="t0" bitsize="32" type="int"/>
  <reg name="t1" bitsize="32" type="int"/>
  <reg name="t2" bitsize="32" type="int"/>
  <reg name="fp" bitsize="32" type="data_ptr"/>
  <reg name="s1" bitsize="32" type="int"/>
  <reg name="a0" bitsize="32" type="int"/>
  <reg name="a1" bitsize="32" type="int"/>
  <reg name="a2" bitsize="32" type="int"/>
  <reg name="a3" bitsize="32" type="int"/>
  <reg name="a4" bitsize="32" type="int"/>
  <reg name="a5" bitsize="32" type="int"/>
  <reg name="a6" bitsize="32" type="int"/>
  <reg name="a7" bitsize="32" type="int"/>
  <reg name="s2" bitsize="32" type="int"/>
  <reg name="s3" bitsize="32" type="int"/>
  <reg name="s4" bitsize="32" type="int"/>
  <reg name="s5" bitsize="32" type="int"/>
  <reg name="s6" bitsize="32" type="int"/>
  <reg name="s7" bitsize="32" type="int"/>
  <reg name="s8" bitsize="32" type="int"/>
  <reg name="s9" bitsize="32" type="int"/>
  <reg name="s10" bitsize="32" type="int"/>
  <reg name="s11" bitsize="32" type="int"/>
  <reg name="t3" bitsize="32" type="int"/>
  <reg name="t4" bitsize="32" type="int"/>
  <reg name="t5" bitsize="32" type="int"/>
  <reg name="t6" bitsize="32" type="int"/>
  <reg name="pc" bitsize="32" type="code_ptr"/>
</feature>
</target>#50
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:632,fff#e8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $Hg1#e0
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $p0#a0
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("p0")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qProcessInfo#dc
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qProcessInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qProcessInfo#dc
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qProcessInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qProcessInfo#dc
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qProcessInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qOffsets#4b
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qOffsets")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qStructuredDataPlugins#02
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qStructuredDataPlugins")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qSymbol::#5b
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qSymbol::")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000042#ce
 TRACE gdbstub::protocol::recv_packet     > <-- $qMemoryRegionInfo:42000000#9a
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qMemoryRegionInfo:42000000")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $jThreadsInfo#c1
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("jThreadsInfo")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $jThreadExtendedInfo:#b9
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("jThreadExtendedInfo:")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $x0,0#04
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("x0,0")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m42000000,200#b1
 TRACE gdbstub::protocol::response_writer > --> $1711c8fd130101001725c8fd1305852497a5c8fd938585216307b500232005001105e34db5fe1715c8fd1305a5fd9725c8fd9385252217d61d001306a69c6308b500044204c111051106e34cb5fe97d00700e78060f8000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000097501300e780007d2571232e1118232c8118232a91182328211923263119232441192322511923206119232e7117232c8117232a91172328a1172326b1170013ae892324a4e63705fdfc130ac5cf37f5f0f0930a050f37c5c0c0130b050c37050303930b3530130cc4e69304c4e8130600142685814597701900e780801d814c03c5190083c5090003c6290083c6390022054d8d4206e206558e518d83c5590003c6490083c6690003c77900a205d18dc2066207d98ed58d03c6990083c6890003c7a90083c7b9002206558e4207e2075d8f598e83c6d90003c7c90083c7e90003c8f900a206d98ec20762083367f800d98e13571500298fb757555593875755#0a
```

</details>

<details>

<summary>Before/After `./example_no_std/check_size.sh` output</summary>

### Before

Can't test - example_no_std doesn't build right now

</details>
