### PR TITLE
Remove "padding" bytes from x86 register packet

### DIFF
--- a/gdbstub_arch/src/x86/reg/core32.rs
+++ b/gdbstub_arch/src/x86/reg/core32.rs
@@ -84,13 +84,10 @@ impl Registers for X86CoreRegs {
 
         // mxcsr
         write_bytes!(&self.mxcsr.to_le_bytes());
-
-        // padding
-        (0..4).for_each(|_| write_byte(None))
     }
 
     fn gdb_deserialize(&mut self, bytes: &[u8]) -> Result<(), ()> {
-        if bytes.len() < 0x138 {
+        if bytes.len() < 0x134 {
             return Err(());
         }
 


### PR DESCRIPTION
### Description

Turns out these were actually Linux-specific registers, namely `orig_eax` for 32-bit and `orig_eax`/`fs_base`/`gs_base` for 64-bit. GDB will gracefully handle a too-short packet but not a too-long one, so removing this padding should make this work for all x86 targets and not just Linux.

Fixes #165

### API Stability

- [x] This PR does not require a breaking API change

### Checklist

- Documentation
  - [ ] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [ ] (if appropriate) Added feature to "Debugging Features" in README.md
- Validation
  - [ ] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [ ] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below
- _If implementing a new protocol extension IDET_
  - [ ] Included a basic sample implementation in `examples/armv4t`
  - [ ] IDET can be optimized out (confirmed via `./example_no_std/check_size.sh`)
  - [ ] **OR** implementation requires introducing non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [x] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

### Validation

Sorry, I've lost my terminal output from when I tested this, but I observed the following with the GDB server implementation at https://github.com/encounter/retrowin32/tree/gdb-stub (32-bit Windows x86)

* no change + `set osabi GNU/Linux`: everything fine
* no change + `set osabi none`: GDB crashes with `Remote 'g' packet reply is too long`
* this change + `set osabi GNU/Linux`: everything fine
* this change + `set osabi none`: everything fine