### PR TITLE
use maybe_async that supports async traits for breakpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ gdbstub_arch = { path = "./gdbstub_arch/" }
 armv4t_emu = "0.1"
 pretty_env_logger = "0.4"
 goblin = "0.4"
+tokio = { version = "1.42.0", features = ["full"] }
 
 [features]
 default = ["std", "trace-pkt", "sync"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "2.3.1"
 cfg-if = "1.0"
 log = "0.4"
 managed = { version = "0.8", default-features = false }
-maybe-async = { version = "0.2.10" }
+maybe-async = { version = "0.2.10", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 paste = "1.0"
 
@@ -31,7 +31,7 @@ pretty_env_logger = "0.4"
 goblin = "0.4"
 
 [features]
-default = ["std", "trace-pkt"]
+default = ["std", "trace-pkt", "sync"]
 alloc = ["managed/alloc"]
 std = ["alloc"]
 trace-pkt = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,12 @@ categories = ["development-tools::debugging", "embedded", "emulators", "network-
 exclude = ["examples/**/*.elf", "examples/**/*.o"]
 
 [dependencies]
+async-trait = "0.1.83"
 bitflags = "2.3.1"
 cfg-if = "1.0"
 log = "0.4"
 managed = { version = "0.8", default-features = false }
+maybe-async = { version = "0.2.10" }
 num-traits = { version = "0.2", default-features = false }
 paste = "1.0"
 
@@ -35,6 +37,7 @@ std = ["alloc"]
 trace-pkt = ["alloc"]
 paranoid_unsafe = []
 core_error = []
+sync = ["maybe-async/is_sync"]
 
 # INTERNAL: enables the `__dead_code_marker!` macro.
 # used as part of the `scripts/test_dead_code_elim.sh`

--- a/example_no_std/Cargo.toml
+++ b/example_no_std/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Daniel Prilik <danielprilik@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-gdbstub = { path = "../", default-features = false }
+gdbstub = { path = "../", default-features = false, features = ["sync"] }
 gdbstub_arch = { path = "../gdbstub_arch", default-features = false }
 
 libc = { version = "0.2", default-features = false }

--- a/examples/armv4t/gdb/breakpoints.rs
+++ b/examples/armv4t/gdb/breakpoints.rs
@@ -9,7 +9,8 @@ impl target::ext::breakpoints::Breakpoints for Emu {
     fn support_sw_breakpoint(
         &mut self,
     ) -> Option<target::ext::breakpoints::SwBreakpointOps<'_, Self>> {
-        Some(self)
+        // Some(self)
+        None
     }
 
     #[inline(always)]
@@ -20,7 +21,7 @@ impl target::ext::breakpoints::Breakpoints for Emu {
     }
 }
 
-#[maybe_async]
+#[maybe_async(AFIT)]
 impl target::ext::breakpoints::SwBreakpoint for Emu {
     async fn add_sw_breakpoint(
         &mut self,
@@ -45,7 +46,7 @@ impl target::ext::breakpoints::SwBreakpoint for Emu {
     }
 }
 
-#[maybe_async]
+#[maybe_async(AFIT)]
 impl target::ext::breakpoints::HwWatchpoint for Emu {
     async fn add_hw_watchpoint(
         &mut self,

--- a/examples/armv4t/gdb/breakpoints.rs
+++ b/examples/armv4t/gdb/breakpoints.rs
@@ -2,6 +2,7 @@ use crate::emu::Emu;
 use gdbstub::target;
 use gdbstub::target::ext::breakpoints::WatchKind;
 use gdbstub::target::TargetResult;
+use maybe_async::maybe_async;
 
 impl target::ext::breakpoints::Breakpoints for Emu {
     #[inline(always)]
@@ -19,8 +20,9 @@ impl target::ext::breakpoints::Breakpoints for Emu {
     }
 }
 
+#[maybe_async]
 impl target::ext::breakpoints::SwBreakpoint for Emu {
-    fn add_sw_breakpoint(
+    async fn add_sw_breakpoint(
         &mut self,
         addr: u32,
         _kind: gdbstub_arch::arm::ArmBreakpointKind,
@@ -29,7 +31,7 @@ impl target::ext::breakpoints::SwBreakpoint for Emu {
         Ok(true)
     }
 
-    fn remove_sw_breakpoint(
+    async fn remove_sw_breakpoint(
         &mut self,
         addr: u32,
         _kind: gdbstub_arch::arm::ArmBreakpointKind,
@@ -43,8 +45,9 @@ impl target::ext::breakpoints::SwBreakpoint for Emu {
     }
 }
 
+#[maybe_async]
 impl target::ext::breakpoints::HwWatchpoint for Emu {
-    fn add_hw_watchpoint(
+    async fn add_hw_watchpoint(
         &mut self,
         addr: u32,
         len: u32,
@@ -61,7 +64,7 @@ impl target::ext::breakpoints::HwWatchpoint for Emu {
         Ok(true)
     }
 
-    fn remove_hw_watchpoint(
+    async fn remove_hw_watchpoint(
         &mut self,
         addr: u32,
         len: u32,

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -11,6 +11,7 @@ use gdbstub::target::Target;
 use gdbstub::target::TargetError;
 use gdbstub::target::TargetResult;
 use gdbstub_arch::arm::reg::id::ArmCoreRegId;
+use maybe_async::maybe_async;
 
 // Additional GDB extensions
 
@@ -231,8 +232,9 @@ impl SingleThreadBase for Emu {
     }
 }
 
+#[maybe_async]
 impl SingleThreadResume for Emu {
-    fn resume(&mut self, signal: Option<Signal>) -> Result<(), Self::Error> {
+    async fn resume(&mut self, signal: Option<Signal>) -> Result<(), Self::Error> {
         // Upon returning from the `resume` method, the target being debugged should be
         // configured to run according to whatever resume actions the GDB client has
         // specified (as specified by `set_resume_action`, `resume_range_step`,

--- a/examples/armv4t/gdb/mod.rs
+++ b/examples/armv4t/gdb/mod.rs
@@ -232,7 +232,7 @@ impl SingleThreadBase for Emu {
     }
 }
 
-#[maybe_async]
+#[maybe_async(AFIT)]
 impl SingleThreadResume for Emu {
     async fn resume(&mut self, signal: Option<Signal>) -> Result<(), Self::Error> {
         // Upon returning from the `resume` method, the target being debugged should be

--- a/examples/armv4t/main.rs
+++ b/examples/armv4t/main.rs
@@ -167,7 +167,14 @@ fn main() -> DynResult<()> {
 
     let gdb = GdbStub::new(connection);
 
-    match gdb.run_blocking::<EmuGdbEventLoop>(&mut emu) {
+    #[cfg(feature = "sync")]
+    let run = gdb.run_blocking::<EmuGdbEventLoop>(&mut emu);
+    #[cfg(not(feature = "sync"))]
+    let run = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(gdb.run_blocking::<EmuGdbEventLoop>(&mut emu));
+
+    match run {
         Ok(disconnect_reason) => match disconnect_reason {
             DisconnectReason::Disconnect => {
                 println!("GDB client has disconnected. Running to completion...");

--- a/examples/armv4t_multicore/gdb.rs
+++ b/examples/armv4t_multicore/gdb.rs
@@ -218,7 +218,7 @@ impl target::ext::breakpoints::Breakpoints for Emu {
     }
 }
 
-#[maybe_async]
+#[maybe_async(AFIT)]
 impl target::ext::breakpoints::SwBreakpoint for Emu {
     async fn add_sw_breakpoint(
         &mut self,
@@ -243,7 +243,7 @@ impl target::ext::breakpoints::SwBreakpoint for Emu {
     }
 }
 
-#[maybe_async]
+#[maybe_async(AFIT)]
 impl target::ext::breakpoints::HwWatchpoint for Emu {
     async fn add_hw_watchpoint(
         &mut self,

--- a/examples/armv4t_multicore/gdb.rs
+++ b/examples/armv4t_multicore/gdb.rs
@@ -12,6 +12,7 @@ use gdbstub::target::ext::breakpoints::WatchKind;
 use gdbstub::target::Target;
 use gdbstub::target::TargetError;
 use gdbstub::target::TargetResult;
+use maybe_async::maybe_async;
 
 pub fn cpuid_to_tid(id: CpuId) -> Tid {
     match id {
@@ -217,8 +218,9 @@ impl target::ext::breakpoints::Breakpoints for Emu {
     }
 }
 
+#[maybe_async]
 impl target::ext::breakpoints::SwBreakpoint for Emu {
-    fn add_sw_breakpoint(
+    async fn add_sw_breakpoint(
         &mut self,
         addr: u32,
         _kind: gdbstub_arch::arm::ArmBreakpointKind,
@@ -227,7 +229,7 @@ impl target::ext::breakpoints::SwBreakpoint for Emu {
         Ok(true)
     }
 
-    fn remove_sw_breakpoint(
+    async fn remove_sw_breakpoint(
         &mut self,
         addr: u32,
         _kind: gdbstub_arch::arm::ArmBreakpointKind,
@@ -241,8 +243,9 @@ impl target::ext::breakpoints::SwBreakpoint for Emu {
     }
 }
 
+#[maybe_async]
 impl target::ext::breakpoints::HwWatchpoint for Emu {
-    fn add_hw_watchpoint(
+    async fn add_hw_watchpoint(
         &mut self,
         addr: u32,
         _len: u32, // TODO: properly handle `len` parameter
@@ -260,7 +263,7 @@ impl target::ext::breakpoints::HwWatchpoint for Emu {
         Ok(true)
     }
 
-    fn remove_hw_watchpoint(
+    async fn remove_hw_watchpoint(
         &mut self,
         addr: u32,
         _len: u32, // TODO: properly handle `len` parameter

--- a/examples/armv4t_multicore/main.rs
+++ b/examples/armv4t_multicore/main.rs
@@ -169,7 +169,13 @@ fn main() -> DynResult<()> {
 
     let gdb = GdbStub::new(connection);
 
-    match gdb.run_blocking::<EmuGdbEventLoop>(&mut emu) {
+    #[cfg(feature = "sync")]
+    let run = gdb.run_blocking::<EmuGdbEventLoop>(&mut emu);
+    #[cfg(not(feature = "sync"))]
+    let run = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(gdb.run_blocking::<EmuGdbEventLoop>(&mut emu));
+    match run {
         Ok(disconnect_reason) => match disconnect_reason {
             DisconnectReason::Disconnect => {
                 println!("GDB client has disconnected. Running to completion...");

--- a/src/stub/core_impl.rs
+++ b/src/stub/core_impl.rs
@@ -200,7 +200,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             // `handle_X` methods are defined in the `ext` module
             Command::Base(cmd) => self.handle_base(res, target, cmd),
             Command::TargetXml(cmd) => self.handle_target_xml(res, target, cmd),
-            Command::Resume(cmd) => self.handle_stop_resume(res, target, cmd),
+            Command::Resume(cmd) => self.handle_stop_resume(res, target, cmd).await,
             Command::NoAckMode(cmd) => self.handle_no_ack_mode(res, target, cmd),
             Command::XUpcasePacket(cmd) => self.handle_x_upcase_packet(res, target, cmd),
             Command::SingleRegisterAccess(cmd) => {

--- a/src/stub/core_impl.rs
+++ b/src/stub/core_impl.rs
@@ -114,7 +114,7 @@ pub enum HandlerStatus {
     Disconnect(DisconnectReason),
 }
 
-#[maybe_async]
+#[maybe_async(AFIT)]
 impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     pub fn new() -> GdbStubImpl<T, C> {
         GdbStubImpl {

--- a/src/stub/core_impl/breakpoints.rs
+++ b/src/stub/core_impl/breakpoints.rs
@@ -9,7 +9,7 @@ enum CmdKind {
     Remove,
 }
 
-#[maybe_async]
+#[maybe_async(AFIT)]
 impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     #[inline(always)]
     async fn handle_breakpoint_common(

--- a/src/stub/core_impl/breakpoints.rs
+++ b/src/stub/core_impl/breakpoints.rs
@@ -43,8 +43,8 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 let ops = ops.support_hw_breakpoint().unwrap();
                 let bp_kind = bp_kind!();
                 match cmd_kind {
-                    CmdKind::Add => ops.add_hw_breakpoint(addr, bp_kind),
-                    CmdKind::Remove => ops.remove_hw_breakpoint(addr, bp_kind),
+                    CmdKind::Add => ops.add_hw_breakpoint(addr, bp_kind).await,
+                    CmdKind::Remove => ops.remove_hw_breakpoint(addr, bp_kind).await,
                 }
             }
             2 | 3 | 4 if ops.support_hw_watchpoint().is_some() => {
@@ -60,8 +60,8 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     .ok_or(Error::TargetMismatch)?;
                 let ops = ops.support_hw_watchpoint().unwrap();
                 match cmd_kind {
-                    CmdKind::Add => ops.add_hw_watchpoint(addr, len, kind),
-                    CmdKind::Remove => ops.remove_hw_watchpoint(addr, len, kind),
+                    CmdKind::Add => ops.add_hw_watchpoint(addr, len, kind).await,
+                    CmdKind::Remove => ops.remove_hw_watchpoint(addr, len, kind).await,
                 }
             }
             // explicitly handle unguarded variants of known breakpoint types

--- a/src/stub/core_impl/resume.rs
+++ b/src/stub/core_impl/resume.rs
@@ -15,7 +15,7 @@ use crate::target::ext::catch_syscalls::CatchSyscallPosition;
 use maybe_async::maybe_async;
 
 impl<T: Target, C: Connection> GdbStubImpl<T, C> {
-    #[maybe_async]
+    #[maybe_async(AFIT)]
     pub(crate) async fn handle_stop_resume(
         &mut self,
         res: &mut ResponseWriter<'_, C>,
@@ -83,7 +83,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
         self.do_vcont(ops, actions).await
     }
 
-    #[maybe_async]
+    #[maybe_async(AFIT)]
     async fn do_vcont_single_thread(
         ops: &mut dyn crate::target::ext::base::singlethread::SingleThreadResume<
             Arch = T::Arch,
@@ -258,7 +258,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
         ops.resume().map_err(Error::TargetError)
     }
 
-    #[maybe_async]
+    #[maybe_async(AFIT)]
     async fn do_vcont(
         &mut self,
         ops: ResumeOps<'_, T::Arch, T::Error>,

--- a/src/stub/mod.rs
+++ b/src/stub/mod.rs
@@ -155,7 +155,7 @@ impl<'a, T: Target, C: Connection> GdbStub<'a, T, C> {
     /// etc...) you will need to interface with the underlying
     /// [`GdbStubStateMachine`](state_machine::GdbStubStateMachine) API
     /// directly.
-    #[maybe_async]
+    #[maybe_async(AFIT)]
     pub async fn run_blocking<E>(
         self,
         target: &mut T,

--- a/src/stub/state_machine.rs
+++ b/src/stub/state_machine.rs
@@ -209,7 +209,7 @@ impl<'a, T: Target, C: Connection> GdbStubStateMachineInner<'a, state::Idle<T>, 
     }
 
     /// Pass a byte to the GDB stub.
-    #[maybe_async]
+    #[maybe_async(AFIT)]
     pub async fn incoming_data(
         mut self,
         target: &mut T,
@@ -251,7 +251,7 @@ impl<'a, T: Target, C: Connection> GdbStubStateMachineInner<'a, state::Idle<T>, 
 
 /// Methods which can only be called from the
 /// [`GdbStubStateMachine::Running`] state.
-#[maybe_async]
+#[maybe_async(AFIT)]
 impl<'a, T: Target, C: Connection> GdbStubStateMachineInner<'a, state::Running, T, C> {
     /// Report a target stop reason back to GDB.
     pub fn report_stop(

--- a/src/target/ext/base/singlethread.rs
+++ b/src/target/ext/base/singlethread.rs
@@ -4,6 +4,7 @@ use crate::arch::Arch;
 use crate::common::Signal;
 use crate::target::Target;
 use crate::target::TargetResult;
+use maybe_async::maybe_async;
 
 /// Base required debugging operations for single threaded targets.
 pub trait SingleThreadBase: Target {
@@ -71,6 +72,7 @@ pub trait SingleThreadBase: Target {
 }
 
 /// Target extension - support for resuming single threaded targets.
+#[maybe_async]
 pub trait SingleThreadResume: Target {
     /// Resume execution on the target.
     ///
@@ -92,7 +94,7 @@ pub trait SingleThreadResume: Target {
     ///
     /// Omitting PC adjustment may result in unexpected execution flow and/or
     /// breakpoints not appearing to work correctly.
-    fn resume(&mut self, signal: Option<Signal>) -> Result<(), Self::Error>;
+    async fn resume(&mut self, signal: Option<Signal>) -> Result<(), Self::Error>;
 
     /// Support for optimized [single stepping].
     ///

--- a/src/target/ext/base/singlethread.rs
+++ b/src/target/ext/base/singlethread.rs
@@ -72,7 +72,7 @@ pub trait SingleThreadBase: Target {
 }
 
 /// Target extension - support for resuming single threaded targets.
-#[maybe_async]
+#[maybe_async(AFIT)]
 pub trait SingleThreadResume: Target {
     /// Resume execution on the target.
     ///

--- a/src/target/ext/breakpoints.rs
+++ b/src/target/ext/breakpoints.rs
@@ -37,7 +37,7 @@ define_ext!(BreakpointsOps, Breakpoints);
 /// using an _interpreted_ CPU (as opposed to a JIT), the simplest way to
 /// implement "software" breakpoints would be to check the `PC` value after each
 /// CPU cycle, ignoring the specified breakpoint `kind` entirely.
-#[maybe_async]
+#[maybe_async(AFIT)]
 pub trait SwBreakpoint: Target + Breakpoints {
     /// Add a new software breakpoint.
     ///
@@ -69,7 +69,7 @@ define_ext!(SwBreakpointOps, SwBreakpoint);
 /// using an _interpreted_ CPU (as opposed to a JIT), there shouldn't be any
 /// reason to implement this extension (as software breakpoints are likely to be
 /// just-as-fast).
-#[maybe_async]
+#[maybe_async(AFIT)]
 pub trait HwBreakpoint: Target + Breakpoints {
     /// Add a new hardware breakpoint.
     ///
@@ -112,7 +112,7 @@ pub enum WatchKind {
 /// _software watchpoints_, which tend to be excruciatingly slow (as hey are
 /// implemented by single-stepping the system, and reading the watched memory
 /// location after each step).
-#[maybe_async]
+#[maybe_async(AFIT)]
 pub trait HwWatchpoint: Target + Breakpoints {
     /// Add a new hardware watchpoint.
     /// The number of bytes to watch is specified by `len`.

--- a/src/target/ext/breakpoints.rs
+++ b/src/target/ext/breakpoints.rs
@@ -3,6 +3,7 @@
 use crate::arch::Arch;
 use crate::target::Target;
 use crate::target::TargetResult;
+use maybe_async::maybe_async;
 
 /// Target Extension - Set/Remove Breakpoints.
 pub trait Breakpoints: Target {
@@ -36,11 +37,12 @@ define_ext!(BreakpointsOps, Breakpoints);
 /// using an _interpreted_ CPU (as opposed to a JIT), the simplest way to
 /// implement "software" breakpoints would be to check the `PC` value after each
 /// CPU cycle, ignoring the specified breakpoint `kind` entirely.
+#[maybe_async]
 pub trait SwBreakpoint: Target + Breakpoints {
     /// Add a new software breakpoint.
     ///
     /// Return `Ok(false)` if the operation could not be completed.
-    fn add_sw_breakpoint(
+    async fn add_sw_breakpoint(
         &mut self,
         addr: <Self::Arch as Arch>::Usize,
         kind: <Self::Arch as Arch>::BreakpointKind,
@@ -49,7 +51,7 @@ pub trait SwBreakpoint: Target + Breakpoints {
     /// Remove an existing software breakpoint.
     ///
     /// Return `Ok(false)` if the operation could not be completed.
-    fn remove_sw_breakpoint(
+    async fn remove_sw_breakpoint(
         &mut self,
         addr: <Self::Arch as Arch>::Usize,
         kind: <Self::Arch as Arch>::BreakpointKind,

--- a/src/target/ext/breakpoints.rs
+++ b/src/target/ext/breakpoints.rs
@@ -69,11 +69,12 @@ define_ext!(SwBreakpointOps, SwBreakpoint);
 /// using an _interpreted_ CPU (as opposed to a JIT), there shouldn't be any
 /// reason to implement this extension (as software breakpoints are likely to be
 /// just-as-fast).
+#[maybe_async]
 pub trait HwBreakpoint: Target + Breakpoints {
     /// Add a new hardware breakpoint.
     ///
     /// Return `Ok(false)` if the operation could not be completed.
-    fn add_hw_breakpoint(
+    async fn add_hw_breakpoint(
         &mut self,
         addr: <Self::Arch as Arch>::Usize,
         kind: <Self::Arch as Arch>::BreakpointKind,
@@ -82,7 +83,7 @@ pub trait HwBreakpoint: Target + Breakpoints {
     /// Remove an existing hardware breakpoint.
     ///
     /// Return `Ok(false)` if the operation could not be completed.
-    fn remove_hw_breakpoint(
+    async fn remove_hw_breakpoint(
         &mut self,
         addr: <Self::Arch as Arch>::Usize,
         kind: <Self::Arch as Arch>::BreakpointKind,
@@ -111,12 +112,13 @@ pub enum WatchKind {
 /// _software watchpoints_, which tend to be excruciatingly slow (as hey are
 /// implemented by single-stepping the system, and reading the watched memory
 /// location after each step).
+#[maybe_async]
 pub trait HwWatchpoint: Target + Breakpoints {
     /// Add a new hardware watchpoint.
     /// The number of bytes to watch is specified by `len`.
     ///
     /// Return `Ok(false)` if the operation could not be completed.
-    fn add_hw_watchpoint(
+    async fn add_hw_watchpoint(
         &mut self,
         addr: <Self::Arch as Arch>::Usize,
         len: <Self::Arch as Arch>::Usize,
@@ -127,7 +129,7 @@ pub trait HwWatchpoint: Target + Breakpoints {
     /// The number of bytes to watch is specified by `len`.
     ///
     /// Return `Ok(false)` if the operation could not be completed.
-    fn remove_hw_watchpoint(
+    async fn remove_hw_watchpoint(
         &mut self,
         addr: <Self::Arch as Arch>::Usize,
         len: <Self::Arch as Arch>::Usize,


### PR DESCRIPTION
### Description

This PR is exprimental codes that uses `maybe_async` for supporting fully async traits. Adding simple `maybe_async` macro for trait and it generates async code when `is_sync` feature is disabled. For this there is new feature `is_sync` for gdbstub which is default feature. So it doesn't affacts original sync code.

issue: #159 

### API Stability

- [x] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

### Checklist

<!-- CI takes care of a lot of things, but there are some things that have yet to be automated -->

- Documentation
  - [ ] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [ ] (if appropriate) Added feature to "Debugging Features" in README.md
- Validation
  - [ ] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [ ] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below
- _If implementing a new protocol extension IDET_
  - [ ] Included a basic sample implementation in `examples/armv4t`
  - [ ] IDET can be optimized out (confirmed via `./example_no_std/check_size.sh`)
  - [ ] **OR** implementation requires introducing non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [ ] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- Oh, and if you're integrating `gdbstub` in an open-source project, do consider updating the README.md's "Real World Examples" section to link back to your project! -->

### Validation

 - Supports async and no change for sync codegen


