### PR TITLE
Rework scheduler locking

### DIFF
--- a/docs/transition_guide.md
+++ b/docs/transition_guide.md
@@ -6,6 +6,14 @@ This document does _not_ discuss any new features that might have been added bet
 
 > _Note:_ after reading through this doc, you may also find it helpful to refer to the in-tree `armv4t` and `armv4t_multicore` examples when transitioning between versions.
 
+## `0.7` -> `0.8`
+
+#### Changes to multi-threaded resume behavior
+
+Previously, if a thread had no `resume_set_action_XXX` methods called on it, the default was to assume `set_resume_action_continue` was called on it.  Now, if a thread has no `set_resume_action_XXX` methods called on it, it should remain stopped.
+
+This new behavior obsoletes the `MultiThreadSchedulerLocking` trait, which has been removed.  If a stub is unable to handle executing a single thread and keeping all others locked, it should return an error in the `resume` method.
+
 ## `0.6` -> `0.7`
 
 `0.7` is a fairly minimal "cleanup" release, landing a collection of small breaking changes that collectively improve various ergonomic issues in `gdbstub`'s API.

--- a/example_no_std/src/gdb.rs
+++ b/example_no_std/src/gdb.rs
@@ -149,7 +149,7 @@ impl MultiThreadResume for DummyTarget {
     #[inline(never)]
     fn set_resume_action_continue(
         &mut self,
-        _tid: Tid,
+        _tid: Option<Tid>,
         _signal: Option<Signal>,
     ) -> Result<(), Self::Error> {
         print_str("> set_resume_action_continue");

--- a/examples/armv4t_multicore/emu.rs
+++ b/examples/armv4t_multicore/emu.rs
@@ -36,11 +36,10 @@ pub enum Event {
     WatchRead(u32),
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum ExecMode {
     Step,
     Continue,
-    Stop,
 }
 
 /// incredibly barebones armv4t-based emulator
@@ -49,6 +48,7 @@ pub struct Emu {
     pub(crate) cop: Cpu,
     pub(crate) mem: ExampleMem,
 
+    // If a CpuId is not in this, it is presumed "stopped".
     pub(crate) exec_mode: HashMap<CpuId, ExecMode>,
 
     pub(crate) watchpoints: Vec<u32>,
@@ -189,7 +189,7 @@ impl Emu {
         let mut evt = None;
 
         for id in [CpuId::Cpu, CpuId::Cop].iter().copied() {
-            if matches!(self.exec_mode.get(&id), Some(ExecMode::Stop)) {
+            if !self.exec_mode.contains_key(&id) {
                 continue;
             }
 
@@ -207,8 +207,7 @@ impl Emu {
         // The underlying armv4t_multicore emulator cycles all cores in lock-step.
         //
         // Inside `self.step()`, we iterate through all cores and only invoke
-        // `step_core` if that core's `ExecMode` is not `Stop`.
-
+        // `step_core` if that core has an `ExecMode`.
         let should_single_step = self.exec_mode.values().any(|mode| mode == &ExecMode::Step);
 
         match should_single_step {

--- a/examples/armv4t_multicore/gdb.rs
+++ b/examples/armv4t_multicore/gdb.rs
@@ -160,6 +160,10 @@ impl MultiThreadResume for Emu {
     }
 
     fn clear_resume_actions(&mut self) -> Result<(), Self::Error> {
+        // We're in all-stop mode (since `gdbstub` doesn't support non-stop yet), so
+        // the fact that we're processing commands from the GDB client means that all
+        // threads have already stopped, which is represented by the thread being
+        // absent from the `exec_mode` map.
         self.exec_mode.clear();
         Ok(())
     }
@@ -173,24 +177,26 @@ impl MultiThreadResume for Emu {
 
     fn set_resume_action_continue(
         &mut self,
-        tid: Tid,
+        tid: Option<Tid>,
         signal: Option<Signal>,
     ) -> Result<(), Self::Error> {
         if signal.is_some() {
             return Err("no support for continuing with signal");
         }
 
-        self.exec_mode
-            .insert(tid_to_cpuid(tid)?, ExecMode::Continue);
+        match tid {
+            None => {
+                for id in [CpuId::Cpu, CpuId::Cop] {
+                    self.exec_mode.entry(id).or_insert(ExecMode::Continue);
+                }
+            }
+            Some(tid) => {
+                self.exec_mode
+                    .insert(tid_to_cpuid(tid)?, ExecMode::Continue);
+            }
+        }
 
         Ok(())
-    }
-
-    #[inline(always)]
-    fn support_scheduler_locking(
-        &mut self,
-    ) -> Option<target::ext::base::multithread::MultiThreadSchedulerLockingOps<'_, Self>> {
-        Some(self)
     }
 }
 
@@ -298,15 +304,6 @@ impl target::ext::thread_extra_info::ThreadExtraInfo for Emu {
         let info = format!("CPU {:?}", cpu_id);
 
         Ok(copy_to_buf(info.as_bytes(), buf))
-    }
-}
-
-impl target::ext::base::multithread::MultiThreadSchedulerLocking for Emu {
-    fn set_resume_action_scheduler_lock(&mut self) -> Result<(), Self::Error> {
-        for id in [CpuId::Cpu, CpuId::Cop] {
-            self.exec_mode.entry(id).or_insert(ExecMode::Stop);
-        }
-        Ok(())
     }
 }
 

--- a/src/protocol/commands/_vCont.rs
+++ b/src/protocol/commands/_vCont.rs
@@ -25,7 +25,8 @@ impl<'a> ParseCommand<'a> for vCont<'a> {
         let body = buf.into_body();
         match body as &[u8] {
             b"?" => Some(vCont::Query),
-            _ => Some(vCont::Actions(Actions::new_from_buf(body))),
+            [b';', rest @ ..] => Some(vCont::Actions(Actions::new_from_buf(rest))),
+            _ => None
         }
     }
 }
@@ -52,7 +53,7 @@ impl<'a> Actions<'a> {
         Actions::FixedCont(tid)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = Option<VContAction<'a>>> + '_ {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = Option<VContAction<'a>>> + '_ {
         match self {
             Actions::Buf(x) => EitherIter::A(x.iter()),
             Actions::FixedStep(x) => EitherIter::B(core::iter::once(Some(VContAction {
@@ -67,12 +68,16 @@ impl<'a> Actions<'a> {
     }
 }
 
+// This does not include the leading semicolon of the first action.
 #[derive(Debug)]
 pub struct ActionsBuf<'a>(&'a [u8]);
 
 impl<'a> ActionsBuf<'a> {
-    fn iter(&self) -> impl Iterator<Item = Option<VContAction<'a>>> + '_ {
-        self.0.split(|b| *b == b';').skip(1).map(|act| {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = Option<VContAction<'a>>> + '_ {
+        // `ActionsBuf` doesn't include the leading semicolon in the first
+        // action, so we don't need to worry about the first element of the
+        // split being empty.
+        self.0.split(|b| *b == b';').map(|act| {
             let mut s = act.split(|b| *b == b':');
             let kind = s.next()?;
             let thread = match s.next() {
@@ -109,7 +114,7 @@ impl<'a> ActionsBuf<'a> {
                     //
                     // As a workaround for these weird GDB clients, `gdbstub`
                     // takes the pragmatic approach of treating this request as
-                    // though it the client requested _all_ threads to be
+                    // though the client requested _all_ threads to be
                     // resumed.
                     //
                     // If this turns out to be wrong... `gdbstub` can explore a
@@ -191,6 +196,20 @@ where
         match self {
             EitherIter::A(a) => a.next(),
             EitherIter::B(b) => b.next(),
+        }
+    }
+}
+
+impl<A, B, T> DoubleEndedIterator for EitherIter<A, B>
+where
+    A: DoubleEndedIterator<Item = T>,
+    B: DoubleEndedIterator<Item = T>,
+{
+    #[inline(always)]
+    fn next_back(&mut self) -> Option<T> {
+        match self {
+            EitherIter::A(a) => a.next_back(),
+            EitherIter::B(b) => b.next_back(),
         }
     }
 }

--- a/src/stub/core_impl/resume.rs
+++ b/src/stub/core_impl/resume.rs
@@ -89,6 +89,12 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     ) -> Result<(), Error<T::Error, C::Error>> {
         use crate::protocol::commands::_vCont::VContKind;
 
+        // In the single-threaded scenario, we don't reverse the actions like we
+        // do in the multi-threaded: there are only two scenarios we concern
+        // ourselves with: 1 action, or 2 actions where the second is a
+        // continue action (sometimes GDB sends a packet of the form
+        // `vCont;s:foo;c`, even in single-threaded scenarios). We ignore the
+        // continue action, since there aren't any other threads to continue.
         let mut actions = actions.iter();
         let first_action = actions
             .next()
@@ -166,14 +172,16 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     ) -> Result<(), Error<T::Error, C::Error>> {
         ops.clear_resume_actions().map_err(Error::TargetError)?;
 
-        // Track whether the packet contains a wildcard/default continue action
-        // (e.g., `c` or `c:-1`).
+        // NOTE: We iterate through these actions in reverse order, which corresponds to
+        // a right-to-left ordering of the actions specified in the vCont packet. This
+        // is intentionally the opposite of the left-to-right order specified by
+        // the vCont packet documentation.
         //
-        // Presence of this action implies "Scheduler Locking" is OFF.
-        // Absence implies "Scheduler Locking" is ON.
-        let mut has_wildcard_continue = false;
-
-        for action in actions.iter() {
+        // This is to simplify target implementations: each `set_resume_action_XXX`
+        // callback can overwrite the current state, instead of having to keep track of
+        // each thread specified by previous actions and making sure they don't get
+        // overwritten.
+        for action in actions.iter().rev() {
             use crate::protocol::commands::_vCont::VContKind;
 
             let action = action.ok_or(Error::PacketParse(
@@ -187,17 +195,15 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                         _ => None,
                     };
 
-                    match action.thread.map(|thread| thread.tid) {
-                        // An action with no thread-id matches all threads
-                        None | Some(SpecificIdKind::All) => {
-                            // Target API contract specifies that the default
-                            // resume action for all threads is continue.
-                            has_wildcard_continue = true;
-                        }
-                        Some(SpecificIdKind::WithId(tid)) => ops
-                            .set_resume_action_continue(tid, signal)
-                            .map_err(Error::TargetError)?,
-                    }
+                    let tid = match action.thread.map(|thread| thread.tid) {
+                        // An action with no thread-id matches all threads, which is passed to
+                        // `set_resume_action_continue` as `None`.
+                        None | Some(SpecificIdKind::All) => None,
+                        Some(SpecificIdKind::WithId(tid)) => Some(tid),
+                    };
+
+                    ops.set_resume_action_continue(tid, signal)
+                        .map_err(Error::TargetError)?;
                 }
                 VContKind::Step | VContKind::StepWithSig(_)
                     if ops.support_single_step().is_some() =>
@@ -257,15 +263,6 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                     return Err(Error::PacketUnexpected);
                 }
             }
-        }
-
-        if !has_wildcard_continue {
-            let Some(locking_ops) = ops.support_scheduler_locking() else {
-                return Err(Error::MissingMultiThreadSchedulerLocking);
-            };
-            locking_ops
-                .set_resume_action_scheduler_lock()
-                .map_err(Error::TargetError)?;
         }
 
         ops.resume().map_err(Error::TargetError)

--- a/src/stub/error.rs
+++ b/src/stub/error.rs
@@ -43,7 +43,6 @@ pub(crate) enum InternalError<T, C> {
     MissingCurrentActivePidImpl,
     TracepointFeatureUnimplemented(u8),
     TracepointUnsupportedSourceEnumeration,
-    MissingMultiThreadSchedulerLocking,
     MissingToRawId,
 
     // Internal - A non-fatal error occurred (with errno-style error code)
@@ -149,7 +148,6 @@ where
             MissingCurrentActivePidImpl => write!(f, "GDB client attempted to attach to a new process, but the target has not implemented support for `ExtendedMode::support_current_active_pid`"),
             TracepointFeatureUnimplemented(feat) => write!(f, "GDB client sent us a tracepoint packet using feature {}, but `gdbstub` doesn't implement it. If this is something you require, please file an issue at https://github.com/daniel5151/gdbstub/issues", *feat as char),
             TracepointUnsupportedSourceEnumeration => write!(f, "The target doesn't support the gdbstub TracepointSource extension, but attempted to transition to enumerating tracepoint sources"),
-            MissingMultiThreadSchedulerLocking => write!(f, "GDB requested Scheduler Locking, but the Target does not implement the `MultiThreadSchedulerLocking` IDET"),
             MissingToRawId => write!(f, "A RegId was used with an API that requires raw register IDs to be available (e.g. `report_stop_with_regs`) but returned `None` from `to_raw_id()`"),
 
             NonFatalError(_) => write!(f, "Internal non-fatal error. You should never see this! Please file an issue if you do!"),

--- a/src/target/ext/base/multithread.rs
+++ b/src/target/ext/base/multithread.rs
@@ -51,9 +51,9 @@ pub trait MultiThreadBase: Target {
     /// to indicate that memory starting at `start_addr + n` cannot be
     /// accessed.
     ///
-    /// Implemenations may also return an appropriate non-fatal error if the
+    /// Implementations may also return an appropriate non-fatal error if the
     /// requested address range could not be accessed (e.g: due to MMU
-    /// protection, unhanded page fault, etc...).
+    /// protection, unhandled page fault, etc...).
     ///
     /// Implementations must guarantee that the returned number is less than or
     /// equal `data.len()`.
@@ -67,7 +67,7 @@ pub trait MultiThreadBase: Target {
     /// Write bytes to the specified address range.
     ///
     /// If the requested address range could not be accessed (e.g: due to
-    /// MMU protection, unhanded page fault, etc...), an appropriate non-fatal
+    /// MMU protection, unhandled page fault, etc...), an appropriate non-fatal
     /// error should be returned.
     fn write_addrs(
         &mut self,
@@ -132,21 +132,21 @@ pub trait MultiThreadResume: Target {
     /// Upon returning from the `resume` method, the target being debugged
     /// should be configured to run according to whatever resume actions the
     /// GDB client had specified using any of the `set_resume_action_XXX`
-    /// methods.
+    /// methods. Any thread that wasn't explicitly specified in a
+    /// `set_resume_action_XXX` method should remain in the same state.
+    /// Currently, because `gdbstub` only supports all-stop mode, the only state
+    /// threads will be in while processing `resume` is stopped, so any threads
+    /// not specified in `set_resume_action_XXX` should remain stopped.
     ///
-    /// # Default Resume Behavior
+    /// If a thread is specified in multiple `set_resume_action_XXX` methods,
+    /// **the last call** takes precedence. A common situation when this happens
+    /// is if a `set_resume_action_XXX` method specifies all threads, and then
+    /// a following call to `set_resume_action_XXX` method specifies one
+    /// specific thread. The second call to the specific thread takes
+    /// precedence.
     ///
-    /// By default, any thread that wasn't explicitly resumed by a
-    /// `set_resume_action_XXX` method should be resumed as though it was
-    /// resumed with `set_resume_action_continue`.
-    ///
-    /// **However**, if [`support_scheduler_locking`] is implemented and
-    /// [`set_resume_action_scheduler_lock`] has been called for the current
-    /// resume cycle, this default changes: **unmentioned threads must remain
-    /// stopped.**
-    ///
-    /// [`support_scheduler_locking`]: Self::support_scheduler_locking
-    /// [`set_resume_action_scheduler_lock`]: MultiThreadSchedulerLocking::set_resume_action_scheduler_lock
+    /// Implementations may assume that at least one `set_resume_action_XXX` was
+    /// called between `clear_resume_actions` and `resume`.
     ///
     /// # Protocol Extensions
     ///
@@ -158,19 +158,25 @@ pub trait MultiThreadResume: Target {
     /// ----------------------------|------------------------------
     /// Optimized [Single Stepping] | See [`support_single_step()`]
     /// Optimized [Range Stepping]  | See [`support_range_step()`]
-    /// [Scheduler Locking]         | See [`support_scheduler_locking()`]
     /// "Stop"                      | Used in "Non-Stop" mode \*
     ///
     /// \* "Non-Stop" mode is currently unimplemented in `gdbstub`
     ///
     /// [Single stepping]: https://sourceware.org/gdb/current/onlinedocs/gdb/Continuing-and-Stepping.html#index-stepi
     /// [Range Stepping]: https://sourceware.org/gdb/current/onlinedocs/gdb/Continuing-and-Stepping.html#range-stepping
-    /// [Scheduler Locking]: https://sourceware.org/gdb/current/onlinedocs/gdb#index-scheduler-locking-mode
     /// [`support_single_step()`]: Self::support_single_step
     /// [`support_range_step()`]: Self::support_range_step
-    /// [`support_scheduler_locking()`]: Self::support_scheduler_locking
     ///
     /// # Additional Considerations
+    ///
+    /// ### Scheduler locking
+    ///
+    /// The GDB client may send a resume message that only continues one thread
+    /// and keeps all other threads in a halted state. Not all OS schedulers are
+    /// able to handle this, so `resume` should return an error if it's ever
+    /// asked to do something that the stub is unable to support. More details
+    /// can be found in the `set scheduler-locking mode` section of the
+    /// [GDB documentation](https://sourceware.org/gdb/current/onlinedocs/gdb#index-scheduler-locking-mode)
     ///
     /// ### Adjusting PC after a breakpoint is hit
     ///
@@ -202,6 +208,8 @@ pub trait MultiThreadResume: Target {
 
     /// Continue the specified thread.
     ///
+    /// If no thread is specified, continue all threads.
+    ///
     /// See the [`resume`](Self::resume) docs for information on when this is
     /// called.
     ///
@@ -209,7 +217,7 @@ pub trait MultiThreadResume: Target {
     /// target.
     fn set_resume_action_continue(
         &mut self,
-        tid: Tid,
+        tid: Option<Tid>,
         signal: Option<Signal>,
     ) -> Result<(), Self::Error>;
 
@@ -246,14 +254,6 @@ pub trait MultiThreadResume: Target {
     fn support_reverse_cont(
         &mut self,
     ) -> Option<super::reverse_exec::ReverseContOps<'_, Tid, Self>> {
-        None
-    }
-
-    /// Support for [scheduler locking].
-    ///
-    /// [scheduler locking]: https://sourceware.org/gdb/current/onlinedocs/gdb#index-scheduler-locking-mode
-    #[inline(always)]
-    fn support_scheduler_locking(&mut self) -> Option<MultiThreadSchedulerLockingOps<'_, Self>> {
         None
     }
 }
@@ -313,26 +313,3 @@ pub trait MultiThreadRangeStepping: Target + MultiThreadResume {
 }
 
 define_ext!(MultiThreadRangeSteppingOps, MultiThreadRangeStepping);
-
-/// Target Extension - support for GDB's "Scheduler Locking" mode.
-/// See [`MultiThreadResume::support_scheduler_locking`].
-pub trait MultiThreadSchedulerLocking: Target + MultiThreadResume {
-    /// Configure the target to enable "Scheduler Locking" for the upcoming
-    /// resume.
-    ///
-    /// This method is invoked when the GDB client expects only a specific set
-    /// of threads to run, while all other threads remain frozen. This behavior
-    /// is typically toggled in GDB using the `set scheduler-locking on`
-    /// command.
-    ///
-    /// When this method is called, the implementation must ensure that any
-    /// threads not explicitly resumed via previous `set_resume_action_...`
-    /// calls **remain stopped**.
-    ///
-    /// This prevents any "implicit continue" behavior for unmentioned threads,
-    /// satisfying GDB's expectation that only the designated threads will
-    /// advance during the next resume.
-    fn set_resume_action_scheduler_lock(&mut self) -> Result<(), Self::Error>;
-}
-
-define_ext!(MultiThreadSchedulerLockingOps, MultiThreadSchedulerLocking);


### PR DESCRIPTION
### Description

This lays down some groundwork for v0.8, where the primary new feature will be multiprocess support, which will be similar to multithreaded support.

As discussed on the multiprocess github support issue, there's a simpler way to support the scheduler locking behavior that we plan to use for multiprocess targets, and since we're breaking the API anyways with v0.8, it's a decent time to implement it for multithreaded targets as well.

While I was in the area, I fixed some typos I noticed when I had copied most of these during local development of multiprocess-extensions.

This PR does NOT do anything about the proposed changes in this comment regarding the order in which we parse resume actions laid out here: https://github.com/daniel5151/gdbstub/issues/124#issuecomment-4374028370.

### API Stability

- [ ] This PR does not require a breaking API change

<!-- If it does require making a breaking API change, please elaborate why -->

This is part of the initial transition to v0.8.  Justification for breaking the API is provided here: https://github.com/daniel5151/gdbstub/issues/124#issuecomment-4375276483

Another quick API breakage that might make sense to throw in this PR too is changing the name of `is_thread_alive` to `check_thread_alive` (available for bikeshedding), which removes the need for the `#[allow(clippy::wrong_self_convention)]`.

### Checklist

<!-- CI takes care of a lot of things, but there are some things that have yet to be automated -->

- Documentation
  - [ ] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [N/A] (if appropriate) Added feature to "Debugging Features" in README.md
- Validation
  - [ ] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below <see below>
  - [x] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below
- _If implementing a new protocol extension IDET_
  - [N/A] Included a basic sample implementation in `examples/armv4t`
  - [N/A] IDET can be optimized out (confirmed via `./example_no_std/check_size.sh`)
  - [N/A] **OR** implementation requires introducing non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [N/A] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

<!-- Oh, and if you're integrating `gdbstub` in an open-source project, do consider updating the README.md's "Real World Examples" section to link back to your project! -->

### Validation

I tested a lot of different scenarios in armv4t for both `dev/0.8` and this PR.  I'm taking a "ask forgiveness, not permission" here approach for the logs; there's a lot of logs to generate (which also means a lot of logs for you to sift through), so for now I'll list all the scenarios I tested, and I can post logs on request (or test alternative scenarios).

* scheduler-lock off, `continue` from thread 1
* scheduler-lock off, `continue` from thread 2
* scheduler-lock off, `nexti 10` from thread 1
* scheduler-lock off, `nexti 80` from thread 2 (which led to the discovery of #196)
* scheduler-lock on, `continue` from thread 1 (program hangs; I needed to ctrl+C, switch to thread 2, `continue`, ctrl+C, switch to thread 1, `continue`, which makes sense given the behavior of `scheduler-lock` and the example binary)
* scheduler-lock on, `continue` from thread 2 (program hangs; ctrl+C'ing and switching between threads doesn't actually seem to ever resolve.  When I have more time I'd like  dig into the example binary to figure out why that might be and if there's a deeper underlying bug, but this is the behavior exhibited by `dev/0.8`, so for the purposes of this PR I stopped investigating there)
* scheduler-lock on, `nexti 10` from thread 1
* scheduler-lock on, `nexti 80` from thread 2

Let me know if you would like logs for any (...or all) of these, or if there are any situations I didn't consider.

<details>
<summary>Before/After `./example_no_std/check_size.sh` output</summary>

### Before

```
File  .text    Size          Crate Name
2.5%  68.8% 10.4KiB      [Unknown] main
0.2%   6.3%    975B        gdbstub gdbstub::stub::state_machine::GdbStubStateMachineInner<gdbstub::stub::state_machine::state::Running,T,C>::report_stop
0.1%   2.4%    372B        gdbstub gdbstub::protocol::commands::breakpoint::BasicBreakpoint::from_slice
0.1%   1.9%    295B        gdbstub <gdbstub::protocol::common::thread_id::ThreadId as core::convert::TryFrom<&[u8]>>::try_from
0.1%   1.8%    275B        gdbstub gdbstub::protocol::common::hex::decode_hex_buf
0.1%   1.4%    222B        gdbstub gdbstub::stub::core_impl::resume::<impl gdbstub::stub::core_impl::GdbStubImpl<T,C>>::write_stop_common
0.1%   1.4%    221B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write
0.0%   1.3%    204B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_specific_thread_id
0.0%   0.9%    143B           core core::iter::traits::iterator::Iterator::nth
0.0%   0.9%    143B           core core::iter::traits::iterator::Iterator::nth
0.0%   0.9%    132B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.8%    131B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.8%    122B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::inner_write
0.0%   0.7%    110B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.7%    109B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.7%    107B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.7%    106B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_addrs
0.0%   0.7%    104B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_hex
0.0%   0.7%    102B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::flush
0.0%   0.6%     93B           core <core::iter::adapters::skip::Skip<I> as core::iter::traits::iterator::Iterator>::next
0.0%   0.6%     92B        gdbstub <gdbstub::protocol::common::thread_id::IdKind as core::convert::TryFrom<&[u8]>>::try_from
0.0%   0.6%     87B           core <core::slice::iter::SplitMut<T,P> as core::iter::traits::iterator::Iterator>::next
0.0%   0.4%     67B   gdbstub_arch <gdbstub_arch::arm::reg::arm_core::ArmCoreRegs as gdbstub::arch::Registers>::gdb_deserialize
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_registers
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_registers
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_addrs
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::resume
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::set_resume_action_continue
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::clear_resume_actions
0.0%   0.3%     44B  gdbstub_nostd gdbstub_nostd::print_str::print_str
0.0%   0.2%     38B      [Unknown] _start
0.0%   0.0%      6B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>::add_sw_breakpoint
3.6% 100.0% 15.1KiB                .text section size, the file size is 420.9KiB
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     680
.note.ABI-tag           32     708
.note.gnu.build-id      36     740
.dynsym                384     776
.gnu.version            32    1160
.gnu.version_r          64    1192
.gnu.hash               28    1256
.dynstr                215    1284
.rela.dyn              432    1504
.rela.plt               24    1936
.rodata               1005    1968
.eh_frame_hdr          268    2976
.eh_frame             1328    3248
.text                15495    8672
.init                   27   24168
.fini                   13   24196
.plt                    32   24224
.fini_array              8   28352
.init_array              8   28360
.dynamic               432   28368
.got                   120   28800
.got.plt                32   28920
.relro_padding        3816   28952
.tm_clone_table          0   33048
.data                    8   33048
.bss                     1   33056
.comment               184       0
Total                24052
```

### After

```
File  .text    Size          Crate Name
2.5%  68.5% 10.3KiB      [Unknown] main
0.2%   6.3%    975B        gdbstub gdbstub::stub::state_machine::GdbStubStateMachineInner<gdbstub::stub::state_machine::state::Running,T,C>::report_stop
0.1%   2.4%    372B        gdbstub gdbstub::protocol::commands::breakpoint::BasicBreakpoint::from_slice
0.1%   1.9%    295B        gdbstub <gdbstub::protocol::common::thread_id::ThreadId as core::convert::TryFrom<&[u8]>>::try_from
0.1%   1.8%    275B        gdbstub gdbstub::protocol::common::hex::decode_hex_buf
0.1%   1.4%    222B        gdbstub gdbstub::stub::core_impl::resume::<impl gdbstub::stub::core_impl::GdbStubImpl<T,C>>::write_stop_common
0.1%   1.4%    221B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write
0.0%   1.3%    204B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_specific_thread_id
0.0%   0.9%    143B           core core::iter::traits::iterator::Iterator::nth
0.0%   0.9%    143B           core core::iter::traits::iterator::Iterator::nth
0.0%   0.9%    132B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.9%    131B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.8%    122B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::inner_write
0.0%   0.7%    110B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.7%    109B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.7%    107B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.7%    106B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_addrs
0.0%   0.7%    104B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_hex
0.0%   0.7%    102B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::flush
0.0%   0.6%     93B           core <core::iter::adapters::skip::Skip<I> as core::iter::traits::iterator::Iterator>::next
0.0%   0.6%     92B        gdbstub <gdbstub::protocol::common::thread_id::IdKind as core::convert::TryFrom<&[u8]>>::try_from
0.0%   0.6%     87B           core <core::slice::iter::SplitMut<T,P> as core::iter::traits::iterator::Iterator>::next
0.0%   0.4%     67B   gdbstub_arch <gdbstub_arch::arm::reg::arm_core::ArmCoreRegs as gdbstub::arch::Registers>::gdb_deserialize
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_registers
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_registers
0.0%   0.4%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_addrs
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::resume
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::set_resume_action_continue
0.0%   0.3%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::clear_resume_actions
0.0%   0.3%     44B  gdbstub_nostd gdbstub_nostd::print_str::print_str
0.0%   0.2%     38B      [Unknown] _start
0.0%   0.0%      6B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>::add_sw_breakpoint
3.6% 100.0% 15.0KiB                .text section size, the file size is 418.3KiB
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     680
.note.ABI-tag           32     708
.note.gnu.build-id      36     740
.dynsym                384     776
.gnu.version            32    1160
.gnu.version_r          64    1192
.gnu.hash               28    1256
.dynstr                215    1284
.rela.dyn              432    1504
.rela.plt               24    1936
.rodata                989    1968
.eh_frame_hdr          268    2960
.eh_frame             1328    3232
.text                15357    8656
.init                   27   24016
.fini                   13   24044
.plt                    32   24064
.fini_array              8   28192
.init_array              8   28200
.dynamic               432   28208
.got                   120   28640
.got.plt                32   28760
.relro_padding        3976   28792
.tm_clone_table          0   32888
.data                    8   32888
.bss                     1   32896
.comment               184       0
Total                24058
```

</details>
