### PR TITLE
Tracepoint extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Of course, most use-cases will want to support additional debugging features as 
 -   Tracepoints
     - Configure tracepoints and actions to perform when hit
     - Select and interrogate collected trace frames
+   - _Note:_ Feature support is not exhaustive, and many feature haven't been implemented yet.
 
 _Note:_ GDB features are implemented on an as-needed basis by `gdbstub`'s contributors. If there's a missing GDB feature that you'd like `gdbstub` to implement, please file an issue and/or open a PR!
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Of course, most use-cases will want to support additional debugging features as 
 -   Read auxiliary vector (`info auxv`)
 -   Extra thread info (`info threads`)
 -   Extra library information (`info sharedlibraries`)
+-   Tracepoints
+    - Configure tracepoints and actions to perform when hit
+    - Select and interrogate collected trace frames
 
 _Note:_ GDB features are implemented on an as-needed basis by `gdbstub`'s contributors. If there's a missing GDB feature that you'd like `gdbstub` to implement, please file an issue and/or open a PR!
 

--- a/examples/armv4t/emu.rs
+++ b/examples/armv4t/emu.rs
@@ -137,7 +137,7 @@ impl Emu {
             let frames: Vec<_> = self
                 .tracepoints
                 .iter()
-                .filter(|(_tracepoint, (ctp, source, actions))| ctp.enabled && ctp.addr == pc)
+                .filter(|(_tracepoint, (ctp, _source, _actions))| ctp.enabled && ctp.addr == pc)
                 .map(|(tracepoint, _definition)| {
                     // our `tracepoint_define` restricts our loaded tracepoints to only contain
                     // register collect actions. instead of only collecting the registers requested

--- a/examples/armv4t/emu.rs
+++ b/examples/armv4t/emu.rs
@@ -8,12 +8,11 @@ use armv4t_emu::ExampleMem;
 use armv4t_emu::Memory;
 use armv4t_emu::Mode;
 use gdbstub::common::Pid;
-use gdbstub::target::ext::tracepoints::DefineTracepoint;
 use gdbstub::target::ext::tracepoints::NewTracepoint;
 use gdbstub::target::ext::tracepoints::SourceTracepoint;
 use gdbstub::target::ext::tracepoints::Tracepoint;
+use gdbstub::target::ext::tracepoints::TracepointAction;
 use gdbstub::target::ext::tracepoints::TracepointEnumerateState;
-use gdbstub::target::ext::tracepoints::TracepointItem;
 use std::collections::HashMap;
 
 const HLE_RETURN_ADDR: u32 = 0x12345678;
@@ -54,11 +53,11 @@ pub struct Emu {
         (
             NewTracepoint<u32>,
             Vec<SourceTracepoint<'static, u32>>,
-            Vec<DefineTracepoint<'static, u32>>,
+            Vec<TracepointAction<'static, u32>>,
         ),
     >,
     pub(crate) traceframes: Vec<TraceFrame>,
-    pub(crate) tracepoint_enumerate_state: TracepointEnumerateState,
+    pub(crate) tracepoint_enumerate_state: TracepointEnumerateState<u32>,
     pub(crate) tracing: bool,
     pub(crate) selected_frame: Option<usize>,
 

--- a/examples/armv4t/emu.rs
+++ b/examples/armv4t/emu.rs
@@ -1,4 +1,3 @@
-use crate::gdb::tracepoints::TraceFrame;
 use crate::mem_sniffer::AccessKind;
 use crate::mem_sniffer::MemSniffer;
 use crate::DynResult;
@@ -30,6 +29,13 @@ pub enum ExecMode {
     Step,
     Continue,
     RangeStep(u32, u32),
+}
+
+#[derive(Debug)]
+pub struct TraceFrame {
+    pub number: Tracepoint,
+    pub addr: u32,
+    pub snapshot: Cpu,
 }
 
 /// incredibly barebones armv4t-based emulator

--- a/examples/armv4t/emu.rs
+++ b/examples/armv4t/emu.rs
@@ -1,5 +1,6 @@
 use crate::mem_sniffer::AccessKind;
 use crate::mem_sniffer::MemSniffer;
+use crate::gdb::tracepoints::TraceFrame;
 use crate::DynResult;
 use armv4t_emu::reg;
 use armv4t_emu::Cpu;
@@ -7,6 +8,8 @@ use armv4t_emu::ExampleMem;
 use armv4t_emu::Memory;
 use armv4t_emu::Mode;
 use gdbstub::common::Pid;
+use gdbstub::target::ext::tracepoints::{Tracepoint, TracepointItem};
+use std::collections::HashMap;
 
 const HLE_RETURN_ADDR: u32 = 0x12345678;
 
@@ -40,6 +43,12 @@ pub struct Emu {
     pub(crate) watchpoints: Vec<u32>,
     pub(crate) breakpoints: Vec<u32>,
     pub(crate) files: Vec<Option<std::fs::File>>,
+
+    pub(crate) tracepoints: HashMap<u32, Vec<TracepointItem<'static, u32>>>,
+    pub(crate) traceframes: Vec<TraceFrame>,
+    pub(crate) tracepoint_enumerate_machine: (Vec<TracepointItem<'static, u32>>, usize),
+    pub(crate) tracing: bool,
+    pub(crate) selected_frame: Option<usize>,
 
     pub(crate) reported_pid: Pid,
 }
@@ -92,6 +101,12 @@ impl Emu {
             watchpoints: Vec::new(),
             breakpoints: Vec::new(),
             files: Vec::new(),
+
+            tracepoints: HashMap::new(),
+            traceframes: Vec::new(),
+            tracepoint_enumerate_machine: (Vec::new(), 0),
+            tracing: false,
+            selected_frame: None,
 
             reported_pid: Pid::new(1).unwrap(),
         })

--- a/examples/armv4t/emu.rs
+++ b/examples/armv4t/emu.rs
@@ -34,7 +34,6 @@ pub enum ExecMode {
 #[derive(Debug)]
 pub struct TraceFrame {
     pub number: Tracepoint,
-    pub addr: u32,
     pub snapshot: Cpu,
 }
 
@@ -151,8 +150,7 @@ impl Emu {
                     // all of them by cloning the cpu itself.
                     TraceFrame {
                         number: *tracepoint,
-                        addr: pc,
-                        snapshot: self.cpu.clone(),
+                        snapshot: self.cpu,
                     }
                 })
                 .collect();

--- a/examples/armv4t/emu.rs
+++ b/examples/armv4t/emu.rs
@@ -12,7 +12,7 @@ use gdbstub::target::ext::tracepoints::SourceTracepoint;
 use gdbstub::target::ext::tracepoints::Tracepoint;
 use gdbstub::target::ext::tracepoints::TracepointAction;
 use gdbstub::target::ext::tracepoints::TracepointEnumerateState;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 const HLE_RETURN_ADDR: u32 = 0x12345678;
 
@@ -54,7 +54,7 @@ pub struct Emu {
     pub(crate) breakpoints: Vec<u32>,
     pub(crate) files: Vec<Option<std::fs::File>>,
 
-    pub(crate) tracepoints: HashMap<
+    pub(crate) tracepoints: BTreeMap<
         Tracepoint,
         (
             NewTracepoint<u32>,
@@ -119,7 +119,7 @@ impl Emu {
             breakpoints: Vec::new(),
             files: Vec::new(),
 
-            tracepoints: HashMap::new(),
+            tracepoints: BTreeMap::new(),
             traceframes: Vec::new(),
             tracepoint_enumerate_state: Default::default(),
             tracing: false,

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -26,6 +26,7 @@ mod memory_map;
 mod monitor_cmd;
 mod section_offsets;
 mod target_description_xml_override;
+pub(crate) mod tracepoints;
 
 /// Turn a `ArmCoreRegId` into an internal register number of `armv4t_emu`.
 fn cpu_reg_id(id: ArmCoreRegId) -> Option<u8> {
@@ -159,6 +160,13 @@ impl Target for Emu {
     fn support_libraries_svr4(
         &mut self,
     ) -> Option<target::ext::libraries::LibrariesSvr4Ops<'_, Self>> {
+        Some(self)
+    }
+
+    #[inline(always)]
+    fn support_tracepoints(
+        &mut self,
+    ) -> Option<target::ext::tracepoints::TracepointsOps<'_, Self>> {
         Some(self)
     }
 }

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -177,11 +177,11 @@ impl SingleThreadBase for Emu {
         regs: &mut custom_arch::ArmCoreRegsCustom,
     ) -> TargetResult<(), Self> {
         // if we selected a frame from a tracepoint, return registers from that snapshot
-        let cpu = self.selected_frame.and_then(|selected| {
-            self.traceframes.get(selected)
-        }).map(|frame| {
-            frame.snapshot
-        }).unwrap_or_else(|| self.cpu);
+        let cpu = self
+            .selected_frame
+            .and_then(|selected| self.traceframes.get(selected))
+            .map(|frame| frame.snapshot)
+            .unwrap_or_else(|| self.cpu);
         let mode = cpu.mode();
 
         for i in 0..13 {
@@ -230,7 +230,7 @@ impl SingleThreadBase for Emu {
             // we only support register collection actions for our tracepoint frames.
             // if we have a selected frame, then we don't have any memory we can
             // return from the frame snapshot.
-            return Ok(0)
+            return Ok(0);
         }
         // this is a simple emulator, with RAM covering the entire 32 bit address space
         for (addr, val) in (start_addr..).zip(data.iter_mut()) {

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -176,15 +176,21 @@ impl SingleThreadBase for Emu {
         &mut self,
         regs: &mut custom_arch::ArmCoreRegsCustom,
     ) -> TargetResult<(), Self> {
-        let mode = self.cpu.mode();
+        // if we selected a frame from a tracepoint, return registers from that snapshot
+        let cpu = self.selected_frame.and_then(|selected| {
+            self.traceframes.get(selected)
+        }).map(|frame| {
+            frame.snapshot
+        }).unwrap_or_else(|| self.cpu);
+        let mode = cpu.mode();
 
         for i in 0..13 {
-            regs.core.r[i] = self.cpu.reg_get(mode, i as u8);
+            regs.core.r[i] = cpu.reg_get(mode, i as u8);
         }
-        regs.core.sp = self.cpu.reg_get(mode, reg::SP);
-        regs.core.lr = self.cpu.reg_get(mode, reg::LR);
-        regs.core.pc = self.cpu.reg_get(mode, reg::PC);
-        regs.core.cpsr = self.cpu.reg_get(mode, reg::CPSR);
+        regs.core.sp = cpu.reg_get(mode, reg::SP);
+        regs.core.lr = cpu.reg_get(mode, reg::LR);
+        regs.core.pc = cpu.reg_get(mode, reg::PC);
+        regs.core.cpsr = cpu.reg_get(mode, reg::CPSR);
 
         regs.custom = self.custom_reg;
 
@@ -192,6 +198,10 @@ impl SingleThreadBase for Emu {
     }
 
     fn write_registers(&mut self, regs: &custom_arch::ArmCoreRegsCustom) -> TargetResult<(), Self> {
+        if self.selected_frame.is_some() {
+            // we can't modify registers in a tracepoint frame
+            return Err(TargetError::NonFatal);
+        }
         let mode = self.cpu.mode();
 
         for i in 0..13 {
@@ -216,6 +226,12 @@ impl SingleThreadBase for Emu {
     }
 
     fn read_addrs(&mut self, start_addr: u32, data: &mut [u8]) -> TargetResult<usize, Self> {
+        if self.selected_frame.is_some() {
+            // we only support register collection actions for our tracepoint frames.
+            // if we have a selected frame, then we don't have any memory we can
+            // return from the frame snapshot.
+            return Ok(0)
+        }
         // this is a simple emulator, with RAM covering the entire 32 bit address space
         for (addr, val) in (start_addr..).zip(data.iter_mut()) {
             *val = self.mem.r8(addr)
@@ -224,6 +240,11 @@ impl SingleThreadBase for Emu {
     }
 
     fn write_addrs(&mut self, start_addr: u32, data: &[u8]) -> TargetResult<(), Self> {
+        if self.selected_frame.is_some() {
+            // we can't modify memory in a tracepoint frame
+            return Err(TargetError::NonFatal);
+        }
+
         // this is a simple emulator, with RAM covering the entire 32 bit address space
         for (addr, val) in (start_addr..).zip(data.iter().copied()) {
             self.mem.w8(addr, val)

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -37,14 +37,16 @@ impl target::ext::tracepoints::Tracepoints for Emu {
     fn tracepoint_define(&mut self, tp: DefineTracepoint<'_, u32>) -> TargetResult<(), Self> {
         let tp_copy = tp.get_owned();
         let mut valid = true;
-        tp.actions(|action| {
-            if let TracepointAction::Registers { mask: _ } = action {
-                // we only handle register collection actions for the simple
-                // case
-            } else {
-                valid = false;
-            }
-        });
+        let _more = tp
+            .actions(|action| {
+                if let TracepointAction::Registers { mask: _ } = action {
+                    // we only handle register collection actions for the simple
+                    // case
+                } else {
+                    valid = false;
+                }
+            })
+            .map_err(|_e| TargetError::Fatal("unable to parse actions"))?;
         if !valid {
             return Err(TargetError::NonFatal);
         }

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -117,7 +117,7 @@ impl target::ext::tracepoints::Tracepoints for Emu {
     fn tracepoint_enumerate_start(
         &mut self,
         tp: Option<Tracepoint>,
-        f: &mut dyn FnMut(NewTracepoint<u32>),
+        f: &mut dyn FnMut(&NewTracepoint<u32>),
     ) -> TargetResult<TracepointEnumerateStep<u32>, Self> {
         let tp = match tp {
             Some(tp) => tp,
@@ -133,7 +133,7 @@ impl target::ext::tracepoints::Tracepoints for Emu {
         };
 
         // Report our tracepoint
-        (f)(self.tracepoints[&tp].0.clone());
+        (f)(&self.tracepoints[&tp].0);
 
         match self.tracepoints[&tp].2.get(0) {
             // We have actions and GDB should step through them
@@ -154,10 +154,10 @@ impl target::ext::tracepoints::Tracepoints for Emu {
         &mut self,
         tp: Tracepoint,
         step: u64,
-        f: &mut dyn FnMut(TracepointAction<'_, u32>),
+        f: &mut dyn FnMut(&TracepointAction<'_, u32>),
     ) -> TargetResult<TracepointEnumerateStep<u32>, Self> {
         // Report our next action
-        (f)(self.tracepoints[&tp].2[step as usize].get_owned());
+        (f)(&self.tracepoints[&tp].2[step as usize]);
 
         match self.tracepoints[&tp].2.get((step as usize) + 1) {
             // Continue stepping
@@ -175,10 +175,10 @@ impl target::ext::tracepoints::Tracepoints for Emu {
         &mut self,
         tp: Tracepoint,
         step: u64,
-        f: &mut dyn FnMut(SourceTracepoint<'_, u32>),
+        f: &mut dyn FnMut(&SourceTracepoint<'_, u32>),
     ) -> TargetResult<TracepointEnumerateStep<u32>, Self> {
         // Report our next source item
-        (f)(self.tracepoints[&tp].1[step as usize].get_owned());
+        (f)(&self.tracepoints[&tp].1[step as usize]);
 
         match self.tracepoints[&tp].1.get((step as usize) + 1) {
             // Continue stepping

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -6,7 +6,7 @@ use gdbstub::target::ext::tracepoints::ExperimentStatus;
 use gdbstub::target::ext::tracepoints::FrameDescription;
 use gdbstub::target::ext::tracepoints::FrameRequest;
 use gdbstub::target::ext::tracepoints::NewTracepoint;
-use gdbstub::target::ext::tracepoints::TraceBuffer;
+use gdbstub::target::ext::tracepoints::TraceBufferConfig;
 use gdbstub::target::ext::tracepoints::Tracepoint;
 use gdbstub::target::ext::tracepoints::TracepointAction;
 use gdbstub::target::ext::tracepoints::TracepointItem;
@@ -96,7 +96,7 @@ impl target::ext::tracepoints::Tracepoints for Emu {
         }
     }
 
-    fn trace_buffer_configure(&mut self, _tb: TraceBuffer) -> TargetResult<(), Self> {
+    fn trace_buffer_configure(&mut self, _config: TraceBufferConfig) -> TargetResult<(), Self> {
         // we don't collect a "real" trace buffer, so just ignore configuration
         // attempts.
         Ok(())

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -2,14 +2,15 @@ use crate::emu::Emu;
 use gdbstub::target;
 use gdbstub::target::TargetResult;
 use gdbstub::target::TargetError;
-use gdbstub::target::ext::tracepoints::{Tracepoint, TracepointItem, NewTracepoint, DefineTracepoint, ExperimentStatus, FrameRequest, FrameDescription, TraceBuffer};
+use gdbstub::target::ext::tracepoints::{Tracepoint, TracepointItem, NewTracepoint, DefineTracepoint, ExperimentStatus, FrameRequest, FrameDescription, TraceBuffer, ExperimentExplanation, TracepointAction};
 use managed::ManagedSlice;
 
 use armv4t_emu::Cpu;
+#[derive(Debug)]
 pub struct TraceFrame {
-    number: Tracepoint,
-    addr: u32,
-    snapshot: Cpu,
+    pub number: Tracepoint,
+    pub addr: u32,
+    pub snapshot: Cpu,
 }
 
 impl target::ext::tracepoints::Tracepoints for Emu {
@@ -20,25 +21,39 @@ impl target::ext::tracepoints::Tracepoints for Emu {
     }
 
     fn tracepoint_create(&mut self, tp: NewTracepoint<u32>) -> TargetResult<(), Self> {
-        self.tracepoints.insert(tp.addr, vec![TracepointItem::New(tp)]);
+        self.tracepoints.insert(tp.number, vec![TracepointItem::New(tp)]);
         Ok(())
     }
 
     fn tracepoint_define(&mut self, tp: DefineTracepoint<'_, u32>) -> TargetResult<(), Self> {
-        self.tracepoints.get_mut(&tp.addr).map(move |existing| {
-            existing.push(TracepointItem::Define(tp.get_owned()));
+        let tp_copy = tp.get_owned();
+        let mut valid = true;
+        tp.actions(|action| {
+            if let TracepointAction::Registers { mask: _ } = action {
+                // we only handle register collection actions for the simple case
+            } else {
+                valid = false;
+            }
+        });
+        if !valid {
+            return Err(TargetError::NonFatal)
+        }
+        self.tracepoints.get_mut(&tp_copy.number).map(move |existing| {
+            existing.push(TracepointItem::Define(tp_copy));
             ()
         }).ok_or_else(move || TargetError::Fatal("define on non-existing tracepoint"))
     }
 
-    fn tracepoint_status(&self, tp: Tracepoint, addr: u32) -> TargetResult<(u64, u64), Self> {
+    fn tracepoint_status(&self, tp: Tracepoint, _addr: u32) -> TargetResult<(u64, u64), Self> {
         // We don't collect "real" trace buffer frames, so just report hit count
-        // and say the number of bytes is always 0
+        // and say the number of bytes is always 0.
+        // Because we don't implement "while-stepping" actions, we don't need to
+        // also check that `addr` matches.
         Ok((self.traceframes.iter().filter(|frame| frame.number.0 == tp.0).count() as u64, 0))
     }
 
     fn tracepoint_enumerate_start(&mut self) -> TargetResult<Option<TracepointItem<'_, u32>>, Self> {
-        let tracepoints: Vec<_> = self.tracepoints.iter().flat_map(|(key, value)| {
+        let tracepoints: Vec<_> = self.tracepoints.iter().flat_map(|(_key, value)| {
             value.iter().map(|item| item.get_owned())
         }).collect();
         self.tracepoint_enumerate_machine = (tracepoints, 0);
@@ -46,30 +61,28 @@ impl target::ext::tracepoints::Tracepoints for Emu {
         self.tracepoint_enumerate_step()
     }
 
-    fn tracepoint_enumerate_step(
-        &mut self,
-    ) -> TargetResult<Option<TracepointItem<'_, u32>>, Self> {
+    fn tracepoint_enumerate_step<'a>(
+        &'a mut self,
+    ) -> TargetResult<Option<TracepointItem<'a, u32>>, Self> {
         let (tracepoints, index) = &mut self.tracepoint_enumerate_machine;
         if let Some(item) = tracepoints.iter().nth(*index) {
             *index += 1;
-            let item2: TracepointItem<'static, u32> = item.get_owned();
-            dbg!(&item2);
-            Ok(Some(item2))
+            Ok(Some(item.get_owned()))
         } else {
             Ok(None)
         }
     }
 
-    fn trace_buffer_configure(&mut self, tb: TraceBuffer) -> TargetResult<(), Self> {
+    fn trace_buffer_configure(&mut self, _tb: TraceBuffer) -> TargetResult<(), Self> {
         // we don't collect a "real" trace buffer, so just ignore configuration attempts.
         Ok(())
     }
 
     fn trace_buffer_request(
         &mut self,
-        offset: u64,
-        len: usize,
-        buf: &mut [u8],
+        _offset: u64,
+        _len: usize,
+        _buf: &mut [u8],
     ) -> TargetResult<Option<usize>, Self> {
         // We don't have a "real" trace buffer, so fail all raw read requests.
         Ok(None)
@@ -79,41 +92,50 @@ impl target::ext::tracepoints::Tracepoints for Emu {
         // For a bare-bones example, we don't provide in-depth status explanations.
         Ok(ExperimentStatus {
             running: self.tracing,
-            explanations: ManagedSlice::Owned(vec![]),
+            explanations: ManagedSlice::Owned(vec![ExperimentExplanation::Frames(self.traceframes.len())]),
         })
     }
 
-   fn select_frame(
+    fn select_frame(
         &mut self,
         frame: FrameRequest<u32>,
         report: &mut dyn FnMut(FrameDescription),
-   ) -> TargetResult<(), Self> {
-       // For a bare-bones example, we only support `tfind <number>` style frame
-       // selection and not the more complicated ones.
-       match frame {
-           FrameRequest::Select(n) => {
-                self.selected_frame = self.traceframes.iter().nth(n as usize).map(|frame| {
-                    (report)(FrameDescription::FrameNumber(Some(n)));
-                    (report)(FrameDescription::Hit(frame.number));
-                    Some(n as usize)
-                }).unwrap_or_else(|| {
-                    (report)(FrameDescription::FrameNumber(None));
-                    None
-                });
-                Ok(())
-           },
-           _ => Err(TargetError::NonFatal),
-       }
-   }
+    ) -> TargetResult<(), Self> {
+        // For a bare-bones example, we only support `tfind <number>` and `tfind tracepoint <tpnum>`
+        // style frame selection and not the more complicated ones.
+        let found = match frame {
+            FrameRequest::Select(n) => {
+                self.traceframes.iter().nth(n as usize).map(|frame| (n, frame))
+            },
+            FrameRequest::Hit(tp) => {
+                let start = self.selected_frame.map(|selected| selected + 1).unwrap_or(0);
+                self.traceframes.get(start..).and_then(|frames| {
+                    frames.iter().enumerate().filter(|(_n, frame)| {
+                        frame.number == tp
+                    }).map(|(n, frame)| ((start + n) as u64, frame) ).next()
+                })
+            },
+            _ => return Err(TargetError::NonFatal),
+        };
+        if let Some((n, frame)) = found {
+            (report)(FrameDescription::FrameNumber(Some(n)));
+            (report)(FrameDescription::Hit(frame.number));
+            self.selected_frame = Some(n as usize);
+        } else {
+            (report)(FrameDescription::FrameNumber(None));
+            self.selected_frame = None;
+        }
+        Ok(())
+    }
 
-   fn trace_experiment_start(&mut self) -> TargetResult<(), Self> {
-       self.tracing = true;
-       Ok(())
-   }
+    fn trace_experiment_start(&mut self) -> TargetResult<(), Self> {
+        self.tracing = true;
+        Ok(())
+    }
 
-   fn trace_experiment_stop(&mut self) -> TargetResult<(), Self> {
-       self.tracing = false;
-       Ok(())
-   }
+    fn trace_experiment_stop(&mut self) -> TargetResult<(), Self> {
+        self.tracing = false;
+        Ok(())
+    }
 }
 

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -168,13 +168,17 @@ impl target::ext::tracepoints::Tracepoints for Emu {
         Ok(())
     }
 
-    fn trace_experiment_status(&self) -> TargetResult<ExperimentStatus<'_>, Self> {
+    fn trace_experiment_status(
+        &self,
+        report: &mut dyn FnMut(ExperimentStatus<'_>),
+    ) -> TargetResult<(), Self> {
         // For a bare-bones example, we don't provide in-depth status explanations.
-        Ok(if self.tracing {
+        (report)(if self.tracing {
             ExperimentStatus::Running
         } else {
             ExperimentStatus::NotRunning
-        })
+        });
+        Ok(())
     }
 
     fn trace_experiment_info(

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -2,6 +2,7 @@ use crate::emu::Emu;
 use gdbstub::target;
 use gdbstub::target::ext::tracepoints::DefineTracepoint;
 use gdbstub::target::ext::tracepoints::ExperimentExplanation;
+use gdbstub::target::ext::tracepoints::ExperimentState;
 use gdbstub::target::ext::tracepoints::ExperimentStatus;
 use gdbstub::target::ext::tracepoints::FrameDescription;
 use gdbstub::target::ext::tracepoints::FrameRequest;
@@ -116,7 +117,11 @@ impl target::ext::tracepoints::Tracepoints for Emu {
     fn trace_experiment_status(&self) -> TargetResult<ExperimentStatus<'_>, Self> {
         // For a bare-bones example, we don't provide in-depth status explanations.
         Ok(ExperimentStatus {
-            running: self.tracing,
+            state: if self.tracing {
+                ExperimentState::Running
+            } else {
+                ExperimentState::NotRunning
+            },
             explanations: ManagedSlice::Owned(vec![ExperimentExplanation::Frames(
                 self.traceframes.len(),
             )]),

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -187,10 +187,10 @@ impl target::ext::tracepoints::Tracepoints for Emu {
         &mut self,
         _offset: u64,
         _len: usize,
-        _buf: &mut [u8],
-    ) -> TargetResult<Option<usize>, Self> {
-        // We don't have a "real" trace buffer, so fail all raw read requests.
-        Ok(None)
+        _f: &mut dyn FnMut(&mut [u8]),
+    ) -> TargetResult<(), Self> {
+        // We don't have a "real" trace buffer, so just don't report any data
+        Ok(())
     }
 
     fn trace_experiment_status(&self) -> TargetResult<ExperimentStatus<'_>, Self> {
@@ -242,11 +242,10 @@ impl target::ext::tracepoints::Tracepoints for Emu {
             _ => return Err(TargetError::NonFatal),
         };
         if let Some((n, frame)) = found {
-            (report)(FrameDescription::FrameNumber(Some(n)));
+            (report)(FrameDescription::FrameNumber(n));
             (report)(FrameDescription::Hit(frame.number));
             self.selected_frame = Some(n as usize);
         } else {
-            (report)(FrameDescription::FrameNumber(None));
             self.selected_frame = None;
         }
         Ok(())

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -73,7 +73,8 @@ impl target::ext::tracepoints::Tracepoints for Emu {
 
     fn tracepoint_enumerate_start(
         &mut self,
-    ) -> TargetResult<Option<TracepointItem<'_, u32>>, Self> {
+        f: &mut dyn FnMut(TracepointItem<'_, u32>),
+    ) -> TargetResult<(), Self> {
         let tracepoints: Vec<_> = self
             .tracepoints
             .iter()
@@ -81,19 +82,20 @@ impl target::ext::tracepoints::Tracepoints for Emu {
             .collect();
         self.tracepoint_enumerate_machine = (tracepoints, 0);
 
-        self.tracepoint_enumerate_step()
+        self.tracepoint_enumerate_step(f)
     }
 
     fn tracepoint_enumerate_step<'a>(
         &'a mut self,
-    ) -> TargetResult<Option<TracepointItem<'a, u32>>, Self> {
+        f: &mut dyn FnMut(TracepointItem<'_, u32>),
+    ) -> TargetResult<(), Self> {
         let (tracepoints, index) = &mut self.tracepoint_enumerate_machine;
         if let Some(item) = tracepoints.iter().nth(*index) {
             *index += 1;
-            Ok(Some(item.get_owned()))
-        } else {
-            Ok(None)
+            f(item.get_owned())
         }
+
+        Ok(())
     }
 
     fn trace_buffer_configure(&mut self, _config: TraceBufferConfig) -> TargetResult<(), Self> {

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -15,14 +15,6 @@ use gdbstub::target::ext::tracepoints::TracepointStatus;
 use gdbstub::target::TargetError;
 use gdbstub::target::TargetResult;
 
-use armv4t_emu::Cpu;
-#[derive(Debug)]
-pub struct TraceFrame {
-    pub number: Tracepoint,
-    pub addr: u32,
-    pub snapshot: Cpu,
-}
-
 impl Emu {
     fn step_to_next_tracepoint(&self, tp: Tracepoint) -> TracepointEnumerateStep<u32> {
         let (tp_pos, _) = self

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -1,0 +1,119 @@
+use crate::emu::Emu;
+use gdbstub::target;
+use gdbstub::target::TargetResult;
+use gdbstub::target::TargetError;
+use gdbstub::target::ext::tracepoints::{Tracepoint, TracepointItem, NewTracepoint, DefineTracepoint, ExperimentStatus, FrameRequest, FrameDescription, TraceBuffer};
+use managed::ManagedSlice;
+
+use armv4t_emu::Cpu;
+pub struct TraceFrame {
+    number: Tracepoint,
+    addr: u32,
+    snapshot: Cpu,
+}
+
+impl target::ext::tracepoints::Tracepoints for Emu {
+    fn tracepoints_init(&mut self) -> TargetResult<(), Self> {
+        self.tracepoints.clear();
+        self.traceframes.clear();
+        Ok(())
+    }
+
+    fn tracepoint_create(&mut self, tp: NewTracepoint<u32>) -> TargetResult<(), Self> {
+        self.tracepoints.insert(tp.addr, vec![TracepointItem::New(tp)]);
+        Ok(())
+    }
+
+    fn tracepoint_define(&mut self, tp: DefineTracepoint<'_, u32>) -> TargetResult<(), Self> {
+        self.tracepoints.get_mut(&tp.addr).map(move |existing| {
+            existing.push(TracepointItem::Define(tp.get_owned()));
+            ()
+        }).ok_or_else(move || TargetError::Fatal("define on non-existing tracepoint"))
+    }
+
+    fn tracepoint_status(&self, tp: Tracepoint, addr: u32) -> TargetResult<(u64, u64), Self> {
+        // We don't collect "real" trace buffer frames, so just report hit count
+        // and say the number of bytes is always 0
+        Ok((self.traceframes.iter().filter(|frame| frame.number.0 == tp.0).count() as u64, 0))
+    }
+
+    fn tracepoint_enumerate_start(&mut self) -> TargetResult<Option<TracepointItem<'_, u32>>, Self> {
+        let tracepoints: Vec<_> = self.tracepoints.iter().flat_map(|(key, value)| {
+            value.iter().map(|item| item.get_owned())
+        }).collect();
+        self.tracepoint_enumerate_machine = (tracepoints, 0);
+
+        self.tracepoint_enumerate_step()
+    }
+
+    fn tracepoint_enumerate_step(
+        &mut self,
+    ) -> TargetResult<Option<TracepointItem<'_, u32>>, Self> {
+        let (tracepoints, index) = &mut self.tracepoint_enumerate_machine;
+        if let Some(item) = tracepoints.iter().nth(*index) {
+            *index += 1;
+            let item2: TracepointItem<'static, u32> = item.get_owned();
+            dbg!(&item2);
+            Ok(Some(item2))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn trace_buffer_configure(&mut self, tb: TraceBuffer) -> TargetResult<(), Self> {
+        // we don't collect a "real" trace buffer, so just ignore configuration attempts.
+        Ok(())
+    }
+
+    fn trace_buffer_request(
+        &mut self,
+        offset: u64,
+        len: usize,
+        buf: &mut [u8],
+    ) -> TargetResult<Option<usize>, Self> {
+        // We don't have a "real" trace buffer, so fail all raw read requests.
+        Ok(None)
+    }
+
+    fn trace_experiment_status(&self) -> TargetResult<ExperimentStatus<'_>, Self> {
+        // For a bare-bones example, we don't provide in-depth status explanations.
+        Ok(ExperimentStatus {
+            running: self.tracing,
+            explanations: ManagedSlice::Owned(vec![]),
+        })
+    }
+
+   fn select_frame(
+        &mut self,
+        frame: FrameRequest<u32>,
+        report: &mut dyn FnMut(FrameDescription),
+   ) -> TargetResult<(), Self> {
+       // For a bare-bones example, we only support `tfind <number>` style frame
+       // selection and not the more complicated ones.
+       match frame {
+           FrameRequest::Select(n) => {
+                self.selected_frame = self.traceframes.iter().nth(n as usize).map(|frame| {
+                    (report)(FrameDescription::FrameNumber(Some(n)));
+                    (report)(FrameDescription::Hit(frame.number));
+                    Some(n as usize)
+                }).unwrap_or_else(|| {
+                    (report)(FrameDescription::FrameNumber(None));
+                    None
+                });
+                Ok(())
+           },
+           _ => Err(TargetError::NonFatal),
+       }
+   }
+
+   fn trace_experiment_start(&mut self) -> TargetResult<(), Self> {
+       self.tracing = true;
+       Ok(())
+   }
+
+   fn trace_experiment_stop(&mut self) -> TargetResult<(), Self> {
+       self.tracing = false;
+       Ok(())
+   }
+}
+

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -10,6 +10,7 @@ use gdbstub::target::ext::tracepoints::TraceBufferConfig;
 use gdbstub::target::ext::tracepoints::Tracepoint;
 use gdbstub::target::ext::tracepoints::TracepointAction;
 use gdbstub::target::ext::tracepoints::TracepointItem;
+use gdbstub::target::ext::tracepoints::TracepointStatus;
 use gdbstub::target::TargetError;
 use gdbstub::target::TargetResult;
 
@@ -59,18 +60,23 @@ impl target::ext::tracepoints::Tracepoints for Emu {
             .ok_or_else(move || TargetError::Fatal("define on non-existing tracepoint"))
     }
 
-    fn tracepoint_status(&self, tp: Tracepoint, _addr: u32) -> TargetResult<(u64, u64), Self> {
+    fn tracepoint_status(
+        &self,
+        tp: Tracepoint,
+        _addr: u32,
+    ) -> TargetResult<TracepointStatus, Self> {
         // We don't collect "real" trace buffer frames, so just report hit count
         // and say the number of bytes is always 0.
         // Because we don't implement "while-stepping" actions, we don't need to
         // also check that `addr` matches.
-        Ok((
-            self.traceframes
+        Ok(TracepointStatus {
+            hit_count: self
+                .traceframes
                 .iter()
                 .filter(|frame| frame.number.0 == tp.0)
                 .count() as u64,
-            0,
-        ))
+            bytes_used: 0,
+        })
     }
 
     fn tracepoint_enumerate_start(

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -17,19 +17,15 @@ use gdbstub::target::TargetResult;
 
 impl Emu {
     fn step_to_next_tracepoint(&self, tp: Tracepoint) -> TracepointEnumerateStep<u32> {
-        let (tp_pos, _) = self
-            .tracepoints
-            .keys()
-            .enumerate()
-            .find(|(_i, k)| **k == tp)
-            .unwrap();
-        match self.tracepoints.keys().nth(tp_pos + 1) {
+        let next_tp = self.tracepoints.range(tp..).nth(1);
+        if let Some((tp, (new_tp, _, _))) = next_tp {
+            TracepointEnumerateStep::Next {
+                tp: *tp,
+                addr: new_tp.addr,
+            }
+        } else {
             // No more tracepoints
-            None => TracepointEnumerateStep::Done,
-            Some(next_tp) => TracepointEnumerateStep::Next {
-                tp: *next_tp,
-                addr: self.tracepoints[next_tp].0.addr,
-            },
+            TracepointEnumerateStep::Done
         }
     }
 }

--- a/examples/armv4t/gdb/tracepoints.rs
+++ b/examples/armv4t/gdb/tracepoints.rs
@@ -2,7 +2,6 @@ use crate::emu::Emu;
 use gdbstub::target;
 use gdbstub::target::ext::tracepoints::ExperimentExplanation;
 use gdbstub::target::ext::tracepoints::ExperimentStatus;
-use gdbstub::target::ext::tracepoints::ExtendTracepoint;
 use gdbstub::target::ext::tracepoints::FrameDescription;
 use gdbstub::target::ext::tracepoints::FrameRequest;
 use gdbstub::target::ext::tracepoints::NewTracepoint;
@@ -58,7 +57,6 @@ impl target::ext::tracepoints::Tracepoints for Emu {
     fn tracepoint_create_continue(
         &mut self,
         tp: Tracepoint,
-        addr: u32,
         action: &TracepointAction<'_, u32>,
     ) -> TargetResult<(), Self> {
         if let &TracepointAction::Registers { mask: _ } = &action {
@@ -76,7 +74,7 @@ impl target::ext::tracepoints::Tracepoints for Emu {
             .ok_or_else(move || TargetError::Fatal("extend on non-existing tracepoint"))
     }
 
-    fn tracepoint_create_complete(&mut self, tp: Tracepoint, addr: u32) -> TargetResult<(), Self> {
+    fn tracepoint_create_complete(&mut self, _tp: Tracepoint) -> TargetResult<(), Self> {
         /* nothing to do */
         Ok(())
     }
@@ -139,7 +137,7 @@ impl target::ext::tracepoints::Tracepoints for Emu {
 
         match self.tracepoints[&tp].2.get(0) {
             // We have actions and GDB should step through them
-            Some(next) => Ok(TracepointEnumerateStep::Action),
+            Some(_next) => Ok(TracepointEnumerateStep::Action),
             // No actions attached to this tracepoint
             None => {
                 match self.tracepoints[&tp].1.get(0) {
@@ -155,7 +153,6 @@ impl target::ext::tracepoints::Tracepoints for Emu {
     fn tracepoint_enumerate_action(
         &mut self,
         tp: Tracepoint,
-        addr: u32,
         step: u64,
         f: &mut dyn FnMut(TracepointAction<'_, u32>),
     ) -> TargetResult<TracepointEnumerateStep<u32>, Self> {
@@ -177,7 +174,6 @@ impl target::ext::tracepoints::Tracepoints for Emu {
     fn tracepoint_enumerate_source(
         &mut self,
         tp: Tracepoint,
-        addr: u32,
         step: u64,
         f: &mut dyn FnMut(SourceTracepoint<'_, u32>),
     ) -> TargetResult<TracepointEnumerateStep<u32>, Self> {

--- a/examples/armv4t/main.rs
+++ b/examples/armv4t/main.rs
@@ -150,50 +150,55 @@ fn main() -> DynResult<()> {
 
     let mut emu = emu::Emu::new(TEST_PROGRAM_ELF)?;
 
-    let connection: Box<dyn ConnectionExt<Error = std::io::Error>> = {
-        if std::env::args().nth(1) == Some("--uds".to_string()) {
-            #[cfg(not(unix))]
-            {
-                return Err("Unix Domain Sockets can only be used on Unix".into());
-            }
-            #[cfg(unix)]
-            {
-                Box::new(wait_for_uds("/tmp/armv4t_gdb")?)
-            }
-        } else {
-            Box::new(wait_for_tcp(9001)?)
-        }
-    };
-
-    let gdb = GdbStub::new(connection);
-
-    match gdb.run_blocking::<EmuGdbEventLoop>(&mut emu) {
-        Ok(disconnect_reason) => match disconnect_reason {
-            DisconnectReason::Disconnect => {
-                println!("GDB client has disconnected. Running to completion...");
-                while emu.step() != Some(emu::Event::Halted) {}
-            }
-            DisconnectReason::TargetExited(code) => {
-                println!("Target exited with code {}!", code)
-            }
-            DisconnectReason::TargetTerminated(sig) => {
-                println!("Target terminated with signal {}!", sig)
-            }
-            DisconnectReason::Kill => println!("GDB sent a kill command!"),
-        },
-        Err(e) => {
-            if e.is_target_error() {
-                println!(
-                    "target encountered a fatal error: {}",
-                    e.into_target_error().unwrap()
-                )
-            } else if e.is_connection_error() {
-                let (e, kind) = e.into_connection_error().unwrap();
-                println!("connection error: {:?} - {}", kind, e,)
+    'client: loop {
+        let connection: Box<dyn ConnectionExt<Error = std::io::Error>> = {
+            if std::env::args().nth(1) == Some("--uds".to_string()) {
+                #[cfg(not(unix))]
+                {
+                    return Err("Unix Domain Sockets can only be used on Unix".into());
+                }
+                #[cfg(unix)]
+                {
+                    Box::new(wait_for_uds("/tmp/armv4t_gdb")?)
+                }
             } else {
-                println!("gdbstub encountered a fatal error: {}", e)
+                Box::new(wait_for_tcp(9001)?)
+            }
+        };
+
+        let gdb = GdbStub::new(connection);
+
+        match gdb.run_blocking::<EmuGdbEventLoop>(&mut emu) {
+            Ok(disconnect_reason) => match disconnect_reason {
+                DisconnectReason::Disconnect => {
+                    //println!("GDB client has disconnected. Running to completion...");
+                    //while emu.step() != Some(emu::Event::Halted) {}
+                    println!("GDB client has disconnected. Waiting for another...");
+                    continue 'client;
+                }
+                DisconnectReason::TargetExited(code) => {
+                    println!("Target exited with code {}!", code)
+                }
+                DisconnectReason::TargetTerminated(sig) => {
+                    println!("Target terminated with signal {}!", sig)
+                }
+                DisconnectReason::Kill => println!("GDB sent a kill command!"),
+            },
+            Err(e) => {
+                if e.is_target_error() {
+                    println!(
+                        "target encountered a fatal error: {}",
+                        e.into_target_error().unwrap()
+                    )
+                } else if e.is_connection_error() {
+                    let (e, kind) = e.into_connection_error().unwrap();
+                    println!("connection error: {:?} - {}", kind, e,)
+                } else {
+                    println!("gdbstub encountered a fatal error: {}", e)
+                }
             }
         }
+        break 'client;
     }
 
     let ret = emu.cpu.reg_get(armv4t_emu::Mode::User, 0);

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -50,7 +50,7 @@ macro_rules! commands {
 
         pub mod ext {
             $(
-                #[allow(non_camel_case_types, clippy::enum_variant_names)]
+                #[allow(non_camel_case_types, clippy::enum_variant_names, clippy::upper_case_acronyms)]
                 pub enum [<$ext:camel>] $(<$lt>)? {
                     $($command(super::$mod::$command<$($lifetime)?>),)*
                 }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -344,7 +344,6 @@ commands! {
         "QTDP" => _QTDP::QTDP<'a>,
         "QTinit" => _QTinit::QTinit,
         "QTBuffer" => _QTBuffer::QTBuffer<'a>,
-        // TODO: QTNotes?
         "QTStart" => _QTStart::QTStart,
         "QTStop" => _QTStop::QTStop,
         "QTFrame" => _QTFrame::QTFrame<'a>,
@@ -353,6 +352,10 @@ commands! {
         "qTP" => _qTP::qTP<'a>,
         "qTfP" => _qTfP::qTfP,
         "qTsP" => _qTsP::qTsP,
+
+        // These are currently stubbed out to no-ops for tracepoints v1: they're
+        // needed to suppress "not implemented" errors.
+        // QTDV is unimplemented.
         "qTfV" => _qTfV::qTfV,
         "qTsV" => _qTsV::qTsV,
     }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -343,11 +343,12 @@ commands! {
     tracepoints use 'a {
         "QTDP" => _QTDP::QTDP<'a>,
         "QTinit" => _QTinit::QTinit,
-        "QTBuffer" => _QTBuffer::QTBuffer<'a>,
+        "QTBuffer" => _QTBuffer::QTBuffer,
         "QTStart" => _QTStart::QTStart,
         "QTStop" => _QTStop::QTStop,
         "QTFrame" => _QTFrame::QTFrame<'a>,
 
+        "qTBuffer" => _qTBuffer::qTBuffer<'a>,
         "qTStatus" => _qTStatus::qTStatus,
         "qTP" => _qTP::qTP<'a>,
         "qTfP" => _qTfP::qTfP,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -346,7 +346,7 @@ commands! {
         "QTStop" => _QTStop::QTStop,
         "QTFrame" => _QTFrame::QTFrame<'a>,
 
-        "qTBuffer" => _qTBuffer::qTBuffer<'a>,
+        "qTBuffer" => _qTBuffer::qTBuffer,
         "qTStatus" => _qTStatus::qTStatus,
         "qTP" => _qTP::qTP<'a>,
         "qTfP" => _qTfP::qTfP,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -352,8 +352,6 @@ commands! {
         "qTfP" => _qTfP::qTfP,
         "qTsP" => _qTsP::qTsP,
 
-        // These are currently stubbed out to no-ops for tracepoints v1: they're
-        // needed to suppress "not implemented" errors.
         // QTDV is unimplemented.
         "qTfV" => _qTfV::qTfV,
         "qTsV" => _qTsV::qTsV,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -51,7 +51,6 @@ macro_rules! commands {
         pub mod ext {
             $(
                 #[allow(non_camel_case_types, clippy::enum_variant_names)]
-                #[derive(Debug)]
                 pub enum [<$ext:camel>] $(<$lt>)? {
                     $($command(super::$mod::$command<$($lifetime)?>),)*
                 }
@@ -59,7 +58,6 @@ macro_rules! commands {
 
             use super::breakpoint::{BasicBreakpoint, BytecodeBreakpoint};
             #[allow(non_camel_case_types)]
-            #[derive(Debug)]
             pub enum Breakpoints<'a> {
                 z(BasicBreakpoint<'a>),
                 Z(BasicBreakpoint<'a>),
@@ -71,7 +69,6 @@ macro_rules! commands {
         }
 
         /// GDB commands
-        #[derive(Debug)]
         pub enum Command<'a> {
             $(
                 [<$ext:camel>](ext::[<$ext:camel>]$(<$lt>)?),

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -51,6 +51,7 @@ macro_rules! commands {
         pub mod ext {
             $(
                 #[allow(non_camel_case_types, clippy::enum_variant_names)]
+                #[derive(Debug)]
                 pub enum [<$ext:camel>] $(<$lt>)? {
                     $($command(super::$mod::$command<$($lifetime)?>),)*
                 }
@@ -58,6 +59,7 @@ macro_rules! commands {
 
             use super::breakpoint::{BasicBreakpoint, BytecodeBreakpoint};
             #[allow(non_camel_case_types)]
+            #[derive(Debug)]
             pub enum Breakpoints<'a> {
                 z(BasicBreakpoint<'a>),
                 Z(BasicBreakpoint<'a>),
@@ -69,6 +71,7 @@ macro_rules! commands {
         }
 
         /// GDB commands
+        #[derive(Debug)]
         pub enum Command<'a> {
             $(
                 [<$ext:camel>](ext::[<$ext:camel>]$(<$lt>)?),
@@ -335,5 +338,22 @@ commands! {
 
     libraries_svr4 use 'a {
         "qXfer:libraries-svr4:read" => _qXfer_libraries_svr4_read::qXferLibrariesSvr4Read<'a>,
+    }
+
+    tracepoints use 'a {
+        "QTDP" => _QTDP::QTDP<'a>,
+        "QTinit" => _QTinit::QTinit,
+        "QTBuffer" => _QTBuffer::QTBuffer<'a>,
+        // TODO: QTNotes?
+        "QTStart" => _QTStart::QTStart,
+        "QTStop" => _QTStop::QTStop,
+        "QTFrame" => _QTFrame::QTFrame<'a>,
+
+        "qTStatus" => _qTStatus::qTStatus,
+        "qTP" => _qTP::qTP<'a>,
+        "qTfP" => _qTfP::qTfP,
+        "qTsP" => _qTsP::qTsP,
+        "qTfV" => _qTfV::qTfV,
+        "qTsV" => _qTsV::qTsV,
     }
 }

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -338,6 +338,7 @@ commands! {
     }
 
     tracepoints use 'a {
+        "QTDPsrc" => _QTDPsrc::QTDPsrc<'a>,
         "QTDP" => _QTDP::QTDP<'a>,
         "QTinit" => _QTinit::QTinit,
         "QTBuffer" => _QTBuffer::QTBuffer,

--- a/src/protocol/commands/_QTBuffer.rs
+++ b/src/protocol/commands/_QTBuffer.rs
@@ -1,8 +1,8 @@
 use super::prelude::*;
-use crate::target::ext::tracepoints::{BufferShape, TraceBuffer};
+use crate::target::ext::tracepoints::{BufferShape, TraceBufferConfig};
 
 #[derive(Debug)]
-pub struct QTBuffer(pub TraceBuffer);
+pub struct QTBuffer(pub TraceBufferConfig);
 
 impl ParseCommand<'_> for QTBuffer {
     #[inline(always)]
@@ -14,7 +14,7 @@ impl ParseCommand<'_> for QTBuffer {
                 match opt.as_ref() {
                     b"circular" => {
                         let shape = s.next()?;
-                        Some(QTBuffer(TraceBuffer::Shape(match shape {
+                        Some(QTBuffer(TraceBufferConfig::Shape(match shape {
                             [b'1'] => Some(BufferShape::Circular),
                             [b'0'] => Some(BufferShape::Linear),
                             _ => None,
@@ -22,7 +22,7 @@ impl ParseCommand<'_> for QTBuffer {
                     },
                     b"size" => {
                         let size = s.next()?;
-                        Some(QTBuffer(TraceBuffer::Size(match size {
+                        Some(QTBuffer(TraceBufferConfig::Size(match size {
                             [b'-', b'1'] => None,
                             i => Some(decode_hex(i).ok()?)
                         })))

--- a/src/protocol/commands/_QTBuffer.rs
+++ b/src/protocol/commands/_QTBuffer.rs
@@ -12,6 +12,8 @@ impl ParseCommand<'_> for QTBuffer {
             [b':', body @ ..] => {
                 let mut s = body.splitn_mut(2, |b| *b == b':');
                 let opt = s.next()?;
+                // Clippy incorrect thinks this as_ref isn't needed, but it is.
+                #[allow(clippy::useless_asref)]
                 match opt.as_ref() {
                     b"circular" => {
                         let shape = s.next()?;

--- a/src/protocol/commands/_QTBuffer.rs
+++ b/src/protocol/commands/_QTBuffer.rs
@@ -1,0 +1,53 @@
+use super::prelude::*;
+use crate::target::ext::tracepoints::{BufferShape, TraceBuffer};
+
+#[derive(Debug)]
+pub enum QTBuffer<'a>
+{
+    Request { offset: u64, length: usize, data: &'a mut [u8] },
+    Configure { buffer: TraceBuffer },
+}
+
+impl<'a> ParseCommand<'a> for QTBuffer<'a> {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let (buf, body_range) = buf.into_raw_buf();
+        let body = &buf[body_range];
+        match body {
+            [b':', body @ ..] => {
+                let mut s = body.split(|b| *b == b':');
+                let opt = s.next()?;
+                Some(match opt.as_ref() {
+                    b"circular" => {
+                        let shape = s.next()?;
+                        QTBuffer::Configure { buffer: TraceBuffer::Shape(match shape {
+                            [b'1'] => Some(BufferShape::Circular),
+                            [b'0'] => Some(BufferShape::Linear),
+                            _ => None,
+                        }?)}
+                    },
+                    b"size" => {
+                        let size = s.next()?;
+                        QTBuffer::Configure { buffer: TraceBuffer::Size(match size {
+                            [b'-', b'1'] => None,
+                            i => Some(decode_hex(i).ok()?)
+                        })}
+                    },
+                    req => {
+                        let mut req_opts = req.split(|b| *b == b',');
+                        let (offset, length) = (req_opts.next()?, req_opts.next()?);
+                        let offset = decode_hex(offset).ok()?;
+                        let length = decode_hex(length).ok()?;
+                        // Our response has to be a hex encoded buffer that fits within
+                        // our packet size, which means we actually have half as much space
+                        // as our slice would indicate.
+                        let (front, _back) = buf.split_at_mut(buf.len() / 2);
+                        QTBuffer::Request { offset, length, data: front } 
+                    },
+                })
+
+            },
+            _ => None,
+        }
+    }
+}

--- a/src/protocol/commands/_QTBuffer.rs
+++ b/src/protocol/commands/_QTBuffer.rs
@@ -1,5 +1,6 @@
 use super::prelude::*;
-use crate::target::ext::tracepoints::{BufferShape, TraceBufferConfig};
+use crate::target::ext::tracepoints::BufferShape;
+use crate::target::ext::tracepoints::TraceBufferConfig;
 
 #[derive(Debug)]
 pub struct QTBuffer(pub TraceBufferConfig);
@@ -19,18 +20,17 @@ impl ParseCommand<'_> for QTBuffer {
                             [b'0'] => Some(BufferShape::Linear),
                             _ => None,
                         }?)))
-                    },
+                    }
                     b"size" => {
                         let size = s.next()?;
                         Some(QTBuffer(TraceBufferConfig::Size(match size {
                             [b'-', b'1'] => None,
-                            i => Some(decode_hex(i).ok()?)
+                            i => Some(decode_hex(i).ok()?),
                         })))
-                    },
+                    }
                     _ => None,
                 }
-
-            },
+            }
             _ => None,
         }
     }

--- a/src/protocol/commands/_QTBuffer.rs
+++ b/src/protocol/commands/_QTBuffer.rs
@@ -2,49 +2,33 @@ use super::prelude::*;
 use crate::target::ext::tracepoints::{BufferShape, TraceBuffer};
 
 #[derive(Debug)]
-pub enum QTBuffer<'a>
-{
-    Request { offset: u64, length: usize, data: &'a mut [u8] },
-    Configure { buffer: TraceBuffer },
-}
+pub struct QTBuffer(pub TraceBuffer);
 
-impl<'a> ParseCommand<'a> for QTBuffer<'a> {
+impl ParseCommand<'_> for QTBuffer {
     #[inline(always)]
-    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
-        let (buf, body_range) = buf.into_raw_buf();
-        let body = &buf[body_range];
-        match body {
+    fn from_packet(buf: PacketBuf<'_>) -> Option<Self> {
+        match buf.into_body() {
             [b':', body @ ..] => {
-                let mut s = body.split(|b| *b == b':');
+                let mut s = body.splitn_mut(2, |b| *b == b':');
                 let opt = s.next()?;
-                Some(match opt.as_ref() {
+                match opt.as_ref() {
                     b"circular" => {
                         let shape = s.next()?;
-                        QTBuffer::Configure { buffer: TraceBuffer::Shape(match shape {
+                        Some(QTBuffer(TraceBuffer::Shape(match shape {
                             [b'1'] => Some(BufferShape::Circular),
                             [b'0'] => Some(BufferShape::Linear),
                             _ => None,
-                        }?)}
+                        }?)))
                     },
                     b"size" => {
                         let size = s.next()?;
-                        QTBuffer::Configure { buffer: TraceBuffer::Size(match size {
+                        Some(QTBuffer(TraceBuffer::Size(match size {
                             [b'-', b'1'] => None,
                             i => Some(decode_hex(i).ok()?)
-                        })}
+                        })))
                     },
-                    req => {
-                        let mut req_opts = req.split(|b| *b == b',');
-                        let (offset, length) = (req_opts.next()?, req_opts.next()?);
-                        let offset = decode_hex(offset).ok()?;
-                        let length = decode_hex(length).ok()?;
-                        // Our response has to be a hex encoded buffer that fits within
-                        // our packet size, which means we actually have half as much space
-                        // as our slice would indicate.
-                        let (front, _back) = buf.split_at_mut(buf.len() / 2);
-                        QTBuffer::Request { offset, length, data: front } 
-                    },
-                })
+                    _ => None,
+                }
 
             },
             _ => None,

--- a/src/protocol/commands/_QTDP.rs
+++ b/src/protocol/commands/_QTDP.rs
@@ -41,15 +41,15 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                     number,
                     addr,
                     while_stepping: false,
-                    actions
+                    actions,
                 }))
-            },
+            }
             [b':', tracepoint @ ..] => {
                 // Strip off the trailing '-' that indicates if there will be
                 // more packets after this
                 let (tracepoint, more) = match tracepoint {
                     [rest @ .., b'-'] => (rest, true),
-                    x => (x, false)
+                    x => (x, false),
                 };
                 let mut params = tracepoint.splitn_mut(6, |b| *b == b':');
                 let n = Tracepoint(decode_hex(params.next()?).ok()?);
@@ -64,7 +64,11 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                 return Some(QTDP::Create(CreateTDP {
                     number: n,
                     addr,
-                    enable: match ena { [b'E'] => Some(true), [b'D'] => Some(false), _ => None }?,
+                    enable: match ena {
+                        [b'E'] => Some(true),
+                        [b'D'] => Some(false),
+                        _ => None,
+                    }?,
                     step,
                     pass,
                     more,
@@ -72,8 +76,8 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                     // TODO: populate tracepoint conditions
                     fast: None,
                     condition: None,
-                }))
-            },
+                }));
+            }
             _ => None,
         }
     }

--- a/src/protocol/commands/_QTDP.rs
+++ b/src/protocol/commands/_QTDP.rs
@@ -14,8 +14,7 @@ pub struct CreateTDP<'a> {
     pub enable: bool,
     pub step: u64,
     pub pass: u64,
-    pub fast: Option<&'a [u8]>,
-    pub condition: Option<&'a [u8]>,
+    pub unsupported_options: bool,
     pub more: bool,
 }
 
@@ -60,7 +59,26 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                 let pass = decode_hex(pass_and_end).ok()?;
                 // TODO: parse `F` fast tracepoint options
                 // TODO: parse `X` tracepoint conditions
-                let _options = params.next();
+                let options = params.next();
+                let unsupported_options = match options {
+                    Some([b'F', ..]) => {
+                        /* TODO: fast tracepoints support */
+                        true
+                    }
+                    Some([b'S']) => {
+                        /* TODO: static tracepoint support */
+                        true
+                    }
+                    Some([b'X', ..]) => {
+                        /* TODO: trace conditions support */
+                        true
+                    }
+                    Some(_) => {
+                        /* invalid option */
+                        return None;
+                    }
+                    None => false,
+                };
                 return Some(QTDP::Create(CreateTDP {
                     number: n,
                     addr,
@@ -72,10 +90,7 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                     step,
                     pass,
                     more,
-                    // TODO: populate fast tracepoint options
-                    // TODO: populate tracepoint conditions
-                    fast: None,
-                    condition: None,
+                    unsupported_options,
                 }));
             }
             _ => None,

--- a/src/protocol/commands/_QTDP.rs
+++ b/src/protocol/commands/_QTDP.rs
@@ -4,7 +4,7 @@ use crate::target::ext::tracepoints::Tracepoint;
 #[derive(Debug)]
 pub enum QTDP<'a> {
     Create(CreateTDP<'a>),
-    Define(DefineTDP<'a>),
+    Extend(ExtendTDP<'a>),
 }
 
 #[derive(Debug)]
@@ -20,7 +20,7 @@ pub struct CreateTDP<'a> {
 }
 
 #[derive(Debug)]
-pub struct DefineTDP<'a> {
+pub struct ExtendTDP<'a> {
     pub number: Tracepoint,
     pub addr: &'a [u8],
     pub while_stepping: bool,
@@ -37,7 +37,7 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                 let number = Tracepoint(decode_hex(params.next()?).ok()?);
                 let addr = decode_hex_buf(params.next()?).ok()?;
                 let actions = params.next()?;
-                Some(QTDP::Define(DefineTDP {
+                Some(QTDP::Extend(ExtendTDP {
                     number,
                     addr,
                     while_stepping: false,

--- a/src/protocol/commands/_QTDP.rs
+++ b/src/protocol/commands/_QTDP.rs
@@ -14,7 +14,7 @@ pub struct CreateTDP<'a> {
     pub enable: bool,
     pub step: u64,
     pub pass: u64,
-    pub unsupported_options: bool,
+    pub unsupported_option: Option<u8>,
     pub more: bool,
 }
 
@@ -60,24 +60,24 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                 // TODO: parse `F` fast tracepoint options
                 // TODO: parse `X` tracepoint conditions
                 let options = params.next();
-                let unsupported_options = match options {
+                let unsupported_option = match options {
                     Some([b'F', ..]) => {
                         /* TODO: fast tracepoints support */
-                        true
+                        Some(b'F')
                     }
                     Some([b'S']) => {
                         /* TODO: static tracepoint support */
-                        true
+                        Some(b'S')
                     }
                     Some([b'X', ..]) => {
                         /* TODO: trace conditions support */
-                        true
+                        Some(b'X')
                     }
                     Some(_) => {
                         /* invalid option */
                         return None;
                     }
-                    None => false,
+                    None => None,
                 };
                 return Some(QTDP::Create(CreateTDP {
                     number: n,
@@ -90,7 +90,7 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                     step,
                     pass,
                     more,
-                    unsupported_options,
+                    unsupported_option,
                 }));
             }
             _ => None,

--- a/src/protocol/commands/_QTDP.rs
+++ b/src/protocol/commands/_QTDP.rs
@@ -2,6 +2,7 @@ use super::prelude::*;
 use crate::target::ext::tracepoints::Tracepoint;
 
 #[derive(Debug)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum QTDP<'a> {
     Create(CreateTDP<'a>),
     Extend(ExtendTDP<'a>),

--- a/src/protocol/commands/_QTDP.rs
+++ b/src/protocol/commands/_QTDP.rs
@@ -1,0 +1,75 @@
+use super::prelude::*;
+use crate::target::ext::tracepoints::Tracepoint;
+
+#[derive(Debug)]
+pub enum QTDP<'a> {
+    Create(CreateTDP<'a>),
+    Define(DefineTDP<'a>),
+}
+
+#[derive(Debug)]
+pub struct CreateTDP<'a> {
+    pub number: Tracepoint,
+    pub addr: &'a [u8],
+    pub enable: bool,
+    pub step: u64,
+    pub pass: u64,
+    pub fast: Option<&'a [u8]>,
+    pub condition: Option<&'a [u8]>,
+    pub more: bool,
+}
+
+#[derive(Debug)]
+pub struct DefineTDP<'a> {
+    pub number: Tracepoint,
+    pub addr: &'a [u8],
+    pub while_stepping: bool,
+    pub actions: &'a mut [u8],
+}
+
+impl<'a> ParseCommand<'a> for QTDP<'a> {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let body = buf.into_body();
+        match body {
+            [b':', b'-', actions @ ..] => {
+                let mut params = actions.splitn_mut(4, |b| matches!(*b, b':'));
+                let number = Tracepoint(decode_hex(params.next()?).ok()?);
+                let addr = decode_hex_buf(params.next()?).ok()?;
+                let actions = params.next()?;
+                Some(QTDP::Define(DefineTDP {
+                    number,
+                    addr,
+                    while_stepping: false,
+                    actions
+                }))
+            },
+            [b':', tracepoint @ ..] => {
+                let more = tracepoint.ends_with(&[b'-']);
+                let mut params = tracepoint.splitn_mut(6, |b| matches!(*b, b':' | b'-'));
+                let n = Tracepoint(decode_hex(params.next()?).ok()?);
+                let addr = decode_hex_buf(params.next()?).ok()?;
+                let ena = params.next()?;
+                let step = decode_hex(params.next()?).ok()?;
+                let pass_and_end = params.next()?;
+                let pass = decode_hex(pass_and_end).ok()?;
+                // TODO: parse `F` fast tracepoint options
+                // TODO: parse `X` tracepoint conditions
+                let _options = params.next();
+                return Some(QTDP::Create(CreateTDP {
+                    number: n,
+                    addr,
+                    enable: match ena { [b'E'] => Some(true), [b'D'] => Some(false), _ => None }?,
+                    step,
+                    pass,
+                    more,
+                    // TODO: populate fast tracepoint options
+                    // TODO: populate tracepoint conditions
+                    fast: None,
+                    condition: None,
+                }))
+            },
+            _ => None,
+        }
+    }
+}

--- a/src/protocol/commands/_QTDP.rs
+++ b/src/protocol/commands/_QTDP.rs
@@ -45,8 +45,13 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                 }))
             },
             [b':', tracepoint @ ..] => {
-                let more = tracepoint.ends_with(&[b'-']);
-                let mut params = tracepoint.splitn_mut(6, |b| matches!(*b, b':' | b'-'));
+                // Strip off the trailing '-' that indicates if there will be
+                // more packets after this
+                let (tracepoint, more) = match tracepoint {
+                    [rest @ .., b'-'] => (rest, true),
+                    x => (x, false)
+                };
+                let mut params = tracepoint.splitn_mut(6, |b| *b == b':');
                 let n = Tracepoint(decode_hex(params.next()?).ok()?);
                 let addr = decode_hex_buf(params.next()?).ok()?;
                 let ena = params.next()?;

--- a/src/protocol/commands/_QTDP.rs
+++ b/src/protocol/commands/_QTDP.rs
@@ -23,7 +23,6 @@ pub struct CreateTDP<'a> {
 pub struct ExtendTDP<'a> {
     pub number: Tracepoint,
     pub addr: &'a [u8],
-    pub while_stepping: bool,
     pub actions: &'a mut [u8],
 }
 
@@ -40,7 +39,6 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                 Some(QTDP::Extend(ExtendTDP {
                     number,
                     addr,
-                    while_stepping: false,
                     actions,
                 }))
             }
@@ -80,7 +78,7 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                     }
                     None => None,
                 };
-                return Some(QTDP::Create(CreateTDP {
+                Some(QTDP::Create(CreateTDP {
                     number: n,
                     addr,
                     enable: match ena {
@@ -92,7 +90,7 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
                     pass,
                     more,
                     unsupported_option,
-                }));
+                }))
             }
             _ => None,
         }

--- a/src/protocol/commands/_QTDP.rs
+++ b/src/protocol/commands/_QTDP.rs
@@ -33,7 +33,7 @@ impl<'a> ParseCommand<'a> for QTDP<'a> {
         let body = buf.into_body();
         match body {
             [b':', b'-', actions @ ..] => {
-                let mut params = actions.splitn_mut(4, |b| matches!(*b, b':'));
+                let mut params = actions.splitn_mut(4, |b| *b == b':');
                 let number = Tracepoint(decode_hex(params.next()?).ok()?);
                 let addr = decode_hex_buf(params.next()?).ok()?;
                 let actions = params.next()?;

--- a/src/protocol/commands/_QTDPsrc.rs
+++ b/src/protocol/commands/_QTDPsrc.rs
@@ -20,6 +20,8 @@ impl<'a> ParseCommand<'a> for QTDPsrc<'a> {
                 let mut params = info.splitn_mut(7, |b| *b == b':');
                 let number = Tracepoint(decode_hex(params.next()?).ok()?);
                 let addr = decode_hex_buf(params.next()?).ok()?;
+                // Clippy incorrect thinks this as_ref isn't needed, but it is.
+                #[allow(clippy::useless_asref)]
                 let kind = match params.next()?.as_ref() {
                     b"at" => Some(TracepointSourceType::At),
                     b"cond" => Some(TracepointSourceType::Cond),

--- a/src/protocol/commands/_QTDPsrc.rs
+++ b/src/protocol/commands/_QTDPsrc.rs
@@ -1,0 +1,44 @@
+use super::prelude::*;
+use crate::target::ext::tracepoints::Tracepoint;
+use crate::target::ext::tracepoints::TracepointSourceType;
+
+pub struct QTDPsrc<'a> {
+    pub number: Tracepoint,
+    pub addr: &'a [u8],
+    pub r#type: TracepointSourceType,
+    pub start: u32,
+    pub slen: u32,
+    pub bytes: &'a mut [u8],
+}
+
+impl<'a> ParseCommand<'a> for QTDPsrc<'a> {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let body = buf.into_body();
+        match body {
+            [b':', info @ ..] => {
+                let mut params = info.splitn_mut(7, |b| *b == b':');
+                let number = Tracepoint(decode_hex(params.next()?).ok()?);
+                let addr = decode_hex_buf(params.next()?).ok()?;
+                let r#type = match params.next()?.as_ref() {
+                    b"at" => Some(TracepointSourceType::At),
+                    b"cond" => Some(TracepointSourceType::Cond),
+                    b"cmd" => Some(TracepointSourceType::Cmd),
+                    _ => None,
+                }?;
+                let start = decode_hex(params.next()?).ok()?;
+                let slen = decode_hex(params.next()?).ok()?;
+                let bytes = decode_hex_buf(params.next()?).ok()?;
+                Some(QTDPsrc {
+                    number,
+                    addr,
+                    r#type,
+                    start,
+                    slen,
+                    bytes,
+                })
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/protocol/commands/_QTDPsrc.rs
+++ b/src/protocol/commands/_QTDPsrc.rs
@@ -5,7 +5,7 @@ use crate::target::ext::tracepoints::TracepointSourceType;
 pub struct QTDPsrc<'a> {
     pub number: Tracepoint,
     pub addr: &'a [u8],
-    pub r#type: TracepointSourceType,
+    pub kind: TracepointSourceType,
     pub start: u32,
     pub slen: u32,
     pub bytes: &'a mut [u8],
@@ -20,7 +20,7 @@ impl<'a> ParseCommand<'a> for QTDPsrc<'a> {
                 let mut params = info.splitn_mut(7, |b| *b == b':');
                 let number = Tracepoint(decode_hex(params.next()?).ok()?);
                 let addr = decode_hex_buf(params.next()?).ok()?;
-                let r#type = match params.next()?.as_ref() {
+                let kind = match params.next()?.as_ref() {
                     b"at" => Some(TracepointSourceType::At),
                     b"cond" => Some(TracepointSourceType::Cond),
                     b"cmd" => Some(TracepointSourceType::Cmd),
@@ -32,7 +32,7 @@ impl<'a> ParseCommand<'a> for QTDPsrc<'a> {
                 Some(QTDPsrc {
                     number,
                     addr,
-                    r#type,
+                    kind,
                     start,
                     slen,
                     bytes,

--- a/src/protocol/commands/_QTFrame.rs
+++ b/src/protocol/commands/_QTFrame.rs
@@ -1,5 +1,6 @@
 use super::prelude::*;
-use crate::target::ext::tracepoints::{Tracepoint, FrameRequest};
+use crate::target::ext::tracepoints::FrameRequest;
+use crate::target::ext::tracepoints::Tracepoint;
 
 #[derive(Debug)]
 pub struct QTFrame<'a>(pub FrameRequest<&'a mut [u8]>);
@@ -16,26 +17,24 @@ impl<'a> ParseCommand<'a> for QTFrame<'a> {
                     b"pc" => {
                         let addr = decode_hex_buf(s.next()?).ok()?;
                         QTFrame(FrameRequest::AtPC(addr))
-                    },
+                    }
                     b"tdp" => {
                         let tp = Tracepoint(decode_hex(s.next()?).ok()?);
                         QTFrame(FrameRequest::Hit(tp))
-                    },
+                    }
                     b"range" => {
                         let start = decode_hex_buf(s.next()?).ok()?;
                         let end = decode_hex_buf(s.next()?).ok()?;
                         QTFrame(FrameRequest::Between(start, end))
-                    },
+                    }
                     b"outside" => {
                         let start = decode_hex_buf(s.next()?).ok()?;
                         let end = decode_hex_buf(s.next()?).ok()?;
                         QTFrame(FrameRequest::Outside(start, end))
-                    },
-                    n => {
-                        QTFrame(FrameRequest::Select(decode_hex(n).ok()?))
-                    },
+                    }
+                    n => QTFrame(FrameRequest::Select(decode_hex(n).ok()?)),
                 })
-            },
+            }
             _ => None,
         }
     }

--- a/src/protocol/commands/_QTFrame.rs
+++ b/src/protocol/commands/_QTFrame.rs
@@ -1,0 +1,42 @@
+use super::prelude::*;
+use crate::target::ext::tracepoints::{Tracepoint, FrameRequest};
+
+#[derive(Debug)]
+pub struct QTFrame<'a>(pub FrameRequest<&'a mut [u8]>);
+
+impl<'a> ParseCommand<'a> for QTFrame<'a> {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let body = buf.into_body();
+        match body {
+            [b':', body @ ..] => {
+                let mut s = body.split_mut(|b| *b == b':');
+                let selector = s.next()?;
+                Some(match selector.as_ref() {
+                    b"pc" => {
+                        let addr = decode_hex_buf(s.next()?).ok()?;
+                        QTFrame(FrameRequest::AtPC(addr))
+                    },
+                    b"tdp" => {
+                        let tp = Tracepoint(decode_hex(s.next()?).ok()?);
+                        QTFrame(FrameRequest::Hit(tp))
+                    },
+                    b"range" => {
+                        let start = decode_hex_buf(s.next()?).ok()?;
+                        let end = decode_hex_buf(s.next()?).ok()?;
+                        QTFrame(FrameRequest::Between(start, end))
+                    },
+                    b"outside" => {
+                        let start = decode_hex_buf(s.next()?).ok()?;
+                        let end = decode_hex_buf(s.next()?).ok()?;
+                        QTFrame(FrameRequest::Outside(start, end))
+                    },
+                    n => {
+                        QTFrame(FrameRequest::Select(decode_hex(n).ok()?))
+                    },
+                })
+            },
+            _ => None,
+        }
+    }
+}

--- a/src/protocol/commands/_QTFrame.rs
+++ b/src/protocol/commands/_QTFrame.rs
@@ -13,6 +13,8 @@ impl<'a> ParseCommand<'a> for QTFrame<'a> {
             [b':', body @ ..] => {
                 let mut s = body.split_mut(|b| *b == b':');
                 let selector = s.next()?;
+                // Clippy incorrect thinks this as_ref isn't needed, but it is.
+                #[allow(clippy::useless_asref)]
                 Some(match selector.as_ref() {
                     b"pc" => {
                         let addr = decode_hex_buf(s.next()?).ok()?;

--- a/src/protocol/commands/_QTStart.rs
+++ b/src/protocol/commands/_QTStart.rs
@@ -1,0 +1,14 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct QTStart;
+
+impl<'a> ParseCommand<'a> for QTStart {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        if !buf.into_body().is_empty() {
+            return None;
+        }
+        Some(QTStart)
+    }
+}

--- a/src/protocol/commands/_QTStop.rs
+++ b/src/protocol/commands/_QTStop.rs
@@ -1,0 +1,14 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct QTStop;
+
+impl<'a> ParseCommand<'a> for QTStop {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        if !buf.into_body().is_empty() {
+            return None;
+        }
+        Some(QTStop)
+    }
+}

--- a/src/protocol/commands/_QTinit.rs
+++ b/src/protocol/commands/_QTinit.rs
@@ -1,11 +1,14 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct QTinit { }
+pub struct QTinit {}
 
 impl<'a> ParseCommand<'a> for QTinit {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
-        if !buf.into_body().is_empty() { None }
-        else { Some(Self { }) }
+        if !buf.into_body().is_empty() {
+            None
+        } else {
+            Some(Self {})
+        }
     }
 }

--- a/src/protocol/commands/_QTinit.rs
+++ b/src/protocol/commands/_QTinit.rs
@@ -1,14 +1,14 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct QTinit {}
+pub struct QTinit;
 
 impl<'a> ParseCommand<'a> for QTinit {
+    #[inline(always)]
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
         if !buf.into_body().is_empty() {
-            None
-        } else {
-            Some(Self {})
+            return None;
         }
+        Some(QTinit)
     }
 }

--- a/src/protocol/commands/_QTinit.rs
+++ b/src/protocol/commands/_QTinit.rs
@@ -1,0 +1,11 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct QTinit { }
+
+impl<'a> ParseCommand<'a> for QTinit {
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        if !buf.into_body().is_empty() { None }
+        else { Some(Self { }) }
+    }
+}

--- a/src/protocol/commands/_qTBuffer.rs
+++ b/src/protocol/commands/_qTBuffer.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 pub struct qTBuffer<'a> {
     pub offset: u64,
     pub length: usize,
-    pub data: &'a mut [u8]
+    pub data: &'a mut [u8],
 }
 
 impl<'a> ParseCommand<'a> for qTBuffer<'a> {
@@ -22,9 +22,13 @@ impl<'a> ParseCommand<'a> for qTBuffer<'a> {
                 // our packet size, which means we actually have half as much space
                 // as our slice would indicate.
                 let (front, _back) = buf.split_at_mut(buf.len() / 2);
-                Some(qTBuffer { offset, length, data: front })
-            },
-            _ => None
+                Some(qTBuffer {
+                    offset,
+                    length,
+                    data: front,
+                })
+            }
+            _ => None,
         }
     }
 }

--- a/src/protocol/commands/_qTBuffer.rs
+++ b/src/protocol/commands/_qTBuffer.rs
@@ -1,13 +1,12 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct qTBuffer<'a> {
+pub struct qTBuffer {
     pub offset: u64,
     pub length: usize,
-    pub data: &'a mut [u8],
 }
 
-impl<'a> ParseCommand<'a> for qTBuffer<'a> {
+impl<'a> ParseCommand<'a> for qTBuffer {
     #[inline(always)]
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
         let (buf, body_range) = buf.into_raw_buf();
@@ -18,15 +17,7 @@ impl<'a> ParseCommand<'a> for qTBuffer<'a> {
                 let (offset, length) = (req_opts.next()?, req_opts.next()?);
                 let offset = decode_hex(offset).ok()?;
                 let length = decode_hex(length).ok()?;
-                // Our response has to be a hex encoded buffer that fits within
-                // our packet size, which means we actually have half as much space
-                // as our slice would indicate.
-                let (front, _back) = buf.split_at_mut(buf.len() / 2);
-                Some(qTBuffer {
-                    offset,
-                    length,
-                    data: front,
-                })
+                Some(qTBuffer { offset, length })
             }
             _ => None,
         }

--- a/src/protocol/commands/_qTBuffer.rs
+++ b/src/protocol/commands/_qTBuffer.rs
@@ -1,0 +1,30 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct qTBuffer<'a> {
+    pub offset: u64,
+    pub length: usize,
+    pub data: &'a mut [u8]
+}
+
+impl<'a> ParseCommand<'a> for qTBuffer<'a> {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let (buf, body_range) = buf.into_raw_buf();
+        let body = &buf[body_range];
+        match body {
+            [b':', body @ ..] => {
+                let mut req_opts = body.split(|b| *b == b',');
+                let (offset, length) = (req_opts.next()?, req_opts.next()?);
+                let offset = decode_hex(offset).ok()?;
+                let length = decode_hex(length).ok()?;
+                // Our response has to be a hex encoded buffer that fits within
+                // our packet size, which means we actually have half as much space
+                // as our slice would indicate.
+                let (front, _back) = buf.split_at_mut(buf.len() / 2);
+                Some(qTBuffer { offset, length, data: front })
+            },
+            _ => None
+        }
+    }
+}

--- a/src/protocol/commands/_qTP.rs
+++ b/src/protocol/commands/_qTP.rs
@@ -1,0 +1,27 @@
+use super::prelude::*;
+use crate::target::ext::tracepoints::Tracepoint;
+
+#[derive(Debug)]
+pub struct qTP<'a> {
+    pub tracepoint: Tracepoint,
+    pub addr: &'a [u8],
+}
+
+impl<'a> ParseCommand<'a> for qTP<'a> {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        let body = buf.into_body();
+        match body {
+            [b':', body @ ..] => {
+                let mut s = body.split_mut(|b| *b == b':');
+                let tracepoint = Tracepoint(decode_hex(s.next()?).ok()?);
+                let addr = decode_hex_buf(s.next()?).ok()?;
+                Some(qTP {
+                    tracepoint,
+                    addr
+                })
+            },
+            _ => None,
+        }
+    }
+}

--- a/src/protocol/commands/_qTP.rs
+++ b/src/protocol/commands/_qTP.rs
@@ -16,11 +16,8 @@ impl<'a> ParseCommand<'a> for qTP<'a> {
                 let mut s = body.split_mut(|b| *b == b':');
                 let tracepoint = Tracepoint(decode_hex(s.next()?).ok()?);
                 let addr = decode_hex_buf(s.next()?).ok()?;
-                Some(qTP {
-                    tracepoint,
-                    addr
-                })
-            },
+                Some(qTP { tracepoint, addr })
+            }
             _ => None,
         }
     }

--- a/src/protocol/commands/_qTStatus.rs
+++ b/src/protocol/commands/_qTStatus.rs
@@ -1,11 +1,14 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct qTStatus { }
+pub struct qTStatus {}
 
 impl<'a> ParseCommand<'a> for qTStatus {
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
-        if !buf.into_body().is_empty() { None }
-        else { Some(Self { }) }
+        if !buf.into_body().is_empty() {
+            None
+        } else {
+            Some(Self {})
+        }
     }
 }

--- a/src/protocol/commands/_qTStatus.rs
+++ b/src/protocol/commands/_qTStatus.rs
@@ -1,14 +1,14 @@
 use super::prelude::*;
 
 #[derive(Debug)]
-pub struct qTStatus {}
+pub struct qTStatus;
 
 impl<'a> ParseCommand<'a> for qTStatus {
+    #[inline(always)]
     fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
         if !buf.into_body().is_empty() {
-            None
-        } else {
-            Some(Self {})
+            return None;
         }
+        Some(qTStatus)
     }
 }

--- a/src/protocol/commands/_qTStatus.rs
+++ b/src/protocol/commands/_qTStatus.rs
@@ -1,0 +1,11 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct qTStatus { }
+
+impl<'a> ParseCommand<'a> for qTStatus {
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        if !buf.into_body().is_empty() { None }
+        else { Some(Self { }) }
+    }
+}

--- a/src/protocol/commands/_qTfP.rs
+++ b/src/protocol/commands/_qTfP.rs
@@ -1,0 +1,14 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct qTfP;
+
+impl<'a> ParseCommand<'a> for qTfP {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        if !buf.into_body().is_empty() {
+            return None;
+        }
+        Some(qTfP)
+    }
+}

--- a/src/protocol/commands/_qTfV.rs
+++ b/src/protocol/commands/_qTfV.rs
@@ -1,0 +1,14 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct qTfV;
+
+impl<'a> ParseCommand<'a> for qTfV {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        if !buf.into_body().is_empty() {
+            return None;
+        }
+        Some(qTfV)
+    }
+}

--- a/src/protocol/commands/_qTsP.rs
+++ b/src/protocol/commands/_qTsP.rs
@@ -1,0 +1,14 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct qTsP;
+
+impl<'a> ParseCommand<'a> for qTsP {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        if !buf.into_body().is_empty() {
+            return None;
+        }
+        Some(qTsP)
+    }
+}

--- a/src/protocol/commands/_qTsV.rs
+++ b/src/protocol/commands/_qTsV.rs
@@ -1,0 +1,14 @@
+use super::prelude::*;
+
+#[derive(Debug)]
+pub struct qTsV;
+
+impl<'a> ParseCommand<'a> for qTsV {
+    #[inline(always)]
+    fn from_packet(buf: PacketBuf<'a>) -> Option<Self> {
+        if !buf.into_body().is_empty() {
+            return None;
+        }
+        Some(qTsV)
+    }
+}

--- a/src/stub/core_impl.rs
+++ b/src/stub/core_impl.rs
@@ -42,6 +42,7 @@ mod section_offsets;
 mod single_register_access;
 mod target_xml;
 mod thread_extra_info;
+mod tracepoints;
 mod x_upcase_packet;
 
 pub(crate) use resume::FinishExecStatus;
@@ -218,6 +219,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Command::ThreadExtraInfo(cmd) => self.handle_thread_extra_info(res, target, cmd),
             Command::LldbRegisterInfo(cmd) => self.handle_lldb_register_info(res, target, cmd),
             Command::LibrariesSvr4(cmd) => self.handle_libraries_svr4(res, target, cmd),
+            Command::Tracepoints(cmd) => self.handle_tracepoints(res, target, cmd),
             // in the worst case, the command could not be parsed...
             Command::Unknown(cmd) => {
                 // HACK: if the user accidentally sends a resume command to a

--- a/src/stub/core_impl/base.rs
+++ b/src/stub/core_impl/base.rs
@@ -172,7 +172,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     }
                 }
 
-                if let Some(_ops) = target.support_tracepoints() {
+                if let Some(ops) = target.support_tracepoints() {
                     // There are a number of optional tracepoint extensions that
                     // gdbstub should eventually implement.
                     // * `StaticTracepoint` for static tracepoint support.
@@ -190,8 +190,9 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     // * `QTBuffer:size` for configuring the trace buffer size, since the target is
                     //   allowed to implement it as a no-op.
                     res.write_str(";QTBuffer:size+")?;
-                    // TODO: gate this behind a support method
-                    res.write_str(";TracepointSource+")?;
+                    if ops.support_tracepoint_source().is_some() {
+                        res.write_str(";TracepointSource+")?;
+                    }
                 }
 
                 if target.support_catch_syscalls().is_some() {

--- a/src/stub/core_impl/base.rs
+++ b/src/stub/core_impl/base.rs
@@ -187,9 +187,11 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     // For now, gdbstub doesn't provide trait extensions for these
                     // options and so we don't report support. We do report support
                     // for one extension however:
-                    // * `QTBuffer:size` for configuring the trace buffer size, since
-                    //   the target is allowed to implement it as a no-op.
+                    // * `QTBuffer:size` for configuring the trace buffer size, since the target is
+                    //   allowed to implement it as a no-op.
                     res.write_str(";QTBuffer:size+")?;
+                    // TODO: gate this behind a support method
+                    res.write_str(";TracepointSource+")?;
                 }
 
                 if target.support_catch_syscalls().is_some() {

--- a/src/stub/core_impl/base.rs
+++ b/src/stub/core_impl/base.rs
@@ -172,6 +172,11 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     }
                 }
 
+                if let Some(_ops) = target.support_tracepoints() {
+                    res.write_str(";InstallInTrace+")?;
+                    res.write_str(";QTBuffer:size+")?;
+                }
+
                 if target.support_catch_syscalls().is_some() {
                     res.write_str(";QCatchSyscalls+")?;
                 }

--- a/src/stub/core_impl/base.rs
+++ b/src/stub/core_impl/base.rs
@@ -173,7 +173,22 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 }
 
                 if let Some(_ops) = target.support_tracepoints() {
-                    res.write_str(";InstallInTrace+")?;
+                    // There are a number of optional tracepoint extensions that
+                    // gdbstub should eventually implement.
+                    // * `StaticTracepoint` for static tracepoint support.
+                    // * `EnableDisableTracepoints` for enabling/disabling tracepoints during a
+                    //   trace experiment.
+                    // * `tracenz` for the tracenz agent bytecode operation.
+                    // * The `Qbtrace:*` family for branch tracing.
+                    // * `InstallInTrace` allows for gdbstub to deliver tracepoint configuration
+                    //   commands while the trace experiment is running instead of them only taking
+                    //   affect on the next `tstart` command.
+                    //
+                    // For now, gdbstub doesn't provide trait extensions for these
+                    // options and so we don't report support. We do report support
+                    // for one extension however:
+                    // * `QTBuffer:size` for configuring the trace buffer size, since
+                    //   the target is allowed to implement it as a no-op.
                     res.write_str(";QTBuffer:size+")?;
                 }
 

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -37,14 +37,6 @@ impl<U: BeBytes> NewTracepoint<U> {
     }
 }
 
-#[cfg(feature = "alloc")]
-impl<U: Copy> NewTracepoint<U> {
-    /// Allocate an owned copy of this structure.
-    pub fn get_owned(&self) -> NewTracepoint<U> {
-        self.clone()
-    }
-}
-
 impl<U: crate::internal::BeBytes + num_traits::Zero + PrimInt> NewTracepoint<U> {
     pub(crate) fn write<T: Target, C: Connection>(
         &self,
@@ -237,7 +229,7 @@ impl<'a, U: Copy> TracepointItem<'a, U> {
     /// Allocate an owned copy of this structure.
     pub fn get_owned<'b>(&self) -> TracepointItem<'b, U> {
         match self {
-            TracepointItem::New(n) => TracepointItem::New(n.get_owned()),
+            TracepointItem::New(n) => TracepointItem::New(n.clone()),
             TracepointItem::Define(d) => TracepointItem::Define(d.get_owned()),
         }
     }

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -642,9 +642,8 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                             )
                         } else {
                             // If the target doesn't support tracepoint sources but told
-                            // us to enumerate one anyways, then all we can do is
-                            // stop our state machine.
-                            None
+                            // us to enumerate one anyways, then the target has an error.
+                            return Err(Error::TracepointUnsupportedSourceEnumeration);
                         }
                     }
                 };

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -239,7 +239,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     let e = (|| -> Result<_, _> {
                         match desc {
                             FrameDescription::FrameNumber(n) => {
-                                res.write_str("F ")?;
+                                res.write_str("F")?;
                                 if let Some(n) = n {
                                     res.write_num(n)?;
                                 } else {
@@ -247,7 +247,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                                 }
                             }
                             FrameDescription::Hit(tdp) => {
-                                res.write_str("T ")?;
+                                res.write_str("T")?;
                                 res.write_num(tdp.0)?;
                             }
                         }
@@ -260,7 +260,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 })
                 .handle_error()?;
                 if !any_results {
-                    res.write_str("F -1")?;
+                    res.write_str("F-1")?;
                 }
             }
             // The GDB protocol for this is very weird: it sends this first packet

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -159,8 +159,9 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             }
             Tracepoints::qTStatus(_) => {
                 let status = ops.trace_experiment_status().handle_error()?;
-                res.write_str("T")?;
-                res.write_dec(if status.running { 1 } else { 0 })?;
+                // Write stop status
+                status.state.write(res)?;
+                // And then all the optional statistical information
                 for explanation in status.explanations.iter() {
                     res.write_str(";")?;
                     explanation.write(res)?;

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -21,10 +21,9 @@ use managed::ManagedSlice;
 impl<U: BeBytes> NewTracepoint<U> {
     /// Parse from a raw CreateTDP packet.
     pub fn from_tdp(ctdp: CreateTDP<'_>) -> Option<Self> {
-        let arch_int = |b: &[u8]| -> Result<U, ()> { U::from_be_bytes(b).ok_or(()) };
         Some(Self {
             number: ctdp.number,
-            addr: arch_int(ctdp.addr).ok()?,
+            addr: U::from_be_bytes(ctdp.addr)?,
             enabled: ctdp.enable,
             pass_count: ctdp.pass,
             step_count: ctdp.step,
@@ -36,11 +35,9 @@ impl<U: BeBytes> NewTracepoint<U> {
 impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
     /// Parse from a raw DefineTDP packet.
     pub fn from_tdp(dtdp: DefineTDP<'a>) -> Option<Self> {
-        let arch_int = |b: &[u8]| -> Result<U, ()> { U::from_be_bytes(b).ok_or(()) };
-
         Some(Self {
             number: dtdp.number,
-            addr: arch_int(dtdp.addr).ok()?,
+            addr: U::from_be_bytes(dtdp.addr)?,
             actions: TracepointActionList::Raw {
                 data: ManagedSlice::Borrowed(dtdp.actions),
             },

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -228,7 +228,7 @@ impl<U: crate::internal::BeBytes + num_traits::Zero + PrimInt> SourceTracepoint<
     }
 }
 
-impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> TracepointAction<'a, U> {
+impl<U: crate::internal::BeBytes + num_traits::Zero + PrimInt> TracepointAction<'_, U> {
     /// Write this as a qTfP/qTsP response
     pub(crate) fn write<T: Target, C: Connection>(
         &self,
@@ -273,7 +273,7 @@ impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> TracepointAct
     }
 }
 
-impl<'a> ExperimentStatus<'a> {
+impl ExperimentStatus<'_> {
     pub(crate) fn write<C: Connection>(
         &self,
         res: &mut ResponseWriter<'_, C>,
@@ -315,7 +315,7 @@ impl<'a> ExperimentStatus<'a> {
     }
 }
 
-impl<'a> ExperimentExplanation<'a> {
+impl ExperimentExplanation<'_> {
     pub(crate) fn write<T: Target, C: Connection>(
         &self,
         res: &mut ResponseWriter<'_, C>,

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -19,6 +19,7 @@ use crate::target::ext::tracepoints::NewTracepoint;
 use crate::target::ext::tracepoints::TracepointAction;
 use crate::target::ext::tracepoints::TracepointActionList;
 use crate::target::ext::tracepoints::TracepointItem;
+use crate::target::ext::tracepoints::TracepointStatus;
 use managed::ManagedSlice;
 use num_traits::PrimInt;
 
@@ -449,11 +450,14 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Tracepoints::qTP(qtp) => {
                 let addr = <T::Arch as Arch>::Usize::from_be_bytes(qtp.addr)
                     .ok_or(Error::TargetMismatch)?;
-                let (hits, usage) = ops.tracepoint_status(qtp.tracepoint, addr).handle_error()?;
+                let TracepointStatus {
+                    hit_count,
+                    bytes_used,
+                } = ops.tracepoint_status(qtp.tracepoint, addr).handle_error()?;
                 res.write_str("V")?;
-                res.write_num(hits)?;
+                res.write_num(hit_count)?;
                 res.write_str(":")?;
-                res.write_num(usage)?;
+                res.write_num(bytes_used)?;
             }
             Tracepoints::QTDP(q) => {
                 match q {

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -228,46 +228,6 @@ impl<U: crate::internal::BeBytes + num_traits::Zero + PrimInt> SourceTracepoint<
     }
 }
 
-#[cfg(feature = "alloc")]
-impl<'a, U: Copy> SourceTracepoint<'a, U> {
-    /// Allocate an owned copy of this structure.
-    pub fn get_owned<'b>(&self) -> SourceTracepoint<'b, U> {
-        SourceTracepoint {
-            number: self.number,
-            addr: self.addr,
-            kind: self.kind,
-            start: self.start,
-            slen: self.slen,
-            bytes: ManagedSlice::Owned(self.bytes.to_owned()),
-        }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<'a, U: Copy> TracepointAction<'a, U> {
-    /// Allocate an owned copy of this structure.
-    pub fn get_owned<'b>(&self) -> TracepointAction<'b, U> {
-        use core::ops::Deref;
-        match self {
-            TracepointAction::Registers { mask } => TracepointAction::Registers {
-                mask: ManagedSlice::Owned(mask.deref().into()),
-            },
-            TracepointAction::Memory {
-                basereg,
-                offset,
-                length,
-            } => TracepointAction::Memory {
-                basereg: *basereg,
-                offset: *offset,
-                length: *length,
-            },
-            TracepointAction::Expression { expr } => TracepointAction::Expression {
-                expr: ManagedSlice::Owned(expr.deref().into()),
-            },
-        }
-    }
-}
-
 impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> TracepointAction<'a, U> {
     /// Write this as a qTfP/qTsP response
     pub(crate) fn write<T: Target, C: Connection>(

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -21,7 +21,6 @@ use crate::target::ext::tracepoints::SourceTracepoint;
 use crate::target::ext::tracepoints::TracepointAction;
 use crate::target::ext::tracepoints::TracepointActionList;
 use crate::target::ext::tracepoints::TracepointEnumerateCursor;
-use crate::target::ext::tracepoints::TracepointEnumerateState;
 use crate::target::ext::tracepoints::TracepointEnumerateStep;
 use crate::target::ext::tracepoints::TracepointItem;
 use crate::target::ext::tracepoints::TracepointSourceType;
@@ -649,7 +648,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     ops.tracepoint_enumerate_state().cursor =
                         Some(TracepointEnumerateCursor::New(started));
                 }
-                self.handle_tracepoint_state_machine_step(res, target, step)?;
+                self.handle_tracepoint_state_machine_step(target, step)?;
             }
             Tracepoints::qTsP(_) => {
                 let state = ops.tracepoint_enumerate_state();
@@ -703,7 +702,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     return Err(e.into());
                 }
                 if let Some(step) = step {
-                    self.handle_tracepoint_state_machine_step(res, target, step)?;
+                    self.handle_tracepoint_state_machine_step(target, step)?;
                 }
             }
 
@@ -722,7 +721,6 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
     fn handle_tracepoint_state_machine_step(
         &mut self,
-        res: &mut ResponseWriter<'_, C>,
         target: &mut T,
         step: TracepointEnumerateStep,
     ) -> Result<(), Error<T::Error, C::Error>> {

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -8,8 +8,11 @@ use crate::protocol::commands::prelude::decode_hex_buf;
 use crate::protocol::commands::_QTDP::CreateTDP;
 use crate::protocol::commands::_QTDP::DefineTDP;
 use crate::protocol::commands::_QTDP::QTDP;
+use crate::protocol::PacketParseError;
+use crate::protocol::ResponseWriterError;
 use crate::target::ext::tracepoints::DefineTracepoint;
 use crate::target::ext::tracepoints::ExperimentExplanation;
+use crate::target::ext::tracepoints::ExperimentStatus;
 use crate::target::ext::tracepoints::FrameDescription;
 use crate::target::ext::tracepoints::FrameRequest;
 use crate::target::ext::tracepoints::NewTracepoint;
@@ -17,6 +20,7 @@ use crate::target::ext::tracepoints::TracepointAction;
 use crate::target::ext::tracepoints::TracepointActionList;
 use crate::target::ext::tracepoints::TracepointItem;
 use managed::ManagedSlice;
+use num_traits::PrimInt;
 
 impl<U: BeBytes> NewTracepoint<U> {
     /// Parse from a raw CreateTDP packet.
@@ -29,6 +33,34 @@ impl<U: BeBytes> NewTracepoint<U> {
             step_count: ctdp.step,
             more: ctdp.more,
         })
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<U: Copy> NewTracepoint<U> {
+    /// Allocate an owned copy of this structure.
+    pub fn get_owned(&self) -> NewTracepoint<U> {
+        self.clone()
+    }
+}
+
+impl<U: crate::internal::BeBytes + num_traits::Zero + PrimInt> NewTracepoint<U> {
+    pub(crate) fn write<T: Target, C: Connection>(
+        &self,
+        res: &mut ResponseWriter<'_, C>,
+    ) -> Result<(), Error<T::Error, C::Error>> {
+        res.write_str("QTDP:")?;
+        res.write_num(self.number.0)?;
+        res.write_str(":")?;
+        res.write_num(self.addr)?;
+        res.write_str(":")?;
+        res.write_str(if self.enabled { "E" } else { "D" })?;
+        res.write_str(":")?;
+        res.write_num(self.step_count)?;
+        res.write_str(":")?;
+        res.write_num(self.pass_count)?;
+
+        Ok(())
     }
 }
 
@@ -51,14 +83,17 @@ impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
     /// Return `Some(more)` on success, where `more` is a bool indicating if
     /// there will be additional "tracepoint define" packets for this
     /// tracepoint.
-    pub fn actions(self, mut f: impl FnMut(&TracepointAction<'_, U>)) -> Option<bool> {
+    pub fn actions(
+        self,
+        mut f: impl FnMut(&TracepointAction<'_, U>),
+    ) -> Result<bool, PacketParseError> {
         match self.actions {
             TracepointActionList::Raw { mut data } => Self::parse_raw_actions(&mut data, f),
             TracepointActionList::Parsed { mut actions, more } => {
                 for action in actions.iter_mut() {
                     (f)(action);
                 }
-                Some(more)
+                Ok(more)
             }
         }
     }
@@ -66,11 +101,14 @@ impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
     fn parse_raw_actions(
         actions: &mut [u8],
         mut f: impl FnMut(&TracepointAction<'_, U>),
-    ) -> Option<bool> {
+    ) -> Result<bool, PacketParseError> {
         let (actions, more) = match actions {
             [rest @ .., b'-'] => (rest, true),
             x => (x, false),
         };
+        // TODO: There's no "packet unsupported", so for now we stub out unimplemented
+        // functionality by reporting the commands malformed instead.
+        use crate::protocol::PacketParseError::MalformedCommand;
         let mut unparsed: Option<&mut [u8]> = Some(actions);
         loop {
             match unparsed {
@@ -85,7 +123,7 @@ impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
                     // "normals" actions may still be "while stepping" actions,
                     // just continued from the previous packet, which we forgot
                     // about!
-                    return None;
+                    return Err(MalformedCommand);
                 }
                 Some([b'R', mask @ ..]) => {
                     let mask_end = mask
@@ -96,10 +134,10 @@ impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
                     let mask = if let Some(mask_end) = mask_end {
                         let (mask_bytes, next) = mask.split_at_mut(mask_end.0);
                         unparsed = Some(next);
-                        decode_hex_buf(mask_bytes).ok()?
+                        decode_hex_buf(mask_bytes).or(Err(MalformedCommand))?
                     } else {
                         unparsed = None;
-                        decode_hex_buf(mask).ok()?
+                        decode_hex_buf(mask).or(Err(MalformedCommand))?
                     };
                     (f)(&TracepointAction::Registers {
                         mask: ManagedSlice::Borrowed(mask),
@@ -108,14 +146,20 @@ impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
                 Some([b'M', _mem_args @ ..]) => {
                     // Unimplemented: even simple actions like `collect *(int*)0x0`
                     // are actually assembled as `X` bytecode actions
-                    return None;
+                    return Err(MalformedCommand);
                 }
                 Some([b'X', eval_args @ ..]) => {
                     let mut len_end = eval_args.splitn_mut(2, |b| *b == b',');
-                    let (len_bytes, rem) = (len_end.next()?, len_end.next()?);
-                    let len: usize = decode_hex(len_bytes).ok()?;
+                    let (len_bytes, rem) = (
+                        len_end.next().ok_or(MalformedCommand)?,
+                        len_end.next().ok_or(MalformedCommand)?,
+                    );
+                    let len: usize = decode_hex(len_bytes).or(Err(MalformedCommand))?;
+                    if rem.len() < len * 2 {
+                        return Err(MalformedCommand);
+                    }
                     let (expr_bytes, next_bytes) = rem.split_at_mut(len * 2);
-                    let expr = decode_hex_buf(expr_bytes).ok()?;
+                    let expr = decode_hex_buf(expr_bytes).or(Err(MalformedCommand))?;
                     (f)(&TracepointAction::Expression {
                         expr: ManagedSlice::Borrowed(expr),
                     });
@@ -124,11 +168,242 @@ impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
                 Some([]) | None => {
                     break;
                 }
-                _ => return None,
+                _ => return Err(MalformedCommand),
             }
         }
 
-        Some(more)
+        Ok(more)
+    }
+}
+#[cfg(feature = "alloc")]
+impl<'a, U: Copy> DefineTracepoint<'a, U> {
+    /// Allocate an owned copy of this structure.
+    pub fn get_owned<'b>(&self) -> DefineTracepoint<'b, U> {
+        DefineTracepoint {
+            number: self.number,
+            addr: self.addr,
+            actions: self.actions.get_owned(),
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, U: Copy> TracepointAction<'a, U> {
+    /// Allocate an owned copy of this structure.
+    pub fn get_owned<'b>(&self) -> TracepointAction<'b, U> {
+        use core::ops::Deref;
+        match self {
+            TracepointAction::Registers { mask } => TracepointAction::Registers {
+                mask: ManagedSlice::Owned(mask.deref().into()),
+            },
+            TracepointAction::Memory {
+                basereg,
+                offset,
+                length,
+            } => TracepointAction::Memory {
+                basereg: *basereg,
+                offset: *offset,
+                length: *length,
+            },
+            TracepointAction::Expression { expr } => TracepointAction::Expression {
+                expr: ManagedSlice::Owned(expr.deref().into()),
+            },
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, U: Copy> TracepointActionList<'a, U> {
+    /// Allocate an owned copy of this structure.
+    pub fn get_owned<'b>(&self) -> TracepointActionList<'b, U> {
+        use core::ops::Deref;
+        match self {
+            TracepointActionList::Raw { data } => TracepointActionList::Raw {
+                data: ManagedSlice::Owned(data.deref().into()),
+            },
+            TracepointActionList::Parsed { actions, more } => TracepointActionList::Parsed {
+                actions: ManagedSlice::Owned(
+                    actions.iter().map(|action| action.get_owned()).collect(),
+                ),
+                more: *more,
+            },
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, U: Copy> TracepointItem<'a, U> {
+    /// Allocate an owned copy of this structure.
+    pub fn get_owned<'b>(&self) -> TracepointItem<'b, U> {
+        match self {
+            TracepointItem::New(n) => TracepointItem::New(n.get_owned()),
+            TracepointItem::Define(d) => TracepointItem::Define(d.get_owned()),
+        }
+    }
+}
+
+impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> DefineTracepoint<'a, U> {
+    pub(crate) fn write<T: Target, C: Connection>(
+        self,
+        res: &mut ResponseWriter<'_, C>,
+    ) -> Result<(), Error<T::Error, C::Error>> {
+        res.write_str("QTDP:-")?;
+        res.write_num(self.number.0)?;
+        res.write_str(":")?;
+        res.write_num(self.addr)?;
+        res.write_str(":")?;
+        let mut err = None;
+        let more = self.actions(|action| {
+            if let Err(e) = action.write::<T, C>(res) {
+                err = Some(e)
+            }
+        });
+        if let Some(e) = err {
+            return Err(e.into());
+        }
+        match more {
+            Ok(true) => Ok(res.write_str("-")?),
+            Ok(false) => Ok(()),
+            e => e.map(|_| ()).map_err(|e| Error::PacketParse(e)),
+        }
+    }
+}
+
+impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> TracepointAction<'a, U> {
+    pub(crate) fn write<T: Target, C: Connection>(
+        &self,
+        res: &mut ResponseWriter<'_, C>,
+    ) -> Result<(), Error<T::Error, C::Error>> {
+        match self {
+            TracepointAction::Registers { mask } => {
+                res.write_str("R")?;
+                res.write_hex_buf(mask)?;
+            }
+            TracepointAction::Memory {
+                basereg,
+                offset,
+                length,
+            } => {
+                res.write_str("M")?;
+                match basereg {
+                    Some(r) => res.write_num(*r),
+                    None => res.write_str("-1"),
+                }?;
+                res.write_str(",")?;
+                res.write_num(*offset)?;
+                res.write_str(",")?;
+                res.write_num(*length)?;
+            }
+            TracepointAction::Expression { expr } => {
+                res.write_str("X")?;
+                res.write_num(expr.len())?;
+                res.write_str(",")?;
+                res.write_hex_buf(expr)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a> ExperimentStatus<'a> {
+    pub(crate) fn write<C: Connection>(
+        &self,
+        res: &mut ResponseWriter<'_, C>,
+    ) -> Result<(), ResponseWriterError<C::Error>> {
+        use crate::target::ext::tracepoints::ExperimentStatus::*;
+        if let Running = self {
+            return res.write_str("T1");
+        }
+        // We're stopped for some reason, and may have an explanation for why
+        res.write_str("T0")?;
+        match self {
+            Running => {
+                /* unreachable */
+                ()
+            }
+            NotRunning => {
+                /* no information */
+                ()
+            }
+            NotRun => res.write_str(";tnotrun:0")?,
+            Stop(ref t) => match t {
+                Some(text) => {
+                    res.write_str(";tstop:")?;
+                    res.write_hex_buf(text)?;
+                    res.write_str(":0")?;
+                }
+                None => res.write_str(";tstop:0")?,
+            },
+            Full => res.write_str(";tfull:0")?,
+            Disconnected => res.write_str(";tdisconnected:0")?,
+            PassCount(tpnum) => {
+                res.write_str(";tpasscount:")?;
+                res.write_num(tpnum.0)?;
+            }
+            Error(text, tpnum) => {
+                res.write_str(";terror:")?;
+                res.write_hex_buf(text)?;
+                res.write_str(":")?;
+                res.write_num(tpnum.0)?;
+            }
+            Unknown => res.write_str(";tunknown:0")?,
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> ExperimentExplanation<'a> {
+    pub(crate) fn write<T: Target, C: Connection>(
+        &self,
+        res: &mut ResponseWriter<'_, C>,
+    ) -> Result<(), Error<T::Error, C::Error>> {
+        use ExperimentExplanation::*;
+        match self {
+            Frames(u) => {
+                res.write_str("tframes:")?;
+                res.write_num(*u)?;
+            }
+            Created(u) => {
+                res.write_str("tcreated:")?;
+                res.write_num(*u)?;
+            }
+            Size(u) => {
+                res.write_str("tsize:")?;
+                res.write_num(*u)?;
+            }
+            Free(u) => {
+                res.write_str("tfree:")?;
+                res.write_num(*u)?;
+            }
+            Circular(u) => {
+                res.write_str("circular:")?;
+                res.write_num(if *u { 1 } else { 0 })?;
+            }
+            Disconn(dis) => match dis {
+                true => res.write_str("disconn:1")?,
+                false => res.write_str("disconn:0")?,
+            },
+            Other(body) => res.write_str(body.as_ref())?,
+        };
+
+        Ok(())
+    }
+}
+
+impl<'a, U: crate::internal::BeBytes> From<FrameRequest<&'a mut [u8]>> for Option<FrameRequest<U>> {
+    fn from(s: FrameRequest<&'a mut [u8]>) -> Self {
+        Some(match s {
+            FrameRequest::Select(u) => FrameRequest::Select(u),
+            FrameRequest::AtPC(u) => FrameRequest::AtPC(U::from_be_bytes(u)?),
+            FrameRequest::Hit(tp) => FrameRequest::Hit(tp),
+            FrameRequest::Between(s, e) => {
+                FrameRequest::Between(U::from_be_bytes(s)?, U::from_be_bytes(e)?)
+            }
+            FrameRequest::Outside(s, e) => {
+                FrameRequest::Outside(U::from_be_bytes(s)?, U::from_be_bytes(e)?)
+            }
+        })
     }
 }
 
@@ -156,9 +431,13 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Tracepoints::qTStatus(_) => {
                 let status = ops.trace_experiment_status().handle_error()?;
                 status.write(res)?;
-                let mut err = None;
+                let mut err: Option<Error<T::Error, C::Error>> = None;
                 ops.trace_experiment_info(&mut |explanation: ExperimentExplanation<'_>| {
-                    if let Err(e) = res.write_str(";").and_then(|()| explanation.write(res)) {
+                    if let Err(e) = res
+                        .write_str(";")
+                        .map_err(|e| e.into())
+                        .and_then(|()| explanation.write::<T, C>(res))
+                    {
                         err = Some(e)
                     }
                 })
@@ -269,11 +548,11 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             // which means we can't really setup the state machine ourselves or
             // turn it into a nicer API.
             Tracepoints::qTfP(_) => {
-                let mut err = None;
+                let mut err: Option<Error<T::Error, C::Error>> = None;
                 ops.tracepoint_enumerate_start(&mut |tp| {
                     let e = match tp {
-                        TracepointItem::New(ctp) => ctp.write(res),
-                        TracepointItem::Define(dtp) => dtp.write(res),
+                        TracepointItem::New(ctp) => ctp.write::<T, C>(res),
+                        TracepointItem::Define(dtp) => dtp.write::<T, C>(res),
                     };
                     if let Err(e) = e {
                         err = Some(e)
@@ -285,11 +564,11 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 }
             }
             Tracepoints::qTsP(_) => {
-                let mut err = None;
+                let mut err: Option<Error<T::Error, C::Error>> = None;
                 ops.tracepoint_enumerate_step(&mut |tp| {
                     let e = match tp {
-                        TracepointItem::New(ctp) => ctp.write(res),
-                        TracepointItem::Define(dtp) => dtp.write(res),
+                        TracepointItem::New(ctp) => ctp.write::<T, C>(res),
+                        TracepointItem::Define(dtp) => dtp.write::<T, C>(res),
                     };
                     if let Err(e) = e {
                         err = Some(e)

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -40,7 +40,9 @@ impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
         Some(Self {
             number: dtdp.number,
             addr: arch_int(dtdp.addr).ok()?,
-            actions: TracepointActionList::Raw { data: ManagedSlice::Borrowed(dtdp.actions) },
+            actions: TracepointActionList::Raw {
+                data: ManagedSlice::Borrowed(dtdp.actions),
+            },
         })
     }
 
@@ -99,7 +101,9 @@ impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
                         unparsed = None;
                         decode_hex_buf(mask).ok()?
                     };
-                    (f)(&TracepointAction::Registers { mask: ManagedSlice::Borrowed(mask) });
+                    (f)(&TracepointAction::Registers {
+                        mask: ManagedSlice::Borrowed(mask),
+                    });
                 }
                 Some([b'M', _mem_args @ ..]) => {
                     // Unimplemented: even simple actions like `collect *(int*)0x0`
@@ -112,7 +116,9 @@ impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
                     let len: usize = decode_hex(len_bytes).ok()?;
                     let (expr_bytes, next_bytes) = rem.split_at_mut(len * 2);
                     let expr = decode_hex_buf(expr_bytes).ok()?;
-                    (f)(&TracepointAction::Expression { expr: ManagedSlice::Borrowed(expr) });
+                    (f)(&TracepointAction::Expression {
+                        expr: ManagedSlice::Borrowed(expr),
+                    });
                     unparsed = Some(next_bytes);
                 }
                 Some([b'-']) => {

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -342,7 +342,7 @@ impl<'a> ExperimentExplanation<'a> {
                 res.write_str("circular:")?;
                 res.write_num(if *u { 1 } else { 0 })?;
             }
-            Disconn(dis) => match dis {
+            DisconnectedTracing(dis) => match dis {
                 true => res.write_str("disconn:1")?,
                 false => res.write_str("disconn:0")?,
             },

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -1,0 +1,297 @@
+use super::prelude::*;
+use crate::arch::Arch;
+use crate::internal::BeBytes;
+use crate::protocol::commands::_QTBuffer::QTBuffer;
+use crate::protocol::commands::ext::Tracepoints;
+use crate::protocol::commands::prelude::decode_hex;
+use crate::protocol::commands::prelude::decode_hex_buf;
+use crate::protocol::commands::_QTDP::CreateTDP;
+use crate::protocol::commands::_QTDP::DefineTDP;
+use crate::protocol::commands::_QTDP::QTDP;
+use crate::target::ext::tracepoints::DefineTracepoint;
+use crate::target::ext::tracepoints::FrameDescription;
+use crate::target::ext::tracepoints::FrameRequest;
+use crate::target::ext::tracepoints::NewTracepoint;
+use crate::target::ext::tracepoints::TracepointAction;
+use crate::target::ext::tracepoints::TracepointActionList;
+use crate::target::ext::tracepoints::TracepointItem;
+
+impl<U: BeBytes> NewTracepoint<U> {
+    /// Parse from a raw CreateTDP packet.
+    pub fn from_tdp(ctdp: CreateTDP<'_>) -> Option<Self> {
+        let arch_int = |b: &[u8]| -> Result<U, ()> { U::from_be_bytes(b).ok_or(()) };
+        Some(Self {
+            number: ctdp.number,
+            addr: arch_int(ctdp.addr).ok()?,
+            enabled: ctdp.enable,
+            pass_count: ctdp.pass,
+            step_count: ctdp.step,
+            more: ctdp.more,
+        })
+    }
+}
+
+impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
+    /// Parse from a raw DefineTDP packet.
+    pub fn from_tdp(dtdp: DefineTDP<'a>) -> Option<Self> {
+        let arch_int = |b: &[u8]| -> Result<U, ()> { U::from_be_bytes(b).ok_or(()) };
+
+        Some(Self {
+            number: dtdp.number,
+            addr: arch_int(dtdp.addr).ok()?,
+            actions: TracepointActionList::Raw { data: dtdp.actions },
+        })
+    }
+
+    /// Parse the actions that should be added to the definition of this
+    /// tracepoint, calling `f` on each action.
+    ///
+    /// Returns None if parsing of actions failed, or hit unsupported actions.
+    /// Return `Some(more)` on success, where `more` is a bool indicating if
+    /// there will be additional "tracepoint define" packets for this
+    /// tracepoint.
+    pub fn actions(self, mut f: impl FnMut(&TracepointAction<'_, U>)) -> Option<bool> {
+        match self.actions {
+            TracepointActionList::Raw { data } => Self::parse_raw_actions(data, f),
+            TracepointActionList::Parsed { mut actions, more } => {
+                for action in actions.iter_mut() {
+                    (f)(action);
+                }
+                Some(more)
+            }
+        }
+    }
+
+    fn parse_raw_actions(
+        actions: &mut [u8],
+        mut f: impl FnMut(&TracepointAction<'_, U>),
+    ) -> Option<bool> {
+        let mut more = false;
+        let mut unparsed: Option<&mut [u8]> = Some(actions);
+        loop {
+            match unparsed {
+                Some([b'S', ..]) => {
+                    // TODO: how can gdbstub even implement this? it changes how
+                    // future packets should be interpreted, but as a trait we
+                    // can't keep a flag around for that (unless we specifically
+                    // have a `mark_while_stepping` callback for the target to
+                    // keep track future tracepoint_defines should be treated different).
+                    // If we go that route we also would need to return two vectors
+                    // here, "normal" actions and "while stepping" actions...but
+                    // "normals" actions may still be "while stepping" actions,
+                    // just continued from the previous packet, which we forgot
+                    // about!
+                    return None;
+                }
+                Some([b'R', mask @ ..]) => {
+                    let mask_end = mask
+                        .iter()
+                        .cloned()
+                        .enumerate()
+                        .find(|(_i, b)| matches!(b, b'S' | b'R' | b'M' | b'X' | b'-'));
+                    // We may or may not have another action after our mask
+                    let mask = if let Some(mask_end) = mask_end {
+                        let (mask_bytes, next) = mask.split_at_mut(mask_end.0);
+                        unparsed = Some(next);
+                        decode_hex_buf(mask_bytes).ok()?
+                    } else {
+                        unparsed = None;
+                        decode_hex_buf(mask).ok()?
+                    };
+                    (f)(&TracepointAction::Registers { mask });
+                }
+                Some([b'M', _mem_args @ ..]) => {
+                    // Unimplemented: even simple actions like `collect *(int*)0x0`
+                    // are actually assembled as `X` bytecode actions
+                    return None;
+                }
+                Some([b'X', eval_args @ ..]) => {
+                    let mut len_end = eval_args.splitn_mut(2, |b| *b == b',');
+                    let (len_bytes, rem) = (len_end.next()?, len_end.next()?);
+                    let len: usize = decode_hex(len_bytes).ok()?;
+                    let (expr_bytes, next_bytes) = rem.split_at_mut(len * 2);
+                    let expr = decode_hex_buf(expr_bytes).ok()?;
+                    (f)(&TracepointAction::Expression { expr });
+                    unparsed = Some(next_bytes);
+                }
+                Some([b'-']) => {
+                    more = true;
+                    break;
+                }
+                Some([]) | None => {
+                    break;
+                }
+                _ => return None,
+            }
+        }
+
+        Some(more)
+    }
+}
+
+impl<T: Target, C: Connection> GdbStubImpl<T, C> {
+    pub(crate) fn handle_tracepoints(
+        &mut self,
+        res: &mut ResponseWriter<'_, C>,
+        target: &mut T,
+        command: Tracepoints<'_>,
+    ) -> Result<HandlerStatus, Error<T::Error, C::Error>> {
+        let ops = match target.support_tracepoints() {
+            Some(ops) => ops,
+            None => return Ok(HandlerStatus::Handled),
+        };
+
+        crate::__dead_code_marker!("tracepoints", "impl");
+
+        match command {
+            Tracepoints::QTinit(_) => {
+                ops.tracepoints_init().handle_error()?;
+                // GDB documentation doesn't say it, but this requires "OK" in order
+                // to signify we support tracepoints.
+                return Ok(HandlerStatus::NeedsOk);
+            }
+            Tracepoints::qTStatus(_) => {
+                let status = ops.trace_experiment_status().handle_error()?;
+                res.write_str("T")?;
+                res.write_dec(if status.running { 1 } else { 0 })?;
+                for explanation in status.explanations.iter() {
+                    res.write_str(";")?;
+                    explanation.write(res)?;
+                }
+            }
+            Tracepoints::qTP(qtp) => {
+                let addr = <T::Arch as Arch>::Usize::from_be_bytes(qtp.addr)
+                    .ok_or(Error::TargetMismatch)?;
+                let (hits, usage) = ops.tracepoint_status(qtp.tracepoint, addr).handle_error()?;
+                res.write_str("V")?;
+                res.write_num(hits)?;
+                res.write_str(":")?;
+                res.write_num(usage)?;
+            }
+            Tracepoints::QTDP(q) => {
+                match q {
+                    QTDP::Create(ctdp) => {
+                        let new_tracepoint =
+                            NewTracepoint::<<T::Arch as Arch>::Usize>::from_tdp(ctdp)
+                                .ok_or(Error::TargetMismatch)?;
+                        ops.tracepoint_create(new_tracepoint).handle_error()?
+                    }
+                    QTDP::Define(dtdp) => {
+                        let define_tracepoint =
+                            DefineTracepoint::<<T::Arch as Arch>::Usize>::from_tdp(dtdp)
+                                .ok_or(Error::TargetMismatch)?;
+                        ops.tracepoint_define(define_tracepoint).handle_error()?
+                    }
+                };
+                // TODO: support qRelocInsn?
+                return Ok(HandlerStatus::NeedsOk);
+            }
+            Tracepoints::QTBuffer(buf) => {
+                match buf {
+                    QTBuffer::Request {
+                        offset,
+                        length,
+                        data,
+                    } => {
+                        let read = ops
+                            .trace_buffer_request(offset, length, data)
+                            .handle_error()?;
+                        if let Some(read) = read {
+                            let read = read.min(data.len());
+                            res.write_hex_buf(&data[..read])?;
+                        } else {
+                            res.write_str("l")?;
+                        }
+                    }
+                    QTBuffer::Configure { buffer } => {
+                        ops.trace_buffer_configure(buffer).handle_error()?;
+                    }
+                }
+                // Documentation doesn't mention this, but it needs OK
+                return Ok(HandlerStatus::NeedsOk);
+            }
+            Tracepoints::QTStart(_) => {
+                ops.trace_experiment_start().handle_error()?;
+                // Documentation doesn't mention this, but it needs OK
+                // TODO: qRelocInsn reply support?
+                return Ok(HandlerStatus::NeedsOk);
+            }
+            Tracepoints::QTStop(_) => {
+                ops.trace_experiment_stop().handle_error()?;
+                // Documentation doesn't mention this, but it needs OK
+                return Ok(HandlerStatus::NeedsOk);
+            }
+            Tracepoints::QTFrame(req) => {
+                let parsed_qtframe: Option<FrameRequest<<T::Arch as Arch>::Usize>> = req.0.into();
+                let parsed_req = parsed_qtframe.ok_or(Error::TargetMismatch)?;
+                let mut err: Result<_, Error<T::Error, C::Error>> = Ok(());
+                let mut any_results = false;
+                ops.select_frame(parsed_req, &mut |desc| {
+                    // TODO: bubble up the C::Error from this closure? list_thread_active does this
+                    // instead
+                    let e = (|| -> Result<_, _> {
+                        match desc {
+                            FrameDescription::FrameNumber(n) => {
+                                res.write_str("F ")?;
+                                if let Some(n) = n {
+                                    res.write_num(n)?;
+                                } else {
+                                    res.write_str("-1")?;
+                                }
+                            }
+                            FrameDescription::Hit(tdp) => {
+                                res.write_str("T ")?;
+                                res.write_num(tdp.0)?;
+                            }
+                        }
+                        any_results = true;
+                        Ok(())
+                    })();
+                    if let Err(e) = e {
+                        err = Err(e)
+                    }
+                })
+                .handle_error()?;
+                if !any_results {
+                    res.write_str("F -1")?;
+                }
+            }
+            // The GDB protocol for this is very weird: it sends this first packet
+            // to initialize a state machine on our stub, and then sends the subsequent
+            // packets N times in order to drive the state machine to the end in
+            // order to ask for all our tracepoints and their actions. gdbstub
+            // is agnostic about the end-user state and shouldn't allocate, however,
+            // which means we can't really setup the state machine ourselves or
+            // turn it into a nicer API.
+            Tracepoints::qTfP(_) => {
+                let tp = ops.tracepoint_enumerate_start().handle_error()?;
+                if let Some(tp) = tp {
+                    match tp {
+                        TracepointItem::New(ctp) => ctp.write(res)?,
+                        TracepointItem::Define(dtp) => dtp.write(res)?,
+                    }
+                }
+            }
+            Tracepoints::qTsP(_) => {
+                let tp = ops.tracepoint_enumerate_step().handle_error()?;
+                if let Some(tp) = tp {
+                    match tp {
+                        TracepointItem::New(ctp) => ctp.write(res)?,
+                        TracepointItem::Define(dtp) => dtp.write(res)?,
+                    }
+                }
+            }
+
+            // Likewise, the same type of driven state machine is used for trace
+            // state variables
+            Tracepoints::qTfV(_) => {
+                // TODO: State variables
+            }
+            Tracepoints::qTsV(_) => {
+                // TODO: State variables
+            }
+        };
+
+        Ok(HandlerStatus::Handled)
+    }
+}

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -1,6 +1,7 @@
 use super::prelude::*;
 use crate::arch::Arch;
 use crate::internal::BeBytes;
+use crate::protocol::commands::_QTDPsrc::QTDPsrc;
 use crate::protocol::commands::_qTBuffer::qTBuffer;
 use crate::protocol::commands::ext::Tracepoints;
 use crate::protocol::commands::prelude::decode_hex;
@@ -16,9 +17,14 @@ use crate::target::ext::tracepoints::ExperimentStatus;
 use crate::target::ext::tracepoints::FrameDescription;
 use crate::target::ext::tracepoints::FrameRequest;
 use crate::target::ext::tracepoints::NewTracepoint;
+use crate::target::ext::tracepoints::SourceTracepoint;
 use crate::target::ext::tracepoints::TracepointAction;
 use crate::target::ext::tracepoints::TracepointActionList;
+use crate::target::ext::tracepoints::TracepointEnumerateCursor;
+use crate::target::ext::tracepoints::TracepointEnumerateState;
+use crate::target::ext::tracepoints::TracepointEnumerateStep;
 use crate::target::ext::tracepoints::TracepointItem;
+use crate::target::ext::tracepoints::TracepointSourceType;
 use crate::target::ext::tracepoints::TracepointStatus;
 use managed::ManagedSlice;
 use num_traits::PrimInt;
@@ -38,11 +44,12 @@ impl<U: BeBytes> NewTracepoint<U> {
 }
 
 impl<U: crate::internal::BeBytes + num_traits::Zero + PrimInt> NewTracepoint<U> {
+    /// Write this as a qTfP/qTsP response
     pub(crate) fn write<T: Target, C: Connection>(
         &self,
         res: &mut ResponseWriter<'_, C>,
     ) -> Result<(), Error<T::Error, C::Error>> {
-        res.write_str("QTDP:")?;
+        res.write_str("T")?;
         res.write_num(self.number.0)?;
         res.write_str(":")?;
         res.write_num(self.addr)?;
@@ -180,6 +187,66 @@ impl<'a, U: Copy> DefineTracepoint<'a, U> {
     }
 }
 
+impl<'a, U: BeBytes> SourceTracepoint<'a, U> {
+    /// Parse from a raw CreateTDP packet.
+    fn from_src(src: QTDPsrc<'a>) -> Option<Self> {
+        Some(Self {
+            number: src.number,
+            addr: U::from_be_bytes(src.addr)?,
+            r#type: src.r#type,
+            start: src.start,
+            slen: src.slen,
+            bytes: ManagedSlice::Borrowed(src.bytes),
+        })
+    }
+}
+impl<U: crate::internal::BeBytes + num_traits::Zero + PrimInt> SourceTracepoint<'_, U> {
+    /// Write this as a qTfP/qTsP response
+    pub(crate) fn write<T: Target, C: Connection>(
+        &self,
+        res: &mut ResponseWriter<'_, C>,
+    ) -> Result<(), Error<T::Error, C::Error>> {
+        res.write_str("Z")?;
+        res.write_num(self.number.0)?;
+        res.write_str(":")?;
+        res.write_num(self.addr)?;
+        res.write_str(":")?;
+        res.write_str(match self.r#type {
+            TracepointSourceType::At => "at",
+            TracepointSourceType::Cond => "cond",
+            TracepointSourceType::Cmd => "cmd",
+        })?;
+        res.write_str(":")?;
+        // We use the start and slen from the SourceTracepoint instead of
+        // start=0 slen=bytes.len() because, although we can assume GDB to be able
+        // to handle arbitrary sized packets, the target implementation might still
+        // be giving us chunked source (such as if it's parroting the chunked source
+        // that GDB initially gave us).
+        res.write_num(self.start)?;
+        res.write_str(":")?;
+        res.write_num(self.slen)?;
+        res.write_str(":")?;
+        res.write_hex_buf(self.bytes.as_ref())?;
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, U: Copy> SourceTracepoint<'a, U> {
+    /// Allocate an owned copy of this structure.
+    pub fn get_owned<'b>(&self) -> SourceTracepoint<'b, U> {
+        SourceTracepoint {
+            number: self.number,
+            addr: self.addr,
+            r#type: self.r#type,
+            start: self.start,
+            slen: self.slen,
+            bytes: ManagedSlice::Owned(self.bytes.to_owned()),
+        }
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl<'a, U: Copy> TracepointAction<'a, U> {
     /// Allocate an owned copy of this structure.
@@ -236,11 +303,12 @@ impl<'a, U: Copy> TracepointItem<'a, U> {
 }
 
 impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> DefineTracepoint<'a, U> {
+    /// Write this as a qTfP/qTsP response
     pub(crate) fn write<T: Target, C: Connection>(
         self,
         res: &mut ResponseWriter<'_, C>,
     ) -> Result<(), Error<T::Error, C::Error>> {
-        res.write_str("QTDP:-")?;
+        res.write_str("A")?;
         res.write_num(self.number.0)?;
         res.write_str(":")?;
         res.write_num(self.addr)?;
@@ -255,7 +323,11 @@ impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> DefineTracepo
             return Err(e.into());
         }
         match more {
-            Ok(true) => Ok(res.write_str("-")?),
+            Ok(true) =>
+            /* Ok(res.write_str("-")?) */
+            {
+                Ok(())
+            }
             Ok(false) => Ok(()),
             e => e.map(|_| ()).map_err(|e| Error::PacketParse(e)),
         }
@@ -263,6 +335,7 @@ impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> DefineTracepo
 }
 
 impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> TracepointAction<'a, U> {
+    /// Write this as a qTfP/qTsP response
     pub(crate) fn write<T: Target, C: Connection>(
         &self,
         res: &mut ResponseWriter<'_, C>,
@@ -469,6 +542,13 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 // TODO: support qRelocInsn?
                 return Ok(HandlerStatus::NeedsOk);
             }
+            Tracepoints::QTDPsrc(src) => {
+                let source = SourceTracepoint::<<T::Arch as Arch>::Usize>::from_src(src)
+                    .ok_or(Error::TargetMismatch)?;
+                ops.tracepoint_attach_source(source).handle_error()?;
+                // Documentation doesn't mention this, but it needs OK
+                return Ok(HandlerStatus::NeedsOk);
+            }
             Tracepoints::qTBuffer(buf) => {
                 let qTBuffer {
                     offset,
@@ -544,35 +624,86 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             // which means we can't really setup the state machine ourselves or
             // turn it into a nicer API.
             Tracepoints::qTfP(_) => {
+                // Reset our state machine
+                let state = ops.tracepoint_enumerate_state();
+                state.cursor = None;
+
                 let mut err: Option<Error<T::Error, C::Error>> = None;
-                ops.tracepoint_enumerate_start(&mut |tp| {
-                    let e = match tp {
-                        TracepointItem::New(ctp) => ctp.write::<T, C>(res),
-                        TracepointItem::Define(dtp) => dtp.write::<T, C>(res),
-                    };
-                    if let Err(e) = e {
-                        err = Some(e)
-                    }
-                })
-                .handle_error()?;
+                let mut started = None;
+                let step = ops
+                    .tracepoint_enumerate_start(None, &mut |ctp| {
+                        // We need to know what tracepoint to begin stepping, since the
+                        // target will just tell us there's TracepointEnumerateStep::More
+                        // otherwise.
+                        started = Some(ctp.number);
+                        let e = ctp.write::<T, C>(res);
+                        if let Err(e) = e {
+                            err = Some(e)
+                        }
+                    })
+                    .handle_error()?;
                 if let Some(e) = err {
                     return Err(e.into());
                 }
+                if let Some(started) = started {
+                    ops.tracepoint_enumerate_state().cursor =
+                        Some(TracepointEnumerateCursor::New(started));
+                }
+                self.handle_tracepoint_state_machine_step(res, target, step)?;
             }
             Tracepoints::qTsP(_) => {
+                let state = ops.tracepoint_enumerate_state();
                 let mut err: Option<Error<T::Error, C::Error>> = None;
-                ops.tracepoint_enumerate_step(&mut |tp| {
-                    let e = match tp {
-                        TracepointItem::New(ctp) => ctp.write::<T, C>(res),
-                        TracepointItem::Define(dtp) => dtp.write::<T, C>(res),
-                    };
-                    if let Err(e) = e {
-                        err = Some(e)
+                let step = match state.cursor {
+                    None => {
+                        // If we don't have a current_tracepoint, than the last
+                        // packet responded
+                        // with a TracepointEnumerateStep::Done. We don't have
+                        // anything else to report.
+                        None
                     }
-                })
-                .handle_error()?;
+                    Some(TracepointEnumerateCursor::New(tp)) => {
+                        // If we don't have any progress, the last packet was
+                        // a Next(tp) and we need to start reporting a new tracepoint
+                        Some(
+                            ops.tracepoint_enumerate_start(Some(tp), &mut |ctp| {
+                                let e = ctp.write::<T, C>(res);
+                                if let Err(e) = e {
+                                    err = Some(e)
+                                }
+                            })
+                            .handle_error()?,
+                        )
+                    }
+                    Some(TracepointEnumerateCursor::Action(tp, progress)) => {
+                        // Otherwise we should be continuing the advance the current tracepoint.
+                        Some(
+                            ops.tracepoint_enumerate_action(tp, progress, &mut |dtp| {
+                                let e = dtp.write::<T, C>(res);
+                                if let Err(e) = e {
+                                    err = Some(e)
+                                }
+                            })
+                            .handle_error()?,
+                        )
+                    }
+                    // TODO: figure out how to gate this behind a supports method?
+                    Some(TracepointEnumerateCursor::Source(tp, progress)) => Some(
+                        ops.tracepoint_enumerate_source(tp, progress, &mut |src| {
+                            let e = src.write::<T, C>(res);
+                            if let Err(e) = e {
+                                err = Some(e)
+                            }
+                        })
+                        .handle_error()?,
+                    ),
+                };
+
                 if let Some(e) = err {
                     return Err(e.into());
+                }
+                if let Some(step) = step {
+                    self.handle_tracepoint_state_machine_step(res, target, step)?;
                 }
             }
 
@@ -587,5 +718,52 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
         };
 
         Ok(HandlerStatus::Handled)
+    }
+
+    fn handle_tracepoint_state_machine_step(
+        &mut self,
+        res: &mut ResponseWriter<'_, C>,
+        target: &mut T,
+        step: TracepointEnumerateStep,
+    ) -> Result<(), Error<T::Error, C::Error>> {
+        let ops = match target.support_tracepoints() {
+            Some(ops) => ops,
+            None => return Ok(()),
+        };
+        let state = ops.tracepoint_enumerate_state();
+        let next = match (&state.cursor, step) {
+            (None, _) => None,
+            (Some(_), TracepointEnumerateStep::Done) => None,
+
+            // Transition to enumerating actions
+            (Some(TracepointEnumerateCursor::New(tp)), TracepointEnumerateStep::Action) => {
+                Some(TracepointEnumerateCursor::Action(*tp, 0))
+            }
+            (Some(TracepointEnumerateCursor::Source(tp, _)), TracepointEnumerateStep::Action) => {
+                Some(TracepointEnumerateCursor::Action(*tp, 0))
+            }
+            (
+                Some(TracepointEnumerateCursor::Action(tp, step)),
+                TracepointEnumerateStep::Action,
+            ) => Some(TracepointEnumerateCursor::Action(*tp, step + 1)),
+
+            // Transition to enumerating sources
+            (
+                Some(TracepointEnumerateCursor::New(tp) | TracepointEnumerateCursor::Action(tp, _)),
+                TracepointEnumerateStep::Source,
+            ) => Some(TracepointEnumerateCursor::Source(*tp, 0)),
+            (
+                Some(TracepointEnumerateCursor::Source(tp, step)),
+                TracepointEnumerateStep::Source,
+            ) => Some(TracepointEnumerateCursor::Source(*tp, step + 1)),
+
+            // Transition to the next tracepoint
+            (Some(_), TracepointEnumerateStep::Next(next)) => {
+                Some(TracepointEnumerateCursor::New(next))
+            }
+        };
+        state.cursor = next;
+
+        Ok(())
     }
 }

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -25,7 +25,7 @@ use num_traits::PrimInt;
 
 impl<U: BeBytes> NewTracepoint<U> {
     /// Parse from a raw CreateTDP packet.
-    pub fn from_tdp(ctdp: CreateTDP<'_>) -> Option<Self> {
+    fn from_tdp(ctdp: CreateTDP<'_>) -> Option<Self> {
         Some(Self {
             number: ctdp.number,
             addr: U::from_be_bytes(ctdp.addr)?,
@@ -67,7 +67,7 @@ impl<U: crate::internal::BeBytes + num_traits::Zero + PrimInt> NewTracepoint<U> 
 
 impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
     /// Parse from a raw DefineTDP packet.
-    pub fn from_tdp(dtdp: DefineTDP<'a>) -> Option<Self> {
+    fn from_tdp(dtdp: DefineTDP<'a>) -> Option<Self> {
         Some(Self {
             number: dtdp.number,
             addr: U::from_be_bytes(dtdp.addr)?,

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -79,8 +79,8 @@ impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
     /// Parse the actions that should be added to the definition of this
     /// tracepoint, calling `f` on each action.
     ///
-    /// Returns None if parsing of actions failed, or hit unsupported actions.
-    /// Return `Some(more)` on success, where `more` is a bool indicating if
+    /// Returns `Err` if parsing of actions failed, or hit unsupported actions.
+    /// Return `Ok(more)` on success, where `more` is a bool indicating if
     /// there will be additional "tracepoint define" packets for this
     /// tracepoint.
     pub fn actions(

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -444,6 +444,11 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             Tracepoints::QTDP(q) => {
                 match q {
                     QTDP::Create(ctdp) => {
+                        if ctdp.unsupported_options {
+                            // We have some options we don't know how to process, so bail out.
+                            return Err(Error::TracepointFeatureUnimplemented);
+                        }
+
                         let new_tracepoint =
                             NewTracepoint::<<T::Arch as Arch>::Usize>::from_tdp(ctdp)
                                 .ok_or(Error::TargetMismatch)?;

--- a/src/stub/core_impl/tracepoints.rs
+++ b/src/stub/core_impl/tracepoints.rs
@@ -89,7 +89,6 @@ impl<'a, U: BeBytes> DefineTracepoint<'a, U> {
                 Some([b'R', mask @ ..]) => {
                     let mask_end = mask
                         .iter()
-                        .cloned()
                         .enumerate()
                         .find(|(_i, b)| matches!(b, b'S' | b'R' | b'M' | b'X' | b'-'));
                     // We may or may not have another action after our mask

--- a/src/stub/error.rs
+++ b/src/stub/error.rs
@@ -41,7 +41,7 @@ pub(crate) enum InternalError<T, C> {
     // I'll find the time to cut a breaking release of gdbstub, I'd prefer to
     // push out this feature as a non-breaking change now.
     MissingCurrentActivePidImpl,
-    TracepointFeatureUnimplemented,
+    TracepointFeatureUnimplemented(u8),
 
     // Internal - A non-fatal error occurred (with errno-style error code)
     //
@@ -144,7 +144,7 @@ where
 
             ImplicitSwBreakpoints => write!(f, "Warning: The target has not opted into using implicit software breakpoints. See `Target::guard_rail_implicit_sw_breakpoints` for more information"),
             MissingCurrentActivePidImpl => write!(f, "GDB client attempted to attach to a new process, but the target has not implemented support for `ExtendedMode::support_current_active_pid`"),
-            TracepointFeatureUnimplemented => write!(f, "GDB client sent us a tracepoint packet, but `gdbstub` doesn't implement some of the features used."),
+            TracepointFeatureUnimplemented(feat) => write!(f, "GDB client sent us a tracepoint packet using feature {}, but `gdbstub` doesn't implement it. If this is something you require, please file an issue at https://github.com/daniel5151/gdbstub/issues", *feat as char),
 
             NonFatalError(_) => write!(f, "Internal non-fatal error. You should never see this! Please file an issue if you do!"),
         }

--- a/src/stub/error.rs
+++ b/src/stub/error.rs
@@ -41,6 +41,7 @@ pub(crate) enum InternalError<T, C> {
     // I'll find the time to cut a breaking release of gdbstub, I'd prefer to
     // push out this feature as a non-breaking change now.
     MissingCurrentActivePidImpl,
+    TracepointFeatureUnimplemented,
 
     // Internal - A non-fatal error occurred (with errno-style error code)
     //
@@ -143,6 +144,7 @@ where
 
             ImplicitSwBreakpoints => write!(f, "Warning: The target has not opted into using implicit software breakpoints. See `Target::guard_rail_implicit_sw_breakpoints` for more information"),
             MissingCurrentActivePidImpl => write!(f, "GDB client attempted to attach to a new process, but the target has not implemented support for `ExtendedMode::support_current_active_pid`"),
+            TracepointFeatureUnimplemented => write!(f, "GDB client sent us a tracepoint packet, but `gdbstub` doesn't implement some of the features used."),
 
             NonFatalError(_) => write!(f, "Internal non-fatal error. You should never see this! Please file an issue if you do!"),
         }

--- a/src/stub/error.rs
+++ b/src/stub/error.rs
@@ -42,6 +42,7 @@ pub(crate) enum InternalError<T, C> {
     // push out this feature as a non-breaking change now.
     MissingCurrentActivePidImpl,
     TracepointFeatureUnimplemented(u8),
+    TracepointUnsupportedSourceEnumeration,
 
     // Internal - A non-fatal error occurred (with errno-style error code)
     //
@@ -145,6 +146,7 @@ where
             ImplicitSwBreakpoints => write!(f, "Warning: The target has not opted into using implicit software breakpoints. See `Target::guard_rail_implicit_sw_breakpoints` for more information"),
             MissingCurrentActivePidImpl => write!(f, "GDB client attempted to attach to a new process, but the target has not implemented support for `ExtendedMode::support_current_active_pid`"),
             TracepointFeatureUnimplemented(feat) => write!(f, "GDB client sent us a tracepoint packet using feature {}, but `gdbstub` doesn't implement it. If this is something you require, please file an issue at https://github.com/daniel5151/gdbstub/issues", *feat as char),
+            TracepointUnsupportedSourceEnumeration => write!(f, "The target doesn't support the gdbstub TracepointSource extension, but attempted to transition to enumerating tracepoint sources"),
 
             NonFatalError(_) => write!(f, "Internal non-fatal error. You should never see this! Please file an issue if you do!"),
         }

--- a/src/target/ext/mod.rs
+++ b/src/target/ext/mod.rs
@@ -272,3 +272,4 @@ pub mod monitor_cmd;
 pub mod section_offsets;
 pub mod target_description_xml_override;
 pub mod thread_extra_info;
+pub mod tracepoints;

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -237,7 +237,7 @@ pub trait Tracepoints: Target {
     ) -> TargetResult<(), Self>;
     /// Request the status of tracepoint `tp` at address `addr`.
     ///
-    /// Returns `(number of tracepoint hits, number of bytes used for frames)`.
+    /// Returns a [TracepointStatus] with the requested information.
     fn tracepoint_status(
         &self,
         tp: Tracepoint,

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -73,6 +73,7 @@ pub enum TracepointActionList<'a, U> {
     },
     /// A slice of parsed actions, such as what may be returned by a target when
     /// enumerating tracepoints.
+    #[cfg(feature = "alloc")]
     Parsed {
         /// The parsed actions.
         actions: ManagedSlice<'a, TracepointAction<'a, U>>,

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -38,17 +38,18 @@ pub struct NewTracepoint<U> {
 pub enum TracepointAction<'a, U> {
     /// Collect registers.
     Registers {
-        /// A bitmask of which registers should be collected. The least significant
-        /// bit is numberered zero. Note that the mask may be larger than the word length.
-        mask: ManagedSlice<'a, u8>
+        /// A bitmask of which registers should be collected. The least
+        /// significant bit is numberered zero. Note that the mask may
+        /// be larger than the word length.
+        mask: ManagedSlice<'a, u8>,
     },
-    /// Collect memory.`len` bytes of memory starting at the address in register number
-    /// `basereg`, plus `offset`. If `basereg` is None, then treat it as a fixed
-    /// address.
+    /// Collect memory.`len` bytes of memory starting at the address in register
+    /// number `basereg`, plus `offset`. If `basereg` is None, then treat it
+    /// as a fixed address.
     Memory {
-        /// If `Some`, then calculate the address of memory to collect relative to
-        /// the value of this register number. If `None` then memory should be
-        /// collected from a fixed address.
+        /// If `Some`, then calculate the address of memory to collect relative
+        /// to the value of this register number. If `None` then memory
+        /// should be collected from a fixed address.
         basereg: Option<u64>,
         /// The offset used to calculate the address to collect memory from.
         offset: U,
@@ -58,7 +59,7 @@ pub enum TracepointAction<'a, U> {
     /// Collect data according to an agent bytecode program.
     Expression {
         /// The GDB agent bytecode program to evaluate.
-        expr: ManagedSlice<'a, u8>
+        expr: ManagedSlice<'a, u8>,
     },
 }
 
@@ -68,7 +69,7 @@ pub enum TracepointActionList<'a, U> {
     /// Raw and unparsed actions, such as from GDB.
     Raw {
         /// The unparsed action data.
-        data: ManagedSlice<'a, u8>
+        data: ManagedSlice<'a, u8>,
     },
     /// A slice of parsed actions, such as what may be returned by a target when
     /// enumerating tracepoints.
@@ -210,6 +211,15 @@ pub enum FrameDescription {
     Hit(Tracepoint),
 }
 
+/// The state of a tracepoint.
+#[derive(Debug)]
+pub struct TracepointStatus {
+    /// The number of times a tracepoint has been hit in a trace run.
+    pub hit_count: u64,
+    /// The number of bytes the tracepoint accounts for in the trace buffer.
+    pub bytes_used: u64,
+}
+
 /// Target Extension - Provide tracepoints.
 pub trait Tracepoints: Target {
     /// Clear any saved tracepoints and empty the trace frame buffer
@@ -232,7 +242,7 @@ pub trait Tracepoints: Target {
         &self,
         tp: Tracepoint,
         addr: <Self::Arch as Arch>::Usize,
-    ) -> TargetResult<(u64, u64), Self>;
+    ) -> TargetResult<TracepointStatus, Self>;
 
     /// Begin enumerating tracepoints. The target implementation should
     /// initialize a state machine that is stepped by

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -371,7 +371,10 @@ pub trait Tracepoints: Target {
     ) -> TargetResult<(), Self>;
 
     /// Return the status of the current trace experiment.
-    fn trace_experiment_status(&self) -> TargetResult<ExperimentStatus<'_>, Self>;
+    fn trace_experiment_status(
+        &self,
+        report: &mut dyn FnMut(ExperimentStatus<'_>),
+    ) -> TargetResult<(), Self>;
     /// List any statistical information for the current trace experiment, by
     /// calling `report` with each [ExperimentExplanation] item.
     fn trace_experiment_info(

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -43,7 +43,6 @@ impl<U: Copy> NewTracepoint<U> {
     }
 }
 
-
 impl<U: crate::internal::BeBytes + num_traits::Zero + PrimInt> NewTracepoint<U> {
     pub(crate) fn write<C: Connection>(
         &self,
@@ -96,9 +95,21 @@ impl<'a, U: Copy> TracepointAction<'a, U> {
     pub fn get_owned<'b>(&self) -> TracepointAction<'b, U> {
         use core::ops::Deref;
         match self {
-            TracepointAction::Registers { mask } => TracepointAction::Registers { mask: ManagedSlice::Owned(mask.deref().into()) },
-            TracepointAction::Memory { basereg, offset, length } => TracepointAction::Memory { basereg: *basereg, offset: *offset, length: *length },
-            TracepointAction::Expression { expr } => TracepointAction::Expression { expr: ManagedSlice::Owned(expr.deref().into()) },
+            TracepointAction::Registers { mask } => TracepointAction::Registers {
+                mask: ManagedSlice::Owned(mask.deref().into()),
+            },
+            TracepointAction::Memory {
+                basereg,
+                offset,
+                length,
+            } => TracepointAction::Memory {
+                basereg: *basereg,
+                offset: *offset,
+                length: *length,
+            },
+            TracepointAction::Expression { expr } => TracepointAction::Expression {
+                expr: ManagedSlice::Owned(expr.deref().into()),
+            },
         }
     }
 }
@@ -164,10 +175,14 @@ impl<'a, U: Copy> TracepointActionList<'a, U> {
     pub fn get_owned<'b>(&self) -> TracepointActionList<'b, U> {
         use core::ops::Deref;
         match self {
-            TracepointActionList::Raw { data } => TracepointActionList::Raw { data: ManagedSlice::Owned(data.deref().into()) },
+            TracepointActionList::Raw { data } => TracepointActionList::Raw {
+                data: ManagedSlice::Owned(data.deref().into()),
+            },
             TracepointActionList::Parsed { actions, more } => TracepointActionList::Parsed {
-                actions: ManagedSlice::Owned(actions.iter().map(|action| action.get_owned()).collect()),
-                more: *more
+                actions: ManagedSlice::Owned(
+                    actions.iter().map(|action| action.get_owned()).collect(),
+                ),
+                more: *more,
             },
         }
     }
@@ -193,7 +208,7 @@ impl<'a, U: Copy> DefineTracepoint<'a, U> {
         DefineTracepoint {
             number: self.number,
             addr: self.addr,
-            actions: self.actions.get_owned()
+            actions: self.actions.get_owned(),
         }
     }
 }
@@ -235,14 +250,14 @@ impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> DefineTracepo
 #[derive(Debug)]
 pub enum TracepointItem<'a, U> {
     /// Introduce a new tracepoint and describe its properties. This must be
-    /// emitted before any [TracepointItem::Define] items that use the same tracepoint
-    /// number, and must have the `more` flag set if it will be followed by
-    /// [TracepointItem::Define] items for this tracepoint.
+    /// emitted before any [TracepointItem::Define] items that use the same
+    /// tracepoint number, and must have the `more` flag set if it will be
+    /// followed by [TracepointItem::Define] items for this tracepoint.
     New(NewTracepoint<U>),
     /// Define additional data for a tracepoint. This must be emitted after a
-    /// [TracepointItem::New] item that introduces the tracepoint number, and must have
-    /// the `more` flag set if it will be followed by more [TracepointItem::Define] items
-    /// for this tracepoint.
+    /// [TracepointItem::New] item that introduces the tracepoint number, and
+    /// must have the `more` flag set if it will be followed by more
+    /// [TracepointItem::Define] items for this tracepoint.
     Define(DefineTracepoint<'a, U>),
 }
 
@@ -256,7 +271,6 @@ impl<'a, U: Copy> TracepointItem<'a, U> {
         }
     }
 }
-
 
 /// Description of the currently running trace experiment.
 pub struct ExperimentStatus<'a> {
@@ -460,8 +474,8 @@ pub trait Tracepoints: Target {
 
     /// Begin enumerating tracepoints. The target implementation should
     /// initialize a state machine that is stepped by
-    /// [Tracepoints::tracepoint_enumerate_step], and returns TracepointItems that
-    /// correspond with the currently configured tracepoints.
+    /// [Tracepoints::tracepoint_enumerate_step], and returns TracepointItems
+    /// that correspond with the currently configured tracepoints.
     fn tracepoint_enumerate_start(
         &mut self,
     ) -> TargetResult<Option<TracepointItem<'_, <Self::Arch as Arch>::Usize>>, Self>;

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -411,7 +411,7 @@ pub enum BufferShape {
 
 /// Configuration for the trace buffer.
 #[derive(Debug)]
-pub enum TraceBuffer {
+pub enum TraceBufferConfig {
     /// Set the buffer's shape.
     Shape(BufferShape),
     /// Set the buffer's size in bytes. If None, the target should use whatever
@@ -502,7 +502,7 @@ pub trait Tracepoints: Target {
     ) -> TargetResult<Option<TracepointItem<'_, <Self::Arch as Arch>::Usize>>, Self>;
 
     /// Reconfigure the trace buffer to include or modify an attribute.
-    fn trace_buffer_configure(&mut self, tb: TraceBuffer) -> TargetResult<(), Self>;
+    fn trace_buffer_configure(&mut self, config: TraceBufferConfig) -> TargetResult<(), Self>;
 
     /// Return up to `len` bytes from the trace buffer, starting at `offset`.
     /// The trace buffer is treated as a contiguous collection of traceframes,

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -51,11 +51,7 @@ impl<U: crate::internal::BeBytes + num_traits::Zero + PrimInt> NewTracepoint<U> 
         res.write_str("QTDP:")?;
         res.write_num(self.number.0)?;
         res.write_str(":")?;
-        let mut buf = [0; 8];
-        self.addr
-            .to_be_bytes(&mut buf)
-            .ok_or_else(|| unreachable!())?;
-        res.write_hex_buf(&buf)?;
+        res.write_num(self.addr)?;
         res.write_str(":")?;
         res.write_str(if self.enabled { "E" } else { "D" })?;
         res.write_str(":")?;
@@ -135,9 +131,7 @@ impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> TracepointAct
                     None => res.write_str("-1"),
                 }?;
                 res.write_str(",")?;
-                let mut buf = [0; 8];
-                offset.to_be_bytes(&mut buf).ok_or_else(|| unreachable!())?;
-                res.write_hex_buf(&buf)?;
+                res.write_num(*offset)?;
                 res.write_str(",")?;
                 res.write_num(*length)?;
             }
@@ -221,11 +215,7 @@ impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> DefineTracepo
         res.write_str("QTDP:-")?;
         res.write_num(self.number.0)?;
         res.write_str(":")?;
-        let mut buf = [0; 8];
-        self.addr
-            .to_be_bytes(&mut buf)
-            .ok_or_else(|| unreachable!())?;
-        res.write_hex_buf(&buf)?;
+        res.write_num(self.addr)?;
         res.write_str(":")?;
         let mut err = None;
         let more = self.actions(|action| {

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -489,17 +489,20 @@ pub trait Tracepoints: Target {
 
     /// Begin enumerating tracepoints. The target implementation should
     /// initialize a state machine that is stepped by
-    /// [Tracepoints::tracepoint_enumerate_step], and returns TracepointItems
-    /// that correspond with the currently configured tracepoints.
+    /// [Tracepoints::tracepoint_enumerate_step], and call `f` with the first
+    /// [TracepointItem] that corresponds with the currently configured
+    /// tracepoints.
     fn tracepoint_enumerate_start(
         &mut self,
-    ) -> TargetResult<Option<TracepointItem<'_, <Self::Arch as Arch>::Usize>>, Self>;
+        f: &mut dyn FnMut(TracepointItem<'_, <Self::Arch as Arch>::Usize>),
+    ) -> TargetResult<(), Self>;
     /// Step the tracepoint enumeration state machine. The target implementation
-    /// should return TracepointItems that correspond with the currently
-    /// configured tracepoints.
+    /// should call `f` with the next TracepointItem that correspond with the
+    /// currently configured tracepoints.
     fn tracepoint_enumerate_step(
         &mut self,
-    ) -> TargetResult<Option<TracepointItem<'_, <Self::Arch as Arch>::Usize>>, Self>;
+        f: &mut dyn FnMut(TracepointItem<'_, <Self::Arch as Arch>::Usize>),
+    ) -> TargetResult<(), Self>;
 
     /// Reconfigure the trace buffer to include or modify an attribute.
     fn trace_buffer_configure(&mut self, config: TraceBufferConfig) -> TargetResult<(), Self>;

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -339,7 +339,7 @@ pub trait Tracepoints: Target {
     ///
     /// For the average trait implementations, this will look like:
     ///
-    /// ```
+    /// ```rust,ignore
     /// struct MyTarget {
     ///    tracepoint_enumerate_state: TracepointEnumerateState,
     ///    ...

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -65,7 +65,7 @@ pub enum TracepointAction<'a, U> {
 
 /// A list of TracepointActions.
 #[derive(Debug)]
-pub enum TracepointActionList<'a, U> {
+pub(crate) enum TracepointActionList<'a, U> {
     /// Raw and unparsed actions, such as from GDB.
     Raw {
         /// The unparsed action data.
@@ -77,9 +77,6 @@ pub enum TracepointActionList<'a, U> {
     Parsed {
         /// The parsed actions.
         actions: ManagedSlice<'a, TracepointAction<'a, U>>,
-        /// Indicate if there will be additional "tracepoint definitions" with
-        /// more actions for this tracepoint.
-        more: bool,
     },
 }
 

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -92,7 +92,7 @@ pub struct DefineTracepoint<'a, U> {
     /// The PC address of the tracepoint that is being defined.
     pub addr: U,
     /// A list of actions that should be appended to the tracepoint.
-    pub actions: TracepointActionList<'a, U>,
+    pub(crate) actions: TracepointActionList<'a, U>,
 }
 
 /// An item from a stream of tracepoint descriptions. Enumerating tracepoints
@@ -161,7 +161,7 @@ pub enum ExperimentExplanation<'a> {
     Disconn(bool),
 
     /// Report a raw string as a trace status explanation.
-    Other(managed::Managed<'a, str>),
+    Other(&'a str),
 }
 
 /// Shape of the trace buffer

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -304,8 +304,9 @@ pub trait Tracepoints: Target {
     /// definition.
     ///
     /// This method will only ever be called in-between
-    /// [`tracepoint_create_begin`] and [`tracepoint_create_complete`]
-    /// invocations for a new tracepoint.
+    /// [`Tracepoints::tracepoint_create_begin`] and
+    /// [`Tracepoints::tracepoint_create_complete`] invocations for a new
+    /// tracepoint.
     fn tracepoint_create_continue(
         &mut self,
         tp: Tracepoint,
@@ -315,8 +316,9 @@ pub trait Tracepoints: Target {
     /// to have been received.
     ///
     /// This method will only ever be called after all of the
-    /// [`tracepoint_create_begin`] and [`tracepoint_create_continue`]
-    /// invocations for a new tracepoint.
+    /// [`Tracepoints::tracepoint_create_begin`] and
+    /// [`Tracepoints::tracepoint_create_continue`] invocations for a new
+    /// tracepoint.
     fn tracepoint_create_complete(&mut self, tp: Tracepoint) -> TargetResult<(), Self>;
     /// Request the status of tracepoint `tp` at address `addr`.
     ///

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -95,6 +95,46 @@ pub struct SourceTracepoint<'a, U> {
     pub bytes: ManagedSlice<'a, u8>,
 }
 
+#[cfg(feature = "alloc")]
+impl<'a, U: Copy> SourceTracepoint<'a, U> {
+    /// Allocate an owned copy of this structure.
+    pub fn get_owned<'b>(&self) -> SourceTracepoint<'b, U> {
+        SourceTracepoint {
+            number: self.number,
+            addr: self.addr,
+            kind: self.kind,
+            start: self.start,
+            slen: self.slen,
+            bytes: ManagedSlice::Owned(self.bytes.to_owned()),
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a, U: Copy> TracepointAction<'a, U> {
+    /// Allocate an owned copy of this structure.
+    pub fn get_owned<'b>(&self) -> TracepointAction<'b, U> {
+        use core::ops::Deref;
+        match self {
+            TracepointAction::Registers { mask } => TracepointAction::Registers {
+                mask: ManagedSlice::Owned(mask.deref().into()),
+            },
+            TracepointAction::Memory {
+                basereg,
+                offset,
+                length,
+            } => TracepointAction::Memory {
+                basereg: *basereg,
+                offset: *offset,
+                length: *length,
+            },
+            TracepointAction::Expression { expr } => TracepointAction::Expression {
+                expr: ManagedSlice::Owned(expr.deref().into()),
+            },
+        }
+    }
+}
+
 /// The running state of a trace experiment.
 #[derive(Debug)]
 pub enum ExperimentStatus<'a> {

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -35,37 +35,48 @@ pub struct NewTracepoint<U> {
 /// it is attached to is hit. A tracepoint may have more than one action
 /// attached.
 #[derive(Debug)]
-#[allow(missing_docs)]
 pub enum TracepointAction<'a, U> {
-    /// Collect the registers whose bits are set in `mask` (big endian).
-    /// Note that `mask` may be larger than the word length.
-    Registers { mask: ManagedSlice<'a, u8> },
-    /// Collect `len` bytes of memory starting at the address in register number
+    /// Collect registers.
+    Registers {
+        /// A bitmask of which registers should be collected. The least significant
+        /// bit is numberered zero. Note that the mask may be larger than the word length.
+        mask: ManagedSlice<'a, u8>
+    },
+    /// Collect memory.`len` bytes of memory starting at the address in register number
     /// `basereg`, plus `offset`. If `basereg` is None, then treat it as a fixed
     /// address.
     Memory {
+        /// If `Some`, then calculate the address of memory to collect relative to
+        /// the value of this register number. If `None` then memory should be
+        /// collected from a fixed address.
         basereg: Option<u64>,
+        /// The offset used to calculate the address to collect memory from.
         offset: U,
+        /// How many bytes of memory to collect.
         length: u64,
     },
-    /// Evaluate `expr`, which is a GDB agent bytecode expression, and collect
-    /// memory as it directs.
-    Expression { expr: ManagedSlice<'a, u8> },
+    /// Collect data according to an agent bytecode program.
+    Expression {
+        /// The GDB agent bytecode program to evaluate.
+        expr: ManagedSlice<'a, u8>
+    },
 }
 
-/// A list of TracepointActions, either raw and unparsed from a GDB packet, or
-/// a slice of parsed structures like which may be returned from enumerating
-/// tracepoints.
+/// A list of TracepointActions.
 #[derive(Debug)]
-#[allow(missing_docs)]
 pub enum TracepointActionList<'a, U> {
     /// Raw and unparsed actions, such as from GDB.
-    Raw { data: ManagedSlice<'a, u8> },
+    Raw {
+        /// The unparsed action data.
+        data: ManagedSlice<'a, u8>
+    },
     /// A slice of parsed actions, such as what may be returned by a target when
-    /// enumerating tracepoints. `more` must be set if there will be another
-    /// "tracepoint definition" with more actions for this tracepoint.
+    /// enumerating tracepoints.
     Parsed {
+        /// The parsed actions.
         actions: ManagedSlice<'a, TracepointAction<'a, U>>,
+        /// Indicate if there will be additional "tracepoint definitions" with
+        /// more actions for this tracepoint.
         more: bool,
     },
 }

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -96,7 +96,7 @@ pub struct SourceTracepoint<'a, U> {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a, U: Copy> SourceTracepoint<'a, U> {
+impl<U: Copy> SourceTracepoint<'_, U> {
     /// Allocate an owned copy of this structure.
     pub fn get_owned<'b>(&self) -> SourceTracepoint<'b, U> {
         SourceTracepoint {
@@ -111,7 +111,7 @@ impl<'a, U: Copy> SourceTracepoint<'a, U> {
 }
 
 #[cfg(feature = "alloc")]
-impl<'a, U: Copy> TracepointAction<'a, U> {
+impl<U: Copy> TracepointAction<'_, U> {
     /// Allocate an owned copy of this structure.
     pub fn get_owned<'b>(&self) -> TracepointAction<'b, U> {
         use core::ops::Deref;

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -121,7 +121,7 @@ impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> TracepointAct
     ) -> Result<(), ResponseWriterError<C::Error>> {
         match self {
             TracepointAction::Registers { mask } => {
-                res.write_str("R ")?;
+                res.write_str("R")?;
                 res.write_hex_buf(mask)?;
             }
             TracepointAction::Memory {
@@ -129,7 +129,7 @@ impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> TracepointAct
                 offset,
                 length,
             } => {
-                res.write_str("M ")?;
+                res.write_str("M")?;
                 match basereg {
                     Some(r) => res.write_num(*r),
                     None => res.write_str("-1"),
@@ -142,7 +142,7 @@ impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> TracepointAct
                 res.write_num(*length)?;
             }
             TracepointAction::Expression { expr } => {
-                res.write_str("X ")?;
+                res.write_str("X")?;
                 res.write_num(expr.len())?;
                 res.write_str(",")?;
                 res.write_hex_buf(expr)?;

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -1,0 +1,448 @@
+//! Provide tracepoints for the target.
+use crate::conn::Connection;
+use crate::protocol::ResponseWriter;
+use crate::protocol::ResponseWriterError;
+use crate::target::Arch;
+use crate::target::Target;
+use crate::target::TargetResult;
+use managed::ManagedSlice;
+use num_traits::PrimInt;
+
+/// A tracepoint, identified by a unique number.
+#[derive(Debug, Clone, Copy)]
+pub struct Tracepoint(pub usize);
+
+/// A state variable, identified by a unique number.
+#[derive(Debug, Clone, Copy)]
+pub struct StateVariable(usize);
+
+/// Describes a new tracepoint. It may be configured by later
+/// [DefineTracepoint] structs. GDB may ask for the state of current
+/// tracepoints, which are described with this same structure.
+#[derive(Debug)]
+pub struct NewTracepoint<U> {
+    /// The tracepoint number
+    pub number: Tracepoint,
+    /// If the tracepoint is enabled or not
+    pub enabled: bool,
+    /// The address the tracepoint is set at.
+    pub addr: U,
+    /// The tracepoint's step count
+    pub step_count: u64,
+    /// The tracepoint's pass count.
+    pub pass_count: u64,
+    /// If there will be tracepoint "define" packets that follow this.
+    pub more: bool,
+}
+
+impl<U: crate::internal::BeBytes + num_traits::Zero + PrimInt> NewTracepoint<U> {
+    pub(crate) fn write<C: Connection>(
+        &self,
+        res: &mut ResponseWriter<'_, C>,
+    ) -> Result<(), ResponseWriterError<C::Error>> {
+        res.write_str("QTDP:")?;
+        res.write_num(self.number.0)?;
+        res.write_str(":")?;
+        let mut buf = [0; 8];
+        self.addr
+            .to_be_bytes(&mut buf)
+            .ok_or_else(|| unreachable!())?;
+        res.write_hex_buf(&buf)?;
+        res.write_str(":")?;
+        res.write_str(if self.enabled { "E" } else { "D" })?;
+        res.write_str(":")?;
+        res.write_num(self.step_count)?;
+        res.write_str(":")?;
+        res.write_num(self.pass_count)?;
+
+        Ok(())
+    }
+}
+
+/// Describes how to collect information for a trace frame when the tracepoint
+/// it is attached to is hit. A tracepoint may have more than one action
+/// attached.
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum TracepointAction<'a, U> {
+    /// Collect the registers whose bits are set in `mask` (big endian).
+    /// Note that `mask` may be larger than the word length.
+    Registers { mask: &'a [u8] },
+    /// Collect `len` bytes of memory starting at the address in register number
+    /// `basereg`, plus `offset`. If `basereg` is None, then treat it as a fixed
+    /// address.
+    Memory {
+        basereg: Option<u64>,
+        offset: U,
+        length: u64,
+    },
+    /// Evaluate `expr`, which is a GDB agent bytecode expression, and collect
+    /// memory as it directs.
+    Expression { expr: &'a [u8] },
+}
+
+impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> TracepointAction<'a, U> {
+    pub(crate) fn write<C: Connection>(
+        &self,
+        res: &mut ResponseWriter<'_, C>,
+    ) -> Result<(), ResponseWriterError<C::Error>> {
+        match self {
+            TracepointAction::Registers { mask } => {
+                res.write_str("R ")?;
+                res.write_hex_buf(mask)?;
+            }
+            TracepointAction::Memory {
+                basereg,
+                offset,
+                length,
+            } => {
+                res.write_str("M ")?;
+                match basereg {
+                    Some(r) => res.write_num(*r),
+                    None => res.write_str("-1"),
+                }?;
+                res.write_str(",")?;
+                let mut buf = [0; 8];
+                offset.to_be_bytes(&mut buf).ok_or_else(|| unreachable!())?;
+                res.write_hex_buf(&buf)?;
+                res.write_str(",")?;
+                res.write_num(*length)?;
+            }
+            TracepointAction::Expression { expr } => {
+                res.write_str("X ")?;
+                res.write_num(expr.len())?;
+                res.write_str(",")?;
+                res.write_hex_buf(expr)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A list of TracepointActions, either raw and unparsed from a GDB packet, or
+/// a slice of parsed structures like which may be returned from enumerating
+/// tracepoints.
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum TracepointActionList<'a, U> {
+    /// Raw and unparsed actions, such as from GDB.
+    Raw { data: &'a mut [u8] },
+    /// A slice of parsed actions, such as what may be returned by a target when
+    /// enumerating tracepoints. `more` must be set if there will be another
+    /// "tracepoint definition" with more actions for this tracepoint.
+    Parsed {
+        actions: ManagedSlice<'a, TracepointAction<'a, U>>,
+        more: bool,
+    },
+}
+
+/// Definition data for a tracepoint. A tracepoint may have more than one define
+/// structure for all of its data. GDB may ask for the state of current
+/// tracepoints, which are described with this same structure.
+#[derive(Debug)]
+pub struct DefineTracepoint<'a, U> {
+    /// The tracepoint that is having actions appended to its definition.
+    pub number: Tracepoint,
+    /// The PC address of the tracepoint that is being defined.
+    pub addr: U,
+    /// A list of actions that should be appended to the tracepoint.
+    pub actions: TracepointActionList<'a, U>,
+}
+
+impl<'a, U: crate::internal::BeBytes + num_traits::Zero + PrimInt> DefineTracepoint<'a, U> {
+    pub(crate) fn write<C: Connection>(
+        self,
+        res: &mut ResponseWriter<'_, C>,
+    ) -> Result<(), ResponseWriterError<C::Error>> {
+        res.write_str("QTDP:-")?;
+        res.write_num(self.number.0)?;
+        res.write_str(":")?;
+        let mut buf = [0; 8];
+        self.addr
+            .to_be_bytes(&mut buf)
+            .ok_or_else(|| unreachable!())?;
+        res.write_hex_buf(&buf)?;
+        res.write_str(":")?;
+        let mut err = None;
+        let more = self.actions(|action| {
+            if let Err(e) = action.write(res) {
+                err = Some(e)
+            }
+        });
+        if let Some(e) = err {
+            return Err(e);
+        }
+        if let Some(true) = more {
+            res.write_str("-")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// An item from a stream of tracepoint descriptions. Enumerating tracepoints
+/// should emit a sequence of Create and Define items for all the tracepoints
+/// that are loaded.
+#[derive(Debug)]
+pub enum TracepointItem<'a, U> {
+    /// Introduce a new tracepoint and describe its properties. This must be
+    /// emitted before any [TracepointItem::Define] items that use the same tracepoint
+    /// number, and must have the `more` flag set if it will be followed by
+    /// [TracepointItem::Define] items for this tracepoint.
+    New(NewTracepoint<U>),
+    /// Define additional data for a tracepoint. This must be emitted after a
+    /// [TracepointItem::New] item that introduces the tracepoint number, and must have
+    /// the `more` flag set if it will be followed by more [TracepointItem::Define] items
+    /// for this tracepoint.
+    Define(DefineTracepoint<'a, U>),
+}
+
+/// Description of the currently running trace experiment.
+pub struct ExperimentStatus<'a> {
+    /// If a trace is presently running
+    pub running: bool,
+    /// A list of optional explanations for the trace status.
+    pub explanations: ManagedSlice<'a, ExperimentExplanation<'a>>,
+}
+
+/// An explanation of some detail of the currently running trace experiment.
+#[derive(Debug)]
+pub enum ExperimentExplanation<'a> {
+    /// No trace has been ran yet.
+    NotRun,
+    /// The trace was stopped by the user. May contain an optional user-supplied
+    /// stop reason.
+    Stop(Option<&'a [u8]>),
+    /// The trace stopped because the buffer is full.
+    Full,
+    /// The trace stopped because GDB disconnect from the target.
+    Disconnected,
+    /// The trace stopped because the specified tracepoint exceeded its pass
+    /// count.
+    PassCount(Tracepoint),
+    /// The trace stopped because the specified tracepoint had an error.
+    Error(&'a [u8], Tracepoint),
+    /// The trace stopped for some other reason.
+    Unknown,
+
+    // Statistical information
+    /// The number of trace frames in the buffer.
+    Frames(usize),
+    /// The total number of trace frames created during the run. This may be
+    /// larger than the trace frame count, if the buffer is circular.
+    Created(usize),
+    /// The total size of the trace buffer, in bytes.
+    Size(usize),
+    /// The number of bytes still unused in the buffer.
+    Free(usize),
+    /// The value of the circular trace buffer flag. True means the trace buffer
+    /// is circular and old trace frames will be discarded if necessary to
+    /// make room, false means that the trace buffer is linear and may fill
+    /// up.
+    Circular(bool),
+    /// The value of the disconnected tracing flag. True means that tracing will
+    /// continue after GDB disconnects, false means that the trace run will
+    /// stop.
+    Disconn(bool),
+
+    /// Report a raw string as a trace status explanation.
+    Other(managed::Managed<'a, str>),
+}
+
+impl<'a> ExperimentExplanation<'a> {
+    pub(crate) fn write<C: Connection>(
+        &self,
+        res: &mut ResponseWriter<'_, C>,
+    ) -> Result<(), ResponseWriterError<C::Error>> {
+        use ExperimentExplanation::*;
+        match self {
+            NotRun => res.write_str("tnotrun:0")?,
+            Stop(ref t) => match t {
+                Some(text) => {
+                    res.write_str("tstop:")?;
+                    res.write_hex_buf(text)?;
+                    res.write_str(":0")?;
+                }
+                None => res.write_str("tstop:0")?,
+            },
+            Full => res.write_str("tfull:0")?,
+            Disconnected => res.write_str("tdisconnected:0")?,
+            PassCount(tpnum) => {
+                res.write_str("tpasscount:")?;
+                res.write_num(tpnum.0)?;
+            }
+            Error(text, tpnum) => {
+                res.write_str("terror:")?;
+                res.write_hex_buf(text)?;
+                res.write_str(":")?;
+                res.write_num(tpnum.0)?;
+            }
+            Unknown => res.write_str("tunknown:0")?,
+
+            Frames(u) => {
+                res.write_str("tframes:")?;
+                res.write_num(*u)?;
+            }
+            Created(u) => {
+                res.write_str("tcreated:")?;
+                res.write_num(*u)?;
+            }
+            Size(u) => {
+                res.write_str("tsize:")?;
+                res.write_num(*u)?;
+            }
+            Free(u) => {
+                res.write_str("tfree:")?;
+                res.write_num(*u)?;
+            }
+            Circular(u) => {
+                res.write_str("circular:")?;
+                res.write_num(if *u { 1 } else { 0 })?;
+            }
+            Disconn(dis) => match dis {
+                true => res.write_str("disconn:1")?,
+                false => res.write_str("disconn:0")?,
+            },
+            Other(body) => res.write_str(body.as_ref())?,
+        };
+
+        Ok(())
+    }
+}
+
+/// Shape of the trace buffer
+#[derive(Debug)]
+pub enum BufferShape {
+    /// A circular trace buffer
+    Circular,
+    /// A linear trace buffer
+    Linear,
+}
+
+/// Configuration for the trace buffer.
+#[derive(Debug)]
+pub enum TraceBuffer {
+    /// Set the buffer's shape.
+    Shape(BufferShape),
+    /// Set the buffer's size in bytes. If None, the target should use whatever
+    /// size it prefers.
+    Size(Option<u64>),
+}
+
+/// Request to select a new frame from the trace buffer.
+#[derive(Debug)]
+pub enum FrameRequest<U> {
+    /// Select the specified tracepoint frame in the buffer.
+    Select(u64),
+    /// Select a tracepoint frame that has a specified PC after the currently
+    /// selected frame.
+    AtPC(U),
+    /// Select a tracepoint frame that hit a specified tracepoint after the
+    /// currently selected frame.
+    Hit(Tracepoint),
+    /// Select a tramepoint frame that has a PC between a start (inclusive) and
+    /// end (inclusive).
+    Between(U, U),
+    /// Select a tracepoint frame that has a PC outside the range of addresses
+    /// (exclusive).
+    Outside(U, U),
+}
+
+impl<'a, U: crate::internal::BeBytes> From<FrameRequest<&'a mut [u8]>> for Option<FrameRequest<U>> {
+    fn from(s: FrameRequest<&'a mut [u8]>) -> Self {
+        Some(match s {
+            FrameRequest::Select(u) => FrameRequest::Select(u),
+            FrameRequest::AtPC(u) => FrameRequest::AtPC(U::from_be_bytes(u)?),
+            FrameRequest::Hit(tp) => FrameRequest::Hit(tp),
+            FrameRequest::Between(s, e) => {
+                FrameRequest::Between(U::from_be_bytes(s)?, U::from_be_bytes(e)?)
+            }
+            FrameRequest::Outside(s, e) => {
+                FrameRequest::Outside(U::from_be_bytes(s)?, U::from_be_bytes(e)?)
+            }
+        })
+    }
+}
+
+/// Describes a detail of a frame from the trace buffer
+#[derive(Debug)]
+pub enum FrameDescription {
+    /// The frame is at the specified index in the trace buffer
+    FrameNumber(Option<u64>),
+    /// The frame is a hit of the specified tracepoint
+    Hit(Tracepoint),
+}
+
+/// Target Extension - Provide tracepoints.
+pub trait Tracepoints: Target {
+    /// Clear any saved tracepoints and empty the trace frame buffer
+    fn tracepoints_init(&mut self) -> TargetResult<(), Self>;
+
+    /// Create a new tracepoint according to the description `tdp`
+    fn tracepoint_create(
+        &mut self,
+        tdp: NewTracepoint<<Self::Arch as Arch>::Usize>,
+    ) -> TargetResult<(), Self>;
+    /// Configure an existing tracepoint, appending new actions
+    fn tracepoint_define(
+        &mut self,
+        dtdp: DefineTracepoint<'_, <Self::Arch as Arch>::Usize>,
+    ) -> TargetResult<(), Self>;
+    /// Request the status of tracepoint `tp` at address `addr`.
+    ///
+    /// Returns `(number of tracepoint hits, number of bytes used for frames)`.
+    fn tracepoint_status(
+        &self,
+        tp: Tracepoint,
+        addr: <Self::Arch as Arch>::Usize,
+    ) -> TargetResult<(u64, u64), Self>;
+
+    /// Begin enumerating tracepoints. The target implementation should
+    /// initialize a state machine that is stepped by
+    /// [Tracepoints::tracepoint_enumerate_step], and returns TracepointItems that
+    /// correspond with the currently configured tracepoints.
+    fn tracepoint_enumerate_start(
+        &mut self,
+    ) -> TargetResult<Option<TracepointItem<'_, <Self::Arch as Arch>::Usize>>, Self>;
+    /// Step the tracepoint enumeration state machine. The target implementation
+    /// should return TracepointItems that correspond with the currently
+    /// configured tracepoints.
+    fn tracepoint_enumerate_step(
+        &mut self,
+    ) -> TargetResult<Option<TracepointItem<'_, <Self::Arch as Arch>::Usize>>, Self>;
+
+    /// Reconfigure the trace buffer to include or modify an attribute.
+    fn trace_buffer_configure(&mut self, tb: TraceBuffer) -> TargetResult<(), Self>;
+
+    /// Return up to `len` bytes from the trace buffer, starting at `offset`.
+    /// The trace buffer is treated as a contiguous collection of traceframes,
+    /// as per [GDB's trace file format](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Trace-File-Format.html).
+    /// The return value should be the number of bytes written.
+    fn trace_buffer_request(
+        &mut self,
+        offset: u64,
+        len: usize,
+        buf: &mut [u8],
+    ) -> TargetResult<Option<usize>, Self>;
+
+    /// Return the status of the current trace experiment.
+    fn trace_experiment_status(&self) -> TargetResult<ExperimentStatus<'_>, Self>;
+    /// Start a new trace experiment.
+    fn trace_experiment_start(&mut self) -> TargetResult<(), Self>;
+    /// Stop the currently running trace experiment.
+    fn trace_experiment_stop(&mut self) -> TargetResult<(), Self>;
+
+    /// Select a new frame in the trace buffer. The target should attempt to
+    /// fulfill the request according to the [FrameRequest]. If it's
+    /// successful it should call `report` with a series of calls describing
+    /// the found frame, and then record it as the currently selected frame.
+    /// Future register and memory requests should be fulfilled from the
+    /// currently selected frame.
+    fn select_frame(
+        &mut self,
+        frame: FrameRequest<<Self::Arch as Arch>::Usize>,
+        report: &mut dyn FnMut(FrameDescription),
+    ) -> TargetResult<(), Self>;
+}
+
+define_ext!(TracepointsOps, Tracepoints);

--- a/src/target/ext/tracepoints.rs
+++ b/src/target/ext/tracepoints.rs
@@ -316,7 +316,7 @@ pub trait Tracepoints: Target {
     fn tracepoint_enumerate_start(
         &mut self,
         tp: Option<Tracepoint>,
-        f: &mut dyn FnMut(NewTracepoint<<Self::Arch as Arch>::Usize>),
+        f: &mut dyn FnMut(&NewTracepoint<<Self::Arch as Arch>::Usize>),
     ) -> TargetResult<TracepointEnumerateStep<<Self::Arch as Arch>::Usize>, Self>;
     /// Enumerate an action attached to a tracepoint. `step` is which action
     /// item is being asked for, so that the implementation can respond with
@@ -329,7 +329,7 @@ pub trait Tracepoints: Target {
         &mut self,
         tp: Tracepoint,
         step: u64,
-        f: &mut dyn FnMut(TracepointAction<'_, <Self::Arch as Arch>::Usize>),
+        f: &mut dyn FnMut(&TracepointAction<'_, <Self::Arch as Arch>::Usize>),
     ) -> TargetResult<TracepointEnumerateStep<<Self::Arch as Arch>::Usize>, Self>;
     /// Enumerate the source strings that describe a tracepoint. `step` is which
     /// source string is being asked for, so that the implementation can
@@ -342,7 +342,7 @@ pub trait Tracepoints: Target {
         &mut self,
         tp: Tracepoint,
         step: u64,
-        f: &mut dyn FnMut(SourceTracepoint<'_, <Self::Arch as Arch>::Usize>),
+        f: &mut dyn FnMut(&SourceTracepoint<'_, <Self::Arch as Arch>::Usize>),
     ) -> TargetResult<TracepointEnumerateStep<<Self::Arch as Arch>::Usize>, Self>;
 
     /// Reconfigure the trace buffer to include or modify an attribute.

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -626,6 +626,12 @@ pub trait Target {
         None
     }
 
+    /// Support for setting / removing tracepoints.
+    #[inline(always)]
+    fn support_tracepoints(&mut self) -> Option<ext::tracepoints::TracepointsOps<'_, Self>> {
+        None
+    }
+
     /// Support for overriding the target description XML specified by
     /// `Target::Arch`.
     #[inline(always)]
@@ -738,6 +744,7 @@ macro_rules! impl_dyn_target {
             __delegate_support!(host_io);
             __delegate_support!(exec_file);
             __delegate_support!(auxv);
+            __delegate_support!(tracepoints);
         }
     };
 }


### PR DESCRIPTION
### Description

This PR adds basic [tracepoint extension](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Tracepoints.html) support to GDB stub. Closes #157. 

### API Stability

- [X] This PR does not require a breaking API change

### Checklist

<!-- CI takes care of a lot of things, but there are some things that have yet to be automated -->

- Documentation
  - [X] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [X] (if appropriate) Added feature to "Debugging Features" in README.md
- Validation
  - [X] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [X] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below
- _If implementing a new protocol extension IDET_
  - [X] Included a basic sample implementation in `examples/armv4t`
  - [X] IDET can be optimized out (confirmed via `./example_no_std/check_size.sh`)
  - [ ] **OR** implementation requires introducing non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [ ] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- Oh, and if you're integrating `gdbstub` in an open-source project, do consider updating the README.md's "Real World Examples" section to link back to your project! -->

### Validation

<!-- example output, from https://github.com/daniel5151/gdbstub/pull/54 -->

<details>
<summary>GDB output</summary>

```
(gdb) trace test.c:10
Tracepoint 1 at 0x55550040: file test.c, line 10.
(gdb) break *0x55550044
Breakpoint 2 at 0x55550044: file test.c, line 10.
(gdb) break main
Breakpoint 3 at 0x5555000c: file test.c, line 2.
(gdb) r
The program being debugged has been started already.
Start it from the beginning? (y or n) y
Starting program: target:/test.elf 
Reading /test.elf from remote target...

Breakpoint 3, main () at test.c:2
2	in test.c
(gdb) tstart
warning: Target does not support trace user/notes, info ignored
(gdb) c
Continuing.

Breakpoint 2, 0x55550044 in main () at test.c:10
10	in test.c
(gdb) tstop
warning: Target does not support trace notes, note ignored
(gdb) tstatus
Trace stopped for an unknown reason.
Collected 1 trace frames.
Trace will stop if GDB disconnects.
Not looking at any trace frame.
(gdb) info tracepoints
Num     Type           Disp Enb Address    What
1       tracepoint     keep y   0x55550040 in main at test.c:10
	tracepoint already hit 1 time
	installed on target
(gdb) tfind
Found trace frame 0, tracepoint 1
#0  main () at test.c:10
10	in test.c
(gdb) i r
r0             0x0                 0
r1             0x0                 0
r2             0x0                 0
r3             0x0                 0
r4             0x0                 0
r5             0x0                 0
r6             0x0                 0
r7             0x0                 0
r8             0x0                 0
r9             0x0                 0
r10            0x0                 0
r11            0xffffffc           268435452
r12            0x0                 0
sp             0xfffffe8           0xfffffe8
lr             0x12345678          305419896
pc             0x55550040          0x55550040 <main+64>
cpsr           0x80000010          -2147483632
custom         0x12345678          305419896
time           0x3a87325d          981938781
unavailable    <unavailable>
```

</details>

<details>
<summary>
loading section ".text" into memory from [0x55550000..0x55550078]
Setting PC to 0x55550000
Waiting for a GDB connection on "127.0.0.1:9001"...
</summary>

(The start of the `cargo run` output is corrupted by binary data that's printed, so I cut out the portion of the output relevant for tracepoint packets)
```
TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 TRACE gdbstub::protocol::response_writer > --> $T0;tframes:00#4b
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $08301be5#f8
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550044,4#69
 TRACE gdbstub::protocol::response_writer > --> $013083e2#c6
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 TRACE gdbstub::protocol::response_writer > --> $T0;tframes:00#4b
 TRACE gdbstub::protocol::recv_packet     > <-- $Z0,5555000c,4#dd
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $Z0,55550044,4#b2
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 TRACE gdbstub::protocol::response_writer > --> $T0;tframes:00#4b
 TRACE gdbstub::protocol::recv_packet     > <-- $vCont;c:p1.-1#0f
 TRACE gdbstub::stub::state_machine       > transition: "Idle<armv4t::emu::Emu>" --> "Running"
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550000, inst: 0xe52db004, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: SingleXferI
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550004, inst: 0xe28db000, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: DataProc2
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550008, inst: 0xe24dd014, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: DataProc2
 TRACE gdbstub::protocol::response_writer > --> $T05thread:p01.01;swbreak:;#6a
 TRACE gdbstub::stub::state_machine       > transition: "Running" --> "Idle<armv4t::emu::Emu>"
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fcffff0f00000000e8ffff0f785634120c005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1000000078563412#06
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $z0,5555000c,4#fd
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $z0,55550044,4#d2
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,4#69
 TRACE gdbstub::protocol::response_writer > --> $14d04de2#28
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,4#69
 TRACE gdbstub::protocol::response_writer > --> $14d04de2#28
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,2#92
 TRACE gdbstub::protocol::response_writer > --> $0430#c7
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000a,2#90
 TRACE gdbstub::protocol::response_writer > --> $4de2#2f
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,2#67
 TRACE gdbstub::protocol::response_writer > --> $14d0#f9
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,2#92
 TRACE gdbstub::protocol::response_writer > --> $0430#c7
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000a,2#90
 TRACE gdbstub::protocol::response_writer > --> $4de2#2f
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,2#67
 TRACE gdbstub::protocol::response_writer > --> $14d0#f9
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,4#69
 TRACE gdbstub::protocol::response_writer > --> $14d04de2#28
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550008,4#69
 TRACE gdbstub::protocol::response_writer > --> $14d04de2#28
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555000c,4#94
 TRACE gdbstub::protocol::response_writer > --> $0430a0e3#f0
 TRACE gdbstub::protocol::recv_packet     > <-- $QTinit#59
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $QTDP:1:0000000055550040:E:0:0#49
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $QTDPsrc:1:55550040:at:0:9:746573742e633a3130#ea
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $QTro:55550000,55550078#23
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("QTro:55550000,55550078")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $QTBuffer:circular:0#f8
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $QTBuffer:size:-1#8c
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $QTNotes:user:;notes:;#ba
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("QTNotes:user:;notes:;")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $QTStart#b3
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $Z0,55550044,4#b2
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 TRACE gdbstub::protocol::response_writer > --> $T1;tframes:00#4c
 TRACE gdbstub::protocol::recv_packet     > <-- $vCont;s:p1.1#f2
 TRACE gdbstub::stub::state_machine       > transition: "Idle<armv4t::emu::Emu>" --> "Running"
 TRACE armv4t_emu::arm                    > ARM: pc: 0x5555000c, inst: 0xe3a03004, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: DataProc2
 TRACE gdbstub::protocol::response_writer > --> $S05#b8
 TRACE gdbstub::stub::state_machine       > transition: "Running" --> "Idle<armv4t::emu::Emu>"
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $0000000000000000000000000400000000000000000000000000000000000000000000000000000000000000fcffff0f00000000e8ffff0f7856341210005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1000000078563412#7d
 TRACE gdbstub::protocol::recv_packet     > <-- $Z0,5555000c,4#dd
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 TRACE gdbstub::protocol::response_writer > --> $T1;tframes:00#4c
 TRACE gdbstub::protocol::recv_packet     > <-- $vCont;c:p1.-1#0f
 TRACE gdbstub::stub::state_machine       > transition: "Idle<armv4t::emu::Emu>" --> "Running"
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550010, inst: 0xe50b3008, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: SingleXferI
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550014, inst: 0xe3a03003, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: DataProc2
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550018, inst: 0xe50b3010, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: SingleXferI
 TRACE armv4t_emu::arm                    > ARM: pc: 0x5555001c, inst: 0xe51b3008, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: SingleXferI
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550020, inst: 0xe2833001, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: DataProc2
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550024, inst: 0xe50b3008, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: SingleXferI
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550028, inst: 0xe51b3010, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: SingleXferI
 TRACE armv4t_emu::arm                    > ARM: pc: 0x5555002c, inst: 0xe2833003, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: DataProc2
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550030, inst: 0xe50b3010, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: SingleXferI
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550034, inst: 0xe3a03000, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: DataProc2
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550038, inst: 0xe50b300c, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: SingleXferI
 TRACE armv4t_emu::arm                    > ARM: pc: 0x5555003c, inst: 0xea000005, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: Branch
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550058, inst: 0xe51b300c, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: SingleXferI
 TRACE armv4t_emu::arm                    > ARM: pc: 0x5555005c, inst: 0xe3530902, cond: 0xe, cflags: 0000
 TRACE armv4t_emu::arm                    > Instruction: DataProc2
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550060, inst: 0xbafffff6, cond: 0xb, cflags: 1000
 TRACE armv4t_emu::arm                    > Instruction: Branch
 TRACE armv4t_emu::arm                    > ARM: pc: 0x55550040, inst: 0xe51b3008, cond: 0xe, cflags: 1000
 TRACE armv4t_emu::arm                    > Instruction: SingleXferI
 TRACE gdbstub::protocol::response_writer > --> $T05thread:p01.01;swbreak:;#6a
 TRACE gdbstub::stub::state_machine       > transition: "Running" --> "Idle<armv4t::emu::Emu>"
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $0000000000000000000000000500000000000000000000000000000000000000000000000000000000000000fcffff0f00000000e8ffff0f7856341244005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1000008078563412#8d
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $z0,5555000c,4#fd
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $z0,55550044,4#d2
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550044,4#69
 TRACE gdbstub::protocol::response_writer > --> $013083e2#c6
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $08301be5#f8
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550044,4#69
 TRACE gdbstub::protocol::response_writer > --> $013083e2#c6
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $08301be5#f8
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550044,2#67
 TRACE gdbstub::protocol::response_writer > --> $0130#c4
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550042,2#65
 TRACE gdbstub::protocol::response_writer > --> $1be5#2d
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,2#63
 TRACE gdbstub::protocol::response_writer > --> $0830#cb
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550044,2#67
 TRACE gdbstub::protocol::response_writer > --> $0130#c4
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550042,2#65
 TRACE gdbstub::protocol::response_writer > --> $1be5#2d
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,2#63
 TRACE gdbstub::protocol::response_writer > --> $0830#cb
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550044,4#69
 TRACE gdbstub::protocol::response_writer > --> $013083e2#c6
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $08301be5#f8
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550044,4#69
 TRACE gdbstub::protocol::response_writer > --> $013083e2#c6
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $08301be5#f8
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550044,4#69
 TRACE gdbstub::protocol::response_writer > --> $013083e2#c6
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550044,4#69
 TRACE gdbstub::protocol::response_writer > --> $013083e2#c6
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550044,4#69
 TRACE gdbstub::protocol::response_writer > --> $013083e2#c6
 TRACE gdbstub::protocol::recv_packet     > <-- $QTStop#4b
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $QTNotes:tstop:;#97
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("QTNotes:tstop:;")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 TRACE gdbstub::protocol::response_writer > --> $T0;tframes:01#4c
 TRACE gdbstub::protocol::recv_packet     > <-- $qTP:1:55550040#52
 TRACE gdbstub::protocol::response_writer > --> $V01:00#51
 TRACE gdbstub::protocol::recv_packet     > <-- $QTFrame:0#fa
 TRACE gdbstub::protocol::response_writer > --> $F00T01#5b
 TRACE gdbstub::protocol::recv_packet     > <-- $QTFrame:0#fa
 TRACE gdbstub::protocol::response_writer > --> $F00T01#5b
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fcffff0f00000000e8ffff0f7856341240005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1000008078563412#df
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555003c,4#97
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555003c,4#97
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,2#63
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555003e,2#97
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555003c,2#95
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,2#63
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555003e,2#97
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555003c,2#95
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555003c,4#97
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m5555003c,4#97
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550040,4#65
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $p1b#03
 TRACE gdbstub::protocol::response_writer > --> $5d32873a#01
 TRACE gdbstub::protocol::recv_packet     > <-- $p1c#04
 TRACE gdbstub::protocol::response_writer > --> $xxxxxxxx#c6

```
</details>

<details>
<summary>Before/After `./example_no_std/check_size.sh` output</summary>

### Before

```
Analyzing target/release/gdbstub-nostd

File  .text    Size          Crate Name
2.4%  71.2% 11.9KiB      [Unknown] main
0.2%   5.7%    969B        gdbstub gdbstub::stub::state_machine::GdbStubStateMachineInner<gdbstub::stub::state_machine::state::Running,T,C>::report_stop
0.1%   2.2%    374B        gdbstub gdbstub::protocol::commands::breakpoint::BasicBreakpoint::from_slice
0.1%   1.7%    295B        gdbstub <gdbstub::protocol::common::thread_id::ThreadId as core::convert::TryFrom<&[u8]>>::try_from
0.1%   1.7%    295B        gdbstub gdbstub::stub::core_impl::resume::<impl gdbstub::stub::core_impl::GdbStubImpl<T,C>>::write_stop_common
0.1%   1.6%    278B        gdbstub gdbstub::protocol::packet::PacketBuf::new
0.1%   1.6%    277B        gdbstub gdbstub::protocol::common::hex::decode_hex_buf
0.1%   1.6%    273B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_specific_thread_id
0.0%   1.2%    213B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write
0.0%   0.8%    132B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.7%    122B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::inner_write
0.0%   0.6%    111B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::flush
0.0%   0.6%    107B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.6%    106B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_addrs
0.0%   0.6%    104B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.6%    101B      [Unknown] __libc_csu_init
0.0%   0.6%     97B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.6%     95B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_hex
0.0%   0.5%     92B        gdbstub <gdbstub::protocol::common::thread_id::IdKind as core::convert::TryFrom<&[u8]>>::try_from
0.0%   0.5%     87B        gdbstub <usize as gdbstub::internal::be_bytes::BeBytes>::from_be_bytes
0.0%   0.5%     85B        gdbstub <u32 as gdbstub::internal::be_bytes::BeBytes>::from_be_bytes
0.0%   0.4%     71B   gdbstub_arch <gdbstub_arch::arm::reg::arm_core::ArmCoreRegs as gdbstub::arch::Registers>::gdb_deserialize
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_addrs
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_registers
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_registers
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::set_resume_action_cont...
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::clear_resume_actions
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::resume
0.0%   0.3%     43B      [Unknown] _start
0.0%   0.0%      6B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>::add_sw_breakpoint
0.0%   0.0%      2B      [Unknown] __libc_csu_fini
3.4% 100.0% 16.7KiB                .text section size, the file size is 488.4KiB
target/release/gdbstub-nostd  :
section               size      addr
.interp                 28       568
.note.ABI-tag           32       596
.note.gnu.build-id      36       628
.gnu.hash               28       664
.dynsym                360       696
.dynstr                193      1056
.gnu.version            30      1250
.gnu.version_r          48      1280
.rela.dyn              408      1328
.init                   23      1736
.plt                    16      1760
.plt.got                 8      1776
.text                17106      1792
.fini                    9     18900
.rodata                920     18912
.eh_frame_hdr          276     19832
.eh_frame             1488     20112
.init_array              8   2121128
.fini_array              8   2121136
.dynamic               448   2121144
.got                   136   2121592
.data                    8   2121728
.bss                     8   2121736
.comment                93         0
Total                21718
```

### After

```
Analyzing target/release/gdbstub-nostd

File  .text    Size          Crate Name
2.3%  71.2% 11.9KiB      [Unknown] main
0.2%   5.7%    969B        gdbstub gdbstub::stub::state_machine::GdbStubStateMachineInner<gdbstub::stub::state_machine::state::Running,T,C>::report_stop
0.1%   2.2%    374B        gdbstub gdbstub::protocol::commands::breakpoint::BasicBreakpoint::from_slice
0.1%   1.7%    295B        gdbstub <gdbstub::protocol::common::thread_id::ThreadId as core::convert::TryFrom<&[u8]>>::try_from
0.1%   1.7%    295B        gdbstub gdbstub::stub::core_impl::resume::<impl gdbstub::stub::core_impl::GdbStubImpl<T,C>>::write_stop_common
0.1%   1.6%    278B        gdbstub gdbstub::protocol::packet::PacketBuf::new
0.1%   1.6%    277B        gdbstub gdbstub::protocol::common::hex::decode_hex_buf
0.1%   1.6%    273B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_specific_thread_id
0.0%   1.2%    213B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write
0.0%   0.8%    132B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.7%    122B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::inner_write
0.0%   0.6%    111B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::flush
0.0%   0.6%    107B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.6%    106B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_addrs
0.0%   0.6%    104B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.6%    101B      [Unknown] __libc_csu_init
0.0%   0.6%     97B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.6%     95B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_hex
0.0%   0.5%     92B        gdbstub <gdbstub::protocol::common::thread_id::IdKind as core::convert::TryFrom<&[u8]>>::try_from
0.0%   0.5%     87B        gdbstub <usize as gdbstub::internal::be_bytes::BeBytes>::from_be_bytes
0.0%   0.5%     85B        gdbstub <u32 as gdbstub::internal::be_bytes::BeBytes>::from_be_bytes
0.0%   0.4%     71B   gdbstub_arch <gdbstub_arch::arm::reg::arm_core::ArmCoreRegs as gdbstub::arch::Registers>::gdb_deserialize
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_addrs
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_registers
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_registers
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::set_resume_action_cont...
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::clear_resume_actions
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::resume
0.0%   0.3%     43B      [Unknown] _start
0.0%   0.0%      6B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>::add_sw_breakpoint
0.0%   0.0%      2B      [Unknown] __libc_csu_fini
3.3% 100.0% 16.7KiB                .text section size, the file size is 506.0KiB
target/release/gdbstub-nostd  :
section               size      addr
.interp                 28       568
.note.ABI-tag           32       596
.note.gnu.build-id      36       628
.gnu.hash               28       664
.dynsym                360       696
.dynstr                193      1056
.gnu.version            30      1250
.gnu.version_r          48      1280
.rela.dyn              408      1328
.init                   23      1736
.plt                    16      1760
.plt.got                 8      1776
.text                17090      1792
.fini                    9     18884
.rodata                920     18896
.eh_frame_hdr          276     19816
.eh_frame             1488     20096
.init_array              8   2121128
.fini_array              8   2121136
.dynamic               448   2121144
.got                   136   2121592
.data                    8   2121728
.bss                     8   2121736
.comment                93         0
Total                21702
```

</details>
