### PR TITLE
feature to use core::error::Error instead of std::error::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ alloc = ["managed/alloc"]
 std = ["alloc"]
 trace-pkt = ["alloc"]
 paranoid_unsafe = []
+core_error = []
 
 # INTERNAL: enables the `__dead_code_marker!` macro.
 # used as part of the `scripts/test_dead_code_elim.sh`

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ When using `gdbstub` in `#![no_std]` contexts, make sure to set `default-feature
     -   Add a `TargetError::Io` variant to simplify `std::io::Error` handling from Target methods.
 -   `paranoid_unsafe`
     -   Please refer to the [`unsafe` in `gdbstub`](#unsafe-in-gdbstub) section below for more details.
+-   `core_error`
+    -   Make `GdbStubError` implement [`core::error::Error`](https://doc.rust-lang.org/core/error/trait.Error.html) instead of `std::error::Error`.
 
 ## Examples
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,9 @@
 //! - `paranoid_unsafe`
 //!     - Please refer to the [`unsafe` in `gdbstub`](https://github.com/daniel5151/gdbstub#unsafe-in-gdbstub)
 //!       section of the README.md for more details.
+//! - `core_error`
+//!     - Make `GdbStubError` implement [`core::error::Error`](https://doc.rust-lang.org/core/error/trait.Error.html)
+//!       instead of `std::error::Error`.
 //!
 //! ## Getting Started
 //!

--- a/src/stub/error.rs
+++ b/src/stub/error.rs
@@ -1,13 +1,13 @@
 use crate::protocol::PacketParseError;
 use crate::protocol::ResponseWriterError;
 use crate::util::managed_vec::CapacityError;
+#[cfg(feature = "core_error")]
+use core::error::Error as CoreError;
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::{self};
 #[cfg(all(feature = "std", not(feature = "core_error")))]
 use std::error::Error as CoreError;
-#[cfg(feature = "core_error")]
-use core::error::Error as CoreError;
 
 /// An error that may occur while interacting with a
 /// [`Connection`](crate::conn::Connection).

--- a/src/stub/error.rs
+++ b/src/stub/error.rs
@@ -4,6 +4,10 @@ use crate::util::managed_vec::CapacityError;
 use core::fmt::Debug;
 use core::fmt::Display;
 use core::fmt::{self};
+#[cfg(all(feature = "std", not(feature = "core_error")))]
+use std::error::Error as CoreError;
+#[cfg(feature = "core_error")]
+use core::error::Error as CoreError;
 
 /// An error that may occur while interacting with a
 /// [`Connection`](crate::conn::Connection).
@@ -145,8 +149,8 @@ where
     }
 }
 
-#[cfg(feature = "std")]
-impl<T, C> std::error::Error for GdbStubError<T, C>
+#[cfg(any(feature = "std", feature = "core_error"))]
+impl<T, C> CoreError for GdbStubError<T, C>
 where
     C: Debug + Display,
     T: Debug + Display,

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -369,7 +369,12 @@ pub trait Target {
     type Arch: Arch;
 
     /// A target-specific **fatal** error.
+    #[cfg(not(feature = "core_error"))]
     type Error;
+
+    /// A target-specific **fatal** error.
+    #[cfg(feature = "core_error")]
+    type Error: core::error::Error;
 
     /// Base operations such as reading/writing from memory/registers,
     /// stopping/resuming the target, etc....

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -369,12 +369,7 @@ pub trait Target {
     type Arch: Arch;
 
     /// A target-specific **fatal** error.
-    #[cfg(not(feature = "core_error"))]
     type Error;
-
-    /// A target-specific **fatal** error.
-    #[cfg(feature = "core_error")]
-    type Error: core::error::Error;
 
     /// Base operations such as reading/writing from memory/registers,
     /// stopping/resuming the target, etc....


### PR DESCRIPTION
### Description

Not sure if the validation outputs are required because it is a small change.

Closes #153.

### API Stability

- [x] This PR does not require a breaking API change

### Checklist

- Documentation
  - [x] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [ ] (if appropriate) Added feature to "Debugging Features" in README.md