### PR TITLE
MultiThreadSchedulerLocking support #178

### DIFF
--- a/examples/armv4t_multicore/gdb.rs
+++ b/examples/armv4t_multicore/gdb.rs
@@ -185,6 +185,13 @@ impl MultiThreadResume for Emu {
 
         Ok(())
     }
+
+    #[inline(always)]
+    fn support_scheduler_locking(
+        &mut self,
+    ) -> Option<target::ext::base::multithread::MultiThreadSchedulerLockingOps<'_, Self>> {
+        Some(self)
+    }
 }
 
 impl target::ext::base::multithread::MultiThreadSingleStep for Emu {
@@ -291,6 +298,15 @@ impl target::ext::thread_extra_info::ThreadExtraInfo for Emu {
         let info = format!("CPU {:?}", cpu_id);
 
         Ok(copy_to_buf(info.as_bytes(), buf))
+    }
+}
+
+impl target::ext::base::multithread::MultiThreadSchedulerLocking for Emu {
+    fn set_resume_action_scheduler_lock(&mut self) -> Result<(), Self::Error> {
+        for id in [CpuId::Cpu, CpuId::Cop] {
+            self.exec_mode.entry(id).or_insert(ExecMode::Stop);
+        }
+        Ok(())
     }
 }
 

--- a/src/stub/error.rs
+++ b/src/stub/error.rs
@@ -43,6 +43,7 @@ pub(crate) enum InternalError<T, C> {
     MissingCurrentActivePidImpl,
     TracepointFeatureUnimplemented(u8),
     TracepointUnsupportedSourceEnumeration,
+    MissingMultiThreadSchedulerLocking,
 
     // Internal - A non-fatal error occurred (with errno-style error code)
     //
@@ -147,6 +148,7 @@ where
             MissingCurrentActivePidImpl => write!(f, "GDB client attempted to attach to a new process, but the target has not implemented support for `ExtendedMode::support_current_active_pid`"),
             TracepointFeatureUnimplemented(feat) => write!(f, "GDB client sent us a tracepoint packet using feature {}, but `gdbstub` doesn't implement it. If this is something you require, please file an issue at https://github.com/daniel5151/gdbstub/issues", *feat as char),
             TracepointUnsupportedSourceEnumeration => write!(f, "The target doesn't support the gdbstub TracepointSource extension, but attempted to transition to enumerating tracepoint sources"),
+            MissingMultiThreadSchedulerLocking => write!(f, "GDB requested Scheduler Locking, but the Target does not implement the `MultiThreadSchedulerLocking` IDET"),
 
             NonFatalError(_) => write!(f, "Internal non-fatal error. You should never see this! Please file an issue if you do!"),
         }


### PR DESCRIPTION
### Description

This PR implements a new Protocol Extension IDET: `MultiThreadSchedulerLocking`.

Closes #178

#### Changes

- Introduced `MultiThreadSchedulerLocking` IDET under `MultiThreadResume`.
- Updated `do_vcont_multi_thread` to track the presence of wildcard/default continue actions.
- If no wildcard continue is found (indicating GDB expects scheduler locking), `gdbstub` now invokes `set_resume_action_scheduler_lock`.
- If the target does not implement this IDET but GDB requests locking, `gdbstub` returns a fatal `PacketUnexpected` error to avoid silent race conditions (as discussed in issue #178).
- Updated the `armv4t_multicore` example to demonstrate a working scheduler-locking implementation.

### API Stability

- \[x\] This PR does not require a breaking API change.

### Checklist

- Documentation
	- \[x\] Ensured any public-facing `rustdoc` formatting looks good
- Validation
	- \[x\] Included output of running `examples/armv4t_multicore`
	- \[x\] Included output of running `./example_no_std/check_size.sh`
- *If implementing a new protocol extension IDET*
	- \[x\] Included a basic sample implementation in `examples/armv4t_multicore`
	- \[x\] IDET can be optimized out (confirmed via `./example_no_std/check_size.sh`)

---

### Validation

#### 1\. Functional Validation (`armv4t_multicore`)

Tested with GDB 15.0. Verified that when `set scheduler-locking on` is used, only the selected thread steps, while the other remain frozen at its last PC.

<details> <summary>GDB Session Output</summary>

Code snippet

```
0x55550000 in ?? ()
(gdb) info threads
  Id   Target Id            Frame
* 1    Thread 1.1 (CPU Cpu) 0x55550000 in ?? ()
  2    Thread 1.2 (CPU Cop) 0x55550000 in ?? ()
(gdb) b*0x55550000+0x30
Breakpoint 1 at 0x55550030
(gdb) c
Continuing.

Thread 1 hit Breakpoint 1, 0x55550030 in ?? ()
(gdb) info threads
  Id   Target Id            Frame
* 1    Thread 1.1 (CPU Cpu) 0x55550030 in ?? ()
  2    Thread 1.2 (CPU Cop) 0x55550044 in ?? ()
(gdb) set scheduler-locking on
(gdb) x/10i $pc
=> 0x55550030:  ldr     r3, [r11, #-16]
   0x55550034:  cmp     r3, #0
   0x55550038:  beq     0x55550030
   0x5555003c:  ldr     r3, [r11, #-8]
   0x55550040:  b       0x55550080
   0x55550044:  mov     r3, #0
   0x55550048:  str     r3, [r11, #-12]
   0x5555004c:  b       0x55550068
   0x55550050:  ldr     r3, [r11, #-8]
   0x55550054:  add     r3, r3, #1
(gdb) b*0x55550038
Breakpoint 3 at 0x55550038
(gdb) c
Continuing.

Thread 1 hit Breakpoint 3, 0x55550038 in ?? ()
(gdb) info threads
  Id   Target Id            Frame
* 1    Thread 1.1 (CPU Cpu) 0x55550038 in ?? ()
  2    Thread 1.2 (CPU Cop) 0x55550044 in ?? ()
```

</details>

#### 2\. Binary Size Check (`./example_no_std/check_size.sh`)

| Section | master | fix/resume\_multi | Diff |
| --- | --- | --- | --- |
| .text | 14128 | 14156 | **+28 bytes** |
| Total | 18586 | 18614 | **+28 bytes** |

<details> <summary>check_size Output</summary>

before:

```
File  .text    Size          Crate Name
2.1%  62.1%  8.6KiB      [Unknown] main
0.2%   5.4%    764B        gdbstub gdbstub::stub::state_machine::GdbStubStateMachineInner<gdbstub::stub::state_machine:...
0.1%   2.4%    336B        gdbstub gdbstub::protocol::commands::breakpoint::BasicBreakpoint::from_slice
0.1%   2.3%    320B        gdbstub <gdbstub::protocol::common::thread_id::ThreadId as core::convert::TryFrom<&[u8]>>::t...
0.1%   2.2%    308B        gdbstub gdbstub::protocol::common::hex::decode_hex_buf
0.1%   2.0%    284B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write
0.1%   1.7%    236B        gdbstub gdbstub::stub::core_impl::resume::<impl gdbstub::stub::core_impl::GdbStubImpl<T,C>>:...
0.1%   1.6%    232B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_specific_thread_id
0.1%   1.5%    216B           core core::iter::traits::iterator::Iterator::nth
0.1%   1.5%    216B           core core::iter::traits::iterator::Iterator::nth
0.0%   1.1%    160B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   1.1%    156B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   1.1%    156B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   1.1%    156B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   1.1%    152B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::inner_write
0.0%   1.0%    144B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   1.0%    140B        gdbstub <gdbstub::protocol::common::thread_id::IdKind as core::convert::TryFrom<&[u8]>>::try...
0.0%   0.9%    132B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::flush
0.0%   0.9%    128B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_hex
0.0%   0.8%    116B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.8%    108B           core <core::iter::adapters::skip::Skip<I> as core::iter::traits::iterator::Iterator>::next
0.0%   0.7%    104B           core <core::slice::iter::SplitMut<T,P> as core::iter::traits::iterator::Iterator>::next
0.0%   0.5%     76B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.5%     76B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.5%     76B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.5%     68B   gdbstub_arch <gdbstub_arch::arm::reg::arm_core::ArmCoreRegs as gdbstub::arch::Registers>::gdb_des...
0.0%   0.4%     52B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.4%     52B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.4%     52B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.4%     52B      [Unknown] _start
0.0%   0.3%     48B  gdbstub_nostd gdbstub_nostd::print_str::print_str
0.0%   0.1%     20B      [Unknown] call_weak_fn
0.0%   0.1%     12B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>...
3.3% 100.0% 13.8KiB                .text section size, the file size is 413.5KiB
target/release/gdbstub-nostd  :
section               size     addr
.interp                 27      568
.note.gnu.build-id      36      596
.note.ABI-tag           32      632
.gnu.hash               28      664
.dynsym                432      696
.dynstr                198     1128
.gnu.version            36     1326
.gnu.version_r          48     1368
.rela.dyn              192     1416
.rela.plt              312     1608
.init                   24     1920
.plt                   240     1952
.text                14128     2240
.fini                   20    16368
.rodata                670    16388
.eh_frame_hdr          300    17060
.eh_frame             1072    17360
.init_array              8   130384
.fini_array              8   130392
.dynamic               496   130400
.got                   176   130896
.data                    8   131072
.bss                     8   131080
.comment                87        0
Total                18586
```

after:

```
File  .text    Size          Crate Name
2.1%  62.2%  8.6KiB      [Unknown] main
0.2%   5.4%    764B        gdbstub gdbstub::stub::state_machine::GdbStubStateMachineInner<gdbstub::stub::state_machine:...
0.1%   2.4%    336B        gdbstub gdbstub::protocol::commands::breakpoint::BasicBreakpoint::from_slice
0.1%   2.3%    320B        gdbstub <gdbstub::protocol::common::thread_id::ThreadId as core::convert::TryFrom<&[u8]>>::t...
0.1%   2.2%    308B        gdbstub gdbstub::protocol::common::hex::decode_hex_buf
0.1%   2.0%    284B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write
0.1%   1.7%    236B        gdbstub gdbstub::stub::core_impl::resume::<impl gdbstub::stub::core_impl::GdbStubImpl<T,C>>:...
0.1%   1.6%    232B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_specific_thread_id
0.1%   1.5%    216B           core core::iter::traits::iterator::Iterator::nth
0.1%   1.5%    216B           core core::iter::traits::iterator::Iterator::nth
0.0%   1.1%    160B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   1.1%    156B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   1.1%    156B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   1.1%    156B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   1.1%    152B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::inner_write
0.0%   1.0%    144B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   1.0%    140B        gdbstub <gdbstub::protocol::common::thread_id::IdKind as core::convert::TryFrom<&[u8]>>::try...
0.0%   0.9%    132B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::flush
0.0%   0.9%    128B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_hex
0.0%   0.8%    116B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.8%    108B           core <core::iter::adapters::skip::Skip<I> as core::iter::traits::iterator::Iterator>::next
0.0%   0.7%    104B           core <core::slice::iter::SplitMut<T,P> as core::iter::traits::iterator::Iterator>::next
0.0%   0.5%     76B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.5%     76B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.5%     76B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.5%     68B   gdbstub_arch <gdbstub_arch::arm::reg::arm_core::ArmCoreRegs as gdbstub::arch::Registers>::gdb_des...
0.0%   0.4%     52B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.4%     52B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.4%     52B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiTh...
0.0%   0.4%     52B      [Unknown] _start
0.0%   0.3%     48B  gdbstub_nostd gdbstub_nostd::print_str::print_str
0.0%   0.1%     20B      [Unknown] call_weak_fn
0.0%   0.1%     12B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>...
3.3% 100.0% 13.8KiB                .text section size, the file size is 414.2KiB
target/release/gdbstub-nostd  :
section               size     addr
.interp                 27      568
.note.gnu.build-id      36      596
.note.ABI-tag           32      632
.gnu.hash               28      664
.dynsym                432      696
.dynstr                198     1128
.gnu.version            36     1326
.gnu.version_r          48     1368
.rela.dyn              192     1416
.rela.plt              312     1608
.init                   24     1920
.plt                   240     1952
.text                14156     2240
.fini                   20    16396
.rodata                670    16416
.eh_frame_hdr          300    17088
.eh_frame             1072    17392
.init_array              8   130384
.fini_array              8   130392
.dynamic               496   130400
.got                   176   130896
.data                    8   131072
.bss                     8   131080
.comment                87        0
Total                18614
```

</details>