### PR TITLE
Rework process attaching

### DIFF
--- a/docs/transition_guide.md
+++ b/docs/transition_guide.md
@@ -14,6 +14,10 @@ Previously, if a thread had no `resume_set_action_XXX` methods called on it, the
 
 This new behavior obsoletes the `MultiThreadSchedulerLocking` trait, which has been removed.  If a stub is unable to handle executing a single thread and keeping all others locked, it should return an error in the `resume` method.
 
+#### The `CurrentActivePid` trait no longer exists
+
+The current PID is now tracked in the stub itself, so targets no longer need to implement this.  No changes are needed for the `attach` method.
+
 ## `0.6` -> `0.7`
 
 `0.7` is a fairly minimal "cleanup" release, landing a collection of small breaking changes that collectively improve various ergonomic issues in `gdbstub`'s API.

--- a/examples/armv4t/gdb/extended_mode.rs
+++ b/examples/armv4t/gdb/extended_mode.rs
@@ -100,13 +100,6 @@ impl target::ext::extended_mode::ExtendedMode for Emu {
     ) -> Option<target::ext::extended_mode::ConfigureWorkingDirOps<'_, Self>> {
         Some(self)
     }
-
-    #[inline(always)]
-    fn support_current_active_pid(
-        &mut self,
-    ) -> Option<target::ext::extended_mode::CurrentActivePidOps<'_, Self>> {
-        Some(self)
-    }
 }
 
 impl target::ext::extended_mode::ConfigureAslr for Emu {
@@ -167,11 +160,5 @@ impl target::ext::extended_mode::ConfigureWorkingDir for Emu {
         }
 
         Ok(())
-    }
-}
-
-impl target::ext::extended_mode::CurrentActivePid for Emu {
-    fn current_active_pid(&mut self) -> Result<Pid, Self::Error> {
-        Ok(self.reported_pid)
     }
 }

--- a/src/stub/core_impl.rs
+++ b/src/stub/core_impl.rs
@@ -1,4 +1,5 @@
 use crate::common::IsValidTid;
+use crate::common::Pid;
 use crate::common::Signal;
 use crate::conn::Connection;
 use crate::protocol::commands::Command;
@@ -7,6 +8,7 @@ use crate::protocol::ResponseWriter;
 use crate::protocol::SpecificIdKind;
 use crate::stub::error::InternalError;
 use crate::target::Target;
+use crate::FAKE_PID;
 use crate::SINGLE_THREAD_TID;
 use core::marker::PhantomData;
 
@@ -105,6 +107,11 @@ pub(crate) struct GdbStubImpl<T: Target, C: Connection> {
     _target: PhantomData<T>,
     _connection: PhantomData<C>,
 
+    // The most recently attached PID
+    current_active_pid: Pid,
+
+    // The TID (and when multiprocess support added, PID) used for memory/register
+    // operations
     current_mem_tid: T::Tid,
     current_resume_tid: SpecificIdKind,
     features: ProtocolFeatures,
@@ -123,14 +130,16 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             _target: PhantomData,
             _connection: PhantomData,
 
-            // NOTE: `current_mem_tid` and `current_resume_tid` are never queried prior to being set
-            // by the GDB client (via the 'H' packet), so it's fine to use dummy values here.
+            // NOTE: `current_active_pid`, `current_mem_tid` and `current_resume_tid` are never
+            // queried prior to being set by the GDB client (via the 'H' packet), so
+            // it's fine to use dummy values here.
             //
             // The alternative would be to use `Option`, and while this would be more "correct", it
             // would introduce a _lot_ of noisy and heavy error handling logic all over the place.
             //
             // Plus, even if the GDB client is acting strangely and doesn't overwrite these values,
             // the target will simply return a non-fatal error, which is totally fine.
+            current_active_pid: FAKE_PID,
             current_mem_tid: T::Tid::sentinel(),
             // FUTURE: this should get switched over to T::Tid as well
             current_resume_tid: SpecificIdKind::WithId(SINGLE_THREAD_TID),

--- a/src/stub/core_impl/base.rs
+++ b/src/stub/core_impl/base.rs
@@ -2,7 +2,6 @@ use super::prelude::*;
 use super::DisconnectReason;
 use crate::arch::Arch;
 use crate::arch::Registers;
-use crate::common::Pid;
 use crate::common::Tid;
 use crate::protocol::commands::ext::Base;
 use crate::protocol::IdKind;
@@ -10,7 +9,6 @@ use crate::protocol::SpecificIdKind;
 use crate::protocol::SpecificThreadId;
 use crate::target::ext::base::BaseOps;
 use crate::target::ext::base::ResumeOps;
-use crate::FAKE_PID;
 use crate::SINGLE_THREAD_TID;
 
 impl<T: Target, C: Connection> GdbStubImpl<T, C> {
@@ -38,20 +36,6 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
         Ok(tid)
     }
 
-    pub(crate) fn get_current_pid(
-        &mut self,
-        target: &mut T,
-    ) -> Result<Pid, Error<T::Error, C::Error>> {
-        if let Some(ops) = target
-            .support_extended_mode()
-            .and_then(|ops| ops.support_current_active_pid())
-        {
-            ops.current_active_pid().map_err(Error::TargetError)
-        } else {
-            Ok(FAKE_PID)
-        }
-    }
-
     // Used by `?` and `vAttach` to return a "reasonable" stop reason.
     //
     // This is a bit of an implementation wart, since this is really something
@@ -71,7 +55,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 pid: self
                     .features
                     .multiprocess()
-                    .then_some(SpecificIdKind::WithId(self.get_current_pid(target)?)),
+                    .then_some(SpecificIdKind::WithId(self.current_active_pid)),
                 tid: SpecificIdKind::WithId(tid),
             })?;
         } else {
@@ -402,7 +386,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
             }
             Base::qfThreadInfo(_) => {
                 res.write_str("m")?;
-                let pid = self.get_current_pid(target)?;
+                let pid = self.current_active_pid;
 
                 match target.base_ops() {
                     BaseOps::SingleThread(_) => res.write_specific_thread_id(SpecificThreadId {

--- a/src/stub/core_impl/extended_mode.rs
+++ b/src/stub/core_impl/extended_mode.rs
@@ -3,6 +3,7 @@ use crate::protocol::commands::ext::ExtendedMode;
 use crate::protocol::SpecificIdKind;
 use crate::protocol::SpecificThreadId;
 use crate::target::ext::base::BaseOps;
+use crate::FAKE_PID;
 
 impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     pub(crate) fn handle_extended_mode(
@@ -28,18 +29,16 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 HandlerStatus::Handled
             }
             ExtendedMode::vAttach(cmd) => {
-                if ops.support_current_active_pid().is_none() {
-                    return Err(Error::MissingCurrentActivePidImpl);
+                if let Err(e) = ops.attach(cmd.pid).handle_error() {
+                    self.current_active_pid = FAKE_PID;
+                    return Err(e);
                 }
-
-                ops.attach(cmd.pid).handle_error()?;
+                self.current_active_pid = cmd.pid;
                 self.report_reasonable_stop_reason(res, target)?
             }
-            ExtendedMode::qC(_cmd) if ops.support_current_active_pid().is_some() => {
-                let ops = ops.support_current_active_pid().unwrap();
-
+            ExtendedMode::qC(_cmd) => {
                 res.write_str("QC")?;
-                let pid = ops.current_active_pid().map_err(Error::TargetError)?;
+                let pid = self.current_active_pid;
                 let tid = match target.base_ops() {
                     BaseOps::SingleThread(_) => T::Tid::sentinel(),
                     BaseOps::MultiThread(ops) => {

--- a/src/stub/core_impl/resume.rs
+++ b/src/stub/core_impl/resume.rs
@@ -293,7 +293,6 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     fn write_stop_common(
         &mut self,
         res: &mut ResponseWriter<'_, C>,
-        target: &mut T,
         tid: Option<T::Tid>,
         signal: Signal,
     ) -> Result<(), Error<T::Error, C::Error>> {
@@ -309,7 +308,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
                 pid: self
                     .features
                     .multiprocess()
-                    .then_some(SpecificIdKind::WithId(self.get_current_pid(target)?)),
+                    .then_some(SpecificIdKind::WithId(self.current_active_pid)),
                 tid: SpecificIdKind::WithId(tid.into_fully_qualified_tid()),
             })?;
             res.write_str(";")?;
@@ -365,11 +364,10 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     pub(crate) fn finish_signal_with_thread(
         &mut self,
         res: &mut ResponseWriter<'_, C>,
-        target: &mut T,
         tid: T::Tid,
         sig: Signal,
     ) -> Result<(), Error<T::Error, C::Error>> {
-        self.write_stop_common(res, target, Some(tid), sig)?;
+        self.write_stop_common(res, Some(tid), sig)?;
         Ok(())
     }
 
@@ -390,7 +388,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
         crate::__dead_code_marker!("sw_breakpoint", "stop_reason");
 
-        self.write_stop_common(res, target, Some(tid), Signal::SIGTRAP)?;
+        self.write_stop_common(res, Some(tid), Signal::SIGTRAP)?;
         res.write_str("swbreak:;")?;
         Ok(())
     }
@@ -412,7 +410,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
         crate::__dead_code_marker!("hw_breakpoint", "stop_reason");
 
-        self.write_stop_common(res, target, Some(tid), Signal::SIGTRAP)?;
+        self.write_stop_common(res, Some(tid), Signal::SIGTRAP)?;
         res.write_str("hwbreak:;")?;
         Ok(())
     }
@@ -436,7 +434,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
         crate::__dead_code_marker!("hw_watchpoint", "stop_reason");
 
-        self.write_stop_common(res, target, Some(tid), Signal::SIGTRAP)?;
+        self.write_stop_common(res, Some(tid), Signal::SIGTRAP)?;
 
         res.write_str(match kind {
             WatchKind::Write => "watch:",
@@ -479,7 +477,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
         crate::__dead_code_marker!("reverse_exec", "stop_reason");
 
-        self.write_stop_common(res, target, tid, Signal::SIGTRAP)?;
+        self.write_stop_common(res, tid, Signal::SIGTRAP)?;
 
         res.write_str("replaylog:")?;
         res.write_str(match pos {
@@ -505,7 +503,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
 
         crate::__dead_code_marker!("catch_syscall", "stop_reason");
 
-        self.write_stop_common(res, target, tid, Signal::SIGTRAP)?;
+        self.write_stop_common(res, tid, Signal::SIGTRAP)?;
 
         res.write_str(match position {
             CatchSyscallPosition::Entry => "syscall_entry:",
@@ -520,10 +518,9 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
     pub(crate) fn finish_library(
         &mut self,
         res: &mut ResponseWriter<'_, C>,
-        target: &mut T,
         tid: T::Tid,
     ) -> Result<(), Error<T::Error, C::Error>> {
-        self.write_stop_common(res, target, Some(tid), Signal::SIGTRAP)?;
+        self.write_stop_common(res, Some(tid), Signal::SIGTRAP)?;
         res.write_str("library:;")?;
         Ok(())
     }
@@ -541,13 +538,13 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
         }
 
         crate::__dead_code_marker!("fork_events", "stop_reason");
-        self.write_stop_common(res, target, Some(cur_tid), Signal::SIGTRAP)?;
+        self.write_stop_common(res, Some(cur_tid), Signal::SIGTRAP)?;
         res.write_str("fork:")?;
         res.write_specific_thread_id(SpecificThreadId {
             pid: self
                 .features
                 .multiprocess()
-                .then_some(SpecificIdKind::WithId(self.get_current_pid(target)?)),
+                .then_some(SpecificIdKind::WithId(self.current_active_pid)),
             tid: SpecificIdKind::WithId(new_tid.into_fully_qualified_tid()),
         })?;
         res.write_str(";")?;
@@ -567,13 +564,13 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
         }
 
         crate::__dead_code_marker!("vfork_events", "stop_reason");
-        self.write_stop_common(res, target, Some(cur_tid), Signal::SIGTRAP)?;
+        self.write_stop_common(res, Some(cur_tid), Signal::SIGTRAP)?;
         res.write_str("vfork:")?;
         res.write_specific_thread_id(SpecificThreadId {
             pid: self
                 .features
                 .multiprocess()
-                .then_some(SpecificIdKind::WithId(self.get_current_pid(target)?)),
+                .then_some(SpecificIdKind::WithId(self.current_active_pid)),
             tid: SpecificIdKind::WithId(new_tid.into_fully_qualified_tid()),
         })?;
         res.write_str(";")?;
@@ -592,7 +589,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
         }
 
         crate::__dead_code_marker!("vforkdone_events", "stop_reason");
-        self.write_stop_common(res, target, Some(tid), Signal::SIGTRAP)?;
+        self.write_stop_common(res, Some(tid), Signal::SIGTRAP)?;
         res.write_str("vforkdone:;")?;
         Ok(())
     }
@@ -609,7 +606,7 @@ impl<T: Target, C: Connection> GdbStubImpl<T, C> {
         }
 
         crate::__dead_code_marker!("vforkdone_events", "stop_reason");
-        self.write_stop_common(res, target, None, Signal::SIGTRAP)?;
+        self.write_stop_common(res, None, Signal::SIGTRAP)?;
         res.write_str("exec:")?;
         res.write_hex_buf(path)?;
         res.write_str(";")?;

--- a/src/stub/error.rs
+++ b/src/stub/error.rs
@@ -39,11 +39,6 @@ pub(crate) enum InternalError<T, C> {
 
     // Errors indicative of a error in the user's `Target` implementation / `gdbstub` integration.
     ImplicitSwBreakpoints,
-    // DEVNOTE: this is a temporary workaround for something that can and should
-    // be caught at compile time via IDETs. That said, since i'm not sure when
-    // I'll find the time to cut a breaking release of gdbstub, I'd prefer to
-    // push out this feature as a non-breaking change now.
-    MissingCurrentActivePidImpl,
     MissingToRawId,
     TracepointUnsupportedSourceEnumeration,
     UnsupportedStopReason,
@@ -88,7 +83,6 @@ impl<T, C> InternalError<T, C> {
 
             TargetError(_)
             | ImplicitSwBreakpoints
-            | MissingCurrentActivePidImpl
             | MissingToRawId
             | TracepointUnsupportedSourceEnumeration
             | UnsupportedStopReason => "Target",
@@ -104,7 +98,6 @@ impl<T, C> InternalError<T, C> {
             ClientSentNack
             | Connection(_, _)
             | ImplicitSwBreakpoints
-            | MissingCurrentActivePidImpl
             | MissingToRawId
             | PacketBufferOverflow
             | PacketParse(_)
@@ -208,7 +201,6 @@ where
 
             // Errors indicating an error in the user's `Target` implementation / `gdbstub` integration.
             ImplicitSwBreakpoints => write!(f, "The target has not opted into using implicit software breakpoints. See `Target::guard_rail_implicit_sw_breakpoints` for more information"),
-            MissingCurrentActivePidImpl => write!(f, "GDB client attempted to attach to a new process, but the target has not implemented support for `ExtendedMode::support_current_active_pid`"),
             MissingToRawId => write!(f, "A RegId was used with an API that requires raw register IDs to be available (e.g. `StopReasonReporter::add_reg`) but returned `None` from `to_raw_id()`"),
             TracepointUnsupportedSourceEnumeration => write!(f, "The target doesn't support the gdbstub TracepointSource extension, but attempted to transition to enumerating tracepoint sources"),
             UnsupportedStopReason => write!(f, "{} {}", unsupported_stop_reason!(), SEE_DOCS_FOR_CONTEXT),

--- a/src/stub/state_machine.rs
+++ b/src/stub/state_machine.rs
@@ -490,7 +490,7 @@ where
 
         gdb.i
             .inner
-            .finish_signal_with_thread(&mut res, target, tid, signal)?;
+            .finish_signal_with_thread(&mut res, tid, signal)?;
 
         Ok(StopReasonReporter {
             target,
@@ -681,7 +681,7 @@ where
 
         let mut res = ResponseWriter::from_state(&mut gdb.i.conn, res);
 
-        gdb.i.inner.finish_library(&mut res, target, tid)?;
+        gdb.i.inner.finish_library(&mut res, tid)?;
 
         Ok(StopReasonReporter {
             target,

--- a/src/target/ext/extended_mode.rs
+++ b/src/target/ext/extended_mode.rs
@@ -81,14 +81,6 @@ pub trait ExtendedMode: Target {
 
     /// Attach to a new process with the specified PID.
     ///
-    /// Targets that wish to use `attach` are required to implement
-    /// [`CurrentActivePid`] (via `support_current_active_pid`), as the default
-    /// `gdbstub` behavior of always reporting a Pid of `1` will cause issues
-    /// when attaching to new processes.
-    ///
-    /// _Note:_ In the next API-breaking release of `gdbstub`, this coupling
-    /// will become a compile-time checked invariant.
-    ///
     /// In all-stop mode, all threads in the attached process are stopped; in
     /// non-stop mode, it may be attached without being stopped (if that is
     /// supported by the target).
@@ -166,13 +158,6 @@ pub trait ExtendedMode: Target {
     /// Support for configuring the working directory for spawned processes.
     #[inline(always)]
     fn support_configure_working_dir(&mut self) -> Option<ConfigureWorkingDirOps<'_, Self>> {
-        None
-    }
-
-    /// Support for reporting the current active Pid. Must be implemented in
-    /// order to use `attach`.
-    #[inline(always)]
-    fn support_current_active_pid(&mut self) -> Option<CurrentActivePidOps<'_, Self>> {
         None
     }
 }
@@ -269,24 +254,3 @@ pub trait ConfigureWorkingDir: ExtendedMode {
 }
 
 define_ext!(ConfigureWorkingDirOps, ConfigureWorkingDir);
-
-/// Nested Target extension - Return the current active Pid.
-pub trait CurrentActivePid: ExtendedMode {
-    /// Report the current active Pid.
-    ///
-    /// When implementing gdbstub on a platform that supports multiple
-    /// processes, the active PID needs to match the attached process. Failing
-    /// to do so will cause GDB to fail to attach to the target process.
-    ///
-    /// This should reflect the currently-debugged process which should be
-    /// updated when switching processes after calling
-    /// [`attach()`](ExtendedMode::attach).
-    ///
-    /// _Note:_ `gdbstub` doesn't yet support debugging multiple processes
-    /// _simultaneously_. If this is a feature you're interested in, please
-    /// leave a comment on this [tracking
-    /// issue](https://github.com/daniel5151/gdbstub/issues/124).
-    fn current_active_pid(&mut self) -> Result<Pid, Self::Error>;
-}
-
-define_ext!(CurrentActivePidOps, CurrentActivePid);


### PR DESCRIPTION
This removes the need for the `CurrentActivePid` trait.  As discussed in the issue tracker for #124 (multiprocess support), we're willing to trade a needless `usize` in targets that don't need it for simpler multiprocess support.

### Description

As discussed https://github.com/daniel5151/gdbstub/issues/124#issuecomment-4247677312 and https://github.com/daniel5151/gdbstub/issues/124#issuecomment-4260953693, we're doing away with the `CurrentActivePid` trait.

The total size reported by the bloat checker surprisingly reported a total size decrease of 7 bytes, but less surprisingly the `.text` section increased about 150 bytes, and the relro_padding section decreased slightly more than 150 bytes (likely for 8-byte padding reasons).

### API Stability

- [ ] This PR does not require a breaking API change

This is going into v0.8, which is already breaking the API.

### Checklist

<!-- CI takes care of a lot of things, but there are some things that have yet to be automated -->

- Documentation
  - [x] Ensured any public-facing `rustdoc` formatting looks good (via `cargo doc`)
  - [N/A] (if appropriate) Added feature to "Debugging Features" in README.md
- Validation
  - [N/A] Included output of running `examples/armv4t` with `RUST_LOG=trace` + any relevant GDB output under the "Validation" section below
  - [ ] Included output of running `./example_no_std/check_size.sh` before/after changes under the "Validation" section below
- _If implementing a new protocol extension IDET_
  - [N/A] Included a basic sample implementation in `examples/armv4t`
  - [N/A] IDET can be optimized out (confirmed via `./example_no_std/check_size.sh`)
  - [x] **OR** implementation requires introducing non-optional binary bloat (please elaborate under "Description")
- _If upstreaming an `Arch` implementation_
  - [ N/A] I have tested this code in my project, and to the best of my knowledge, it is working as intended.

### Validation

<details>
<summary>GDB output</summary>

```
$ gdb-multiarch --ex 'target extended-remote 127.0.0.1:9001'
Remote debugging using 127.0.0.1:9001
Reading /test.elf from remote target...
warning: File transfers from remote targets can be slow. Use "set sysroot" to access files locally instead.
Reading /test.elf from remote target...
Reading symbols from target:/test.elf...
Reading /test.elf from remote target...
Reading symbols from target:/test.elf...
main () at test.c:1
1	test.c: No such file or directory.
(gdb) attach 123
A program is being debugged already.  Kill it? (y or n) y
Attaching to program: target:/test.elf, process 123
`target:/test.elf' has disappeared; keeping its symbols.
Reading /test.elf from remote target...
Reading symbols from target:/test.elf...
main () at test.c:1
1	in test.c
(gdb)
```
</details>

<details>
<summary>TRACE log</summary>

```
$ RUST_LOG=trace cargo run --example armv4t
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/examples/armv4t`
loading section ".text" into memory from [0x55550000..0x55550078]
Setting PC to 0x55550000
Waiting for a GDB connection on "127.0.0.1:9001"...
Debugger connected from 127.0.0.1:39588
 TRACE gdbstub::protocol::recv_packet > <-- +
 TRACE gdbstub::protocol::recv_packet > <-- $qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;no-resumed+;memory-tagging+;xmlRegisters=i386#77
 TRACE gdbstub::protocol::response_writer > --> $PacketSize=1000;vContSupported+;multiprocess+;QStartNoAckMode+;fork-events+;vfork-events+;vforkdone-events+;exec-events+;ReverseContinue+;ReverseStep+;QDisableRandomization+;QEnvironmentHexEncoded+;QEnvironmentUnset+;QEnvironmentReset+;QStartupWithShell+;QSetWorkingDir+;swbreak+;hwbreak+;QTBuffer:size+;TracepointSource+;QCatchSyscalls+;qXfer:features:read+;qXfer:memory-map:read+;qXfer:exec-file:read+;qXfer:auxv:read+;qXfer:libraries-svr4:read+;qXfer:libraries:read+#5f
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $vMustReplyEmpty#3a
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("vMustReplyEmpty")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $QStartNoAckMode#b0
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- +
 TRACE gdbstub::protocol::recv_packet     > <-- $!#21
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $Hgp0.0#ad
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:0,ffb#79
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<target version="1.0">
    <architecture>armv4t</architecture>
    <feature name="org.gnu.gdb.arm.core">
        <vector id="padding" type="uint32" count="25"/>

        <reg name="r0" bitsize="32" type="uint32"/>
        <reg name="r1" bitsize="32" type="uint32"/>
        <reg name="r2" bitsize="32" type="uint32"/>
        <reg name="r3" bitsize="32" type="uint32"/>
        <reg name="r4" bitsize="32" type="uint32"/>
        <reg name="r5" bitsize="32" type="uint32"/>
        <reg name="r6" bitsize="32" type="uint32"/>
        <reg name="r7" bitsize="32" type="uint32"/>
        <reg name="r8" bitsize="32" type="uint32"/>
        <reg name="r9" bitsize="32" type="uint32"/>
        <reg name="r10" bitsize="32" type="uint32"/>
        <reg name="r11" bitsize="32" type="uint32"/>
        <reg name="r12" bitsize="32" type="uint32"/>
        <reg name="sp" bitsize="32" type="data_ptr"/>
        <reg name="lr" bitsize="32"/>
        <reg name="pc" bitsize="32" type="code_ptr"/>

        <!--
            For some reason, my version of `gdb-multiarch` doesn't seem to
            respect "regnum", and will not parse this custom target.xml unless I
            manually include the padding bytes in the target description.

            On the bright side, AFAIK, there aren't all that many architectures
            that use padding bytes. Heck, the only reason armv4t uses padding is
            for historical reasons (see comment below).

            Odds are if you're defining your own custom arch, you won't run into
            this issue, since you can just lay out all the registers in the
            correct order.
        -->
        <reg name="padding" type="padding" bitsize="32"/>

        <!-- The CPSR is register 25, rather than register 16, because
        the FPA registers historically were placed between the PC
        and the CPSR in the "g" packet. -->
        <reg name="cpsr" bitsize="32" regnum="25"/>
    </feature>
    <xi:include href="extra.xml"/>
</target>#08
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:80d,ffb#15
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:extra.xml:0,ffb#16
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<feature name="custom-armv4t-extension">
    <!--
        maps to a simple scratch register within the emulator. the GDB
        client can read the register using `p }custom` and set it using
        `set }custom=1337`
    -->
    <reg name="custom" bitsize="32" type="uint32"/>

    <!--
        pseudo-register that return the current time when read.

        notably, i've set up the target to NOT send this register as part of
        the regular register list, which means that GDB will fetch/update
        this register via the 'p' and 'P' packets respectively
    -->
    <reg name="time" bitsize="32" type="uint32"/>

    <!--
        pseudo-register that is always unavailable.

        it is supposed to be reported as 'x'-ed bytes in replies to 'p' packets
        and shown by the GDB client as "<unavailable>".
    -->
    <reg name="unavailable" bitsize="32" type="uint32"/>
</feature>#e9
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:extra.xml:3c5,ffb#b1
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::0,ffb#d8
 TRACE gdbstub::protocol::response_writer > --> $m#b9
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::8,ffb#e0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 TRACE gdbstub::protocol::response_writer > --> $T0;tframes:00#4b
 TRACE gdbstub::protocol::recv_packet     > <-- $qTfV#81
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $?#3f
 TRACE gdbstub::protocol::response_writer > --> $T05thread:p01.01;#06
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qAttached:1#fa
GDB queried if it was attached to a process with PID 1
 TRACE gdbstub::protocol::response_writer > --> $1#31
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:0,ffb#b7
 TRACE gdbstub::protocol::response_writer > --> $m/test.elf#c1
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:9,ffb#c0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:setfs:0#bf
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:6a7573742070726f62696e67,0,1c0#ed
 TRACE gdbstub::protocol::response_writer > --> $F-1,02#32
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:setfs:1#c0
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746573742e656c66,0,0#1e
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746573742e656c66,0,0#1e
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $qSymbol::#5b
 INFO  gdbstub::stub::core_impl           > Unknown command: Ok("qSymbol::")
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:0,ffb#b7
 TRACE gdbstub::protocol::response_writer > --> $m/test.elf#c1
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:1:9,ffb#c0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $Hc-1#09
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qOffsets#4b
 TRACE gdbstub::protocol::response_writer > --> $Text=00;Data=00;Bss=00#94
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000107856341200005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1000000078563412#db
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:libraries-svr4:read::0,ffb#8d
 TRACE gdbstub::protocol::response_writer > --> $m<library-list-svr4 version="1.0" main-lm="0x4">
    <library name="/test.elf" lm="0x8" l_addr="0" l_ld="0" lmid="0x14"/>
</library-list-svr4>#25
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:libraries-svr4:read::8d,ffb#f9
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::0,ffb#d8
 TRACE gdbstub::protocol::response_writer > --> $m#b9
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::8,ffb#e0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746573742e656c66,0,0#1e
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp01.01#cd
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::0,ffb#18
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE memory-map
    PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN"
            "http://sourceware.org/gdb/gdb-memory-map.dtd">
<memory-map>
    <memory type="ram" start="0x00000000" length="0x10000000"/>
    <memory type="ram" start="0x12340000" length="0x10000"/>
    <memory type="flash" start="0x55550000" length="0x10000000">
        <property name="blocksize">0x1000</property>
    </memory>
</memory-map>#f4
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::1bb,ffb#dd
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $qTStatus#49
 TRACE gdbstub::protocol::response_writer > --> $T0;tframes:00#4b
 TRACE gdbstub::protocol::recv_packet     > <-- $qTfP#7b
 TRACE gdbstub::protocol::response_writer > --> $#00
 TRACE gdbstub::protocol::recv_packet     > <-- $vKill;1#6e
GDB sent a kill request for pid Some(1)
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:close:0#b0
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,102fc#1b
 TRACE gdbstub::protocol::response_writer > --> $F0474;UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#3c
 TRACE gdbstub::protocol::recv_packet     > <-- $vAttach;7b#9f
GDB attached to a process with PID 123
 TRACE gdbstub::protocol::response_writer > --> $T05thread:p7b.01;#3e
 TRACE gdbstub::protocol::recv_packet     > <-- $Hgp0.0#ad
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:7b:0,ffb#1f
 TRACE gdbstub::protocol::response_writer > --> $m/test.elf#c1
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:7b:9,ffb#28
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qC#b4
 TRACE gdbstub::protocol::response_writer > --> $QCp7b.01#2c
 TRACE gdbstub::protocol::recv_packet     > <-- $Hgp7b.1#17
 TRACE gdbstub::protocol::response_writer > --> $OK#9a
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:0,ffb#79
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<target version="1.0">
    <architecture>armv4t</architecture>
    <feature name="org.gnu.gdb.arm.core">
        <vector id="padding" type="uint32" count="25"/>

        <reg name="r0" bitsize="32" type="uint32"/>
        <reg name="r1" bitsize="32" type="uint32"/>
        <reg name="r2" bitsize="32" type="uint32"/>
        <reg name="r3" bitsize="32" type="uint32"/>
        <reg name="r4" bitsize="32" type="uint32"/>
        <reg name="r5" bitsize="32" type="uint32"/>
        <reg name="r6" bitsize="32" type="uint32"/>
        <reg name="r7" bitsize="32" type="uint32"/>
        <reg name="r8" bitsize="32" type="uint32"/>
        <reg name="r9" bitsize="32" type="uint32"/>
        <reg name="r10" bitsize="32" type="uint32"/>
        <reg name="r11" bitsize="32" type="uint32"/>
        <reg name="r12" bitsize="32" type="uint32"/>
        <reg name="sp" bitsize="32" type="data_ptr"/>
        <reg name="lr" bitsize="32"/>
        <reg name="pc" bitsize="32" type="code_ptr"/>

        <!--
            For some reason, my version of `gdb-multiarch` doesn't seem to
            respect "regnum", and will not parse this custom target.xml unless I
            manually include the padding bytes in the target description.

            On the bright side, AFAIK, there aren't all that many architectures
            that use padding bytes. Heck, the only reason armv4t uses padding is
            for historical reasons (see comment below).

            Odds are if you're defining your own custom arch, you won't run into
            this issue, since you can just lay out all the registers in the
            correct order.
        -->
        <reg name="padding" type="padding" bitsize="32"/>

        <!-- The CPSR is register 25, rather than register 16, because
        the FPA registers historically were placed between the PC
        and the CPSR in the "g" packet. -->
        <reg name="cpsr" bitsize="32" regnum="25"/>
    </feature>
    <xi:include href="extra.xml"/>
</target>#08
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:target.xml:80d,ffb#15
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:extra.xml:0,ffb#16
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE target SYSTEM "gdb-target.dtd">
<feature name="custom-armv4t-extension">
    <!--
        maps to a simple scratch register within the emulator. the GDB
        client can read the register using `p }custom` and set it using
        `set }custom=1337`
    -->
    <reg name="custom" bitsize="32" type="uint32"/>

    <!--
        pseudo-register that return the current time when read.

        notably, i've set up the target to NOT send this register as part of
        the regular register list, which means that GDB will fetch/update
        this register via the 'p' and 'P' packets respectively
    -->
    <reg name="time" bitsize="32" type="uint32"/>

    <!--
        pseudo-register that is always unavailable.

        it is supposed to be reported as 'x'-ed bytes in replies to 'p' packets
        and shown by the GDB client as "<unavailable>".
    -->
    <reg name="unavailable" bitsize="32" type="uint32"/>
</feature>#e9
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:features:read:extra.xml:3c5,ffb#b1
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:7b:0,ffb#1f
 TRACE gdbstub::protocol::response_writer > --> $m/test.elf#c1
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:exec-file:read:7b:9,ffb#28
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $g#67
 TRACE gdbstub::protocol::response_writer > --> $00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000107856341200005555xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1000000078563412#db
 TRACE gdbstub::protocol::recv_packet     > <-- $qOffsets#4b
 TRACE gdbstub::protocol::response_writer > --> $Text=00;Data=00;Bss=00#94
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:libraries-svr4:read::0,ffb#8d
 TRACE gdbstub::protocol::response_writer > --> $m<library-list-svr4 version="1.0" main-lm="0x4">
    <library name="/test.elf" lm="0x8" l_addr="0" l_ld="0" lmid="0x14"/>
</library-list-svr4>#25
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:libraries-svr4:read::8d,ffb#f9
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::0,ffb#d8
 TRACE gdbstub::protocol::response_writer > --> $m#b9
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:auxv:read::8,ffb#e0
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:setfs:7b#28
 TRACE gdbstub::protocol::response_writer > --> $F0#76
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:open:2f746573742e656c66,0,0#1e
 TRACE gdbstub::protocol::response_writer > --> $F00#a6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,0#ef
UUUUxx#eabstub::protocol::response_writer > --> $F1000;ELF(UU4@4 (
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10540#b9
 TRACE gdbstub::protocol::response_writer > --> $F0230;UxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#d6
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,34#26
 TRACE gdbstub::protocol::response_writer > --> $F1000;UUUUxx#83
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,104b2#e8
 TRACE gdbstub::protocol::response_writer > --> $F02be;.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#e2
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:pread:0,1000,10078#bf
 TRACE gdbstub::protocol::response_writer > --> $F06f8;s
                                                        .UUx�oUUx�ox	o�ty	o�l4UU0i	o�pint%
                                                                                                      :
                                                                                                       ;
                                                                                                        9
                                                                                                         I@�B:
                                                                                                              ;
                                                                                                               9
                                                                                                                I
                                                                                                                 }

                                                                                                                  >
test.c                                                                                                            UUx[�
      UU	gKLgiJ
                      /%ef
                          jtest.cGNU C11 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599] -mfloat-abi=soft -marm -march=armv4t -g -O0 -std=c11mainGCC: (15:9-2019-q4-0ubuntu1) 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]A)aeabi4T  �
                                                                                                                                                                                                                                                                 ����|
UUxB�B
B�UUxUU
�UU
   xUU�xUUxUU+xUU7UUx<xUUIxUUWUUtest.c}a__DATA_START__end__DATA_END____BSS_END__main__TEXT_END____BSS_START____TEXT_START__.symtab.strtab.shstrtab.text.bss.debug_info.debug_abbrev.debug_aranges.debug_line.debug_str.comment.ARM.attributes.debug_frameUxxUUx&xw2�U@D Od_[0��f0HYop�}
�0�P
	Lf��#9d
 TRACE gdbstub::protocol::recv_packet     > <-- $vFile:fstat:0#bc
 TRACE gdbstub::protocol::response_writer > --> $F40;p#26
 TRACE gdbstub::protocol::recv_packet     > <-- $qfThreadInfo#bb
 TRACE gdbstub::protocol::response_writer > --> $mp7b.01#05
 TRACE gdbstub::protocol::recv_packet     > <-- $qsThreadInfo#c8
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::0,ffb#18
 TRACE gdbstub::protocol::response_writer > --> $m<?xml version="1.0"?>
<!DOCTYPE memory-map
    PUBLIC "+//IDN gnu.org//DTD GDB Memory Map V1.0//EN"
            "http://sourceware.org/gdb/gdb-memory-map.dtd">
<memory-map>
    <memory type="ram" start="0x00000000" length="0x10000000"/>
    <memory type="ram" start="0x12340000" length="0x10000"/>
    <memory type="flash" start="0x55550000" length="0x10000000">
        <property name="blocksize">0x1000</property>
    </memory>
</memory-map>#f4
 TRACE gdbstub::protocol::recv_packet     > <-- $qXfer:memory-map:read::1bb,ffb#dd
 TRACE gdbstub::protocol::response_writer > --> $l#6c
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,2#5f
 TRACE gdbstub::protocol::response_writer > --> $04b0#f6
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
 TRACE gdbstub::protocol::recv_packet     > <-- $m55550000,4#61
 TRACE gdbstub::protocol::response_writer > --> $04b02de5#26
```

</details>

<details>
<summary>Before/After `./example_no_std/check_size.sh` output</summary>

### Before

```
File  .text    Size          Crate Name
2.4%  70.3%  8.7KiB      [Unknown] main
0.1%   2.9%    372B        gdbstub gdbstub::protocol::commands::breakpoint::BasicBreakpoint::from_slice
0.1%   2.3%    295B        gdbstub <gdbstub::protocol::common::thread_id::ThreadId as core::convert::TryFrom<&[u8]>>::try_from
0.1%   2.2%    278B        gdbstub gdbstub::protocol::packet::PacketBuf::new
0.1%   2.2%    275B        gdbstub gdbstub::protocol::common::hex::decode_hex_buf
0.1%   1.7%    218B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write
0.1%   1.6%    206B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_specific_thread_id
0.0%   1.1%    143B           core core::iter::traits::iterator::Iterator::nth
0.0%   1.0%    132B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   1.0%    131B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   1.0%    124B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::inner_write
0.0%   0.9%    110B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.9%    109B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.8%    107B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.8%    106B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::flush
0.0%   0.8%    106B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_addrs
0.0%   0.8%    104B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_hex
0.0%   0.7%     93B           core <core::iter::adapters::skip::Skip<I> as core::iter::traits::iterator::Iterator>::next
0.0%   0.7%     92B        gdbstub <gdbstub::protocol::common::thread_id::IdKind as core::convert::TryFrom<&[u8]>>::try_from
0.0%   0.7%     87B           core <core::slice::iter::SplitMut<T,P> as core::iter::traits::iterator::Iterator>::next
0.0%   0.5%     67B   gdbstub_arch <gdbstub_arch::arm::reg::arm_core::ArmCoreRegs as gdbstub::arch::Registers>::gdb_deserialize
0.0%   0.5%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_registers
0.0%   0.5%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_registers
0.0%   0.5%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_addrs
0.0%   0.4%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::resume
0.0%   0.4%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::set_resume_action_continue
0.0%   0.4%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::clear_resume_actions
0.0%   0.3%     44B  gdbstub_nostd gdbstub_nostd::print_str::print_str
0.0%   0.3%     38B      [Unknown] _start
0.0%   0.0%      6B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>::add_sw_breakpoint
3.5% 100.0% 12.4KiB                .text section size, the file size is 357.2KiB
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     680
.note.ABI-tag           32     708
.note.gnu.build-id      36     740
.dynsym                384     776
.gnu.version            32    1160
.gnu.version_r          64    1192
.gnu.hash               28    1256
.dynstr                215    1284
.rela.dyn              432    1504
.rela.plt               24    1936
.rodata                881    1968
.eh_frame_hdr          252    2852
.eh_frame             1256    3104
.text                12737    8464
.init                   27   21204
.fini                   13   21232
.plt                    32   21248
.fini_array              8   25376
.init_array              8   25384
.dynamic               432   25392
.got                   120   25824
.got.plt                32   25944
.relro_padding        2696   25976
.tm_clone_table          0   30072
.data                    8   30072
.bss                     1   30080
.comment               184       0
Total                19962
```

### After

```
File  .text    Size          Crate Name
2.5%  70.7%  8.9KiB      [Unknown] main
0.1%   2.9%    372B        gdbstub gdbstub::protocol::commands::breakpoint::BasicBreakpoint::from_slice
0.1%   2.3%    295B        gdbstub <gdbstub::protocol::common::thread_id::ThreadId as core::convert::TryFrom<&[u8]>>::try_from
0.1%   2.2%    278B        gdbstub gdbstub::protocol::packet::PacketBuf::new
0.1%   2.1%    275B        gdbstub gdbstub::protocol::common::hex::decode_hex_buf
0.1%   1.7%    218B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write
0.1%   1.6%    206B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_specific_thread_id
0.0%   1.1%    143B           core core::iter::traits::iterator::Iterator::nth
0.0%   1.0%    132B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   1.0%    131B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   1.0%    124B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::inner_write
0.0%   0.9%    110B        gdbstub gdbstub::protocol::common::hex::decode_hex
0.0%   0.8%    109B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.8%    107B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_num
0.0%   0.8%    106B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::flush
0.0%   0.8%    106B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_addrs
0.0%   0.8%    104B        gdbstub gdbstub::protocol::response_writer::ResponseWriter<C>::write_hex
0.0%   0.7%     93B           core <core::iter::adapters::skip::Skip<I> as core::iter::traits::iterator::Iterator>::next
0.0%   0.7%     92B        gdbstub <gdbstub::protocol::common::thread_id::IdKind as core::convert::TryFrom<&[u8]>>::try_from
0.0%   0.7%     87B           core <core::slice::iter::SplitMut<T,P> as core::iter::traits::iterator::Iterator>::next
0.0%   0.5%     67B   gdbstub_arch <gdbstub_arch::arm::reg::arm_core::ArmCoreRegs as gdbstub::arch::Registers>::gdb_deserialize
0.0%   0.5%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_registers
0.0%   0.5%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::read_registers
0.0%   0.5%     65B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadBase>::write_addrs
0.0%   0.4%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::resume
0.0%   0.4%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::set_resume_action_continue
0.0%   0.4%     50B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::base::multithread::MultiThreadResume>::clear_resume_actions
0.0%   0.3%     44B  gdbstub_nostd gdbstub_nostd::print_str::print_str
0.0%   0.3%     38B      [Unknown] _start
0.0%   0.0%      6B gdbstub_nostd? <gdbstub_nostd::gdb::DummyTarget as gdbstub::target::ext::breakpoints::SwBreakpoint>::add_sw_breakpoint
3.5% 100.0% 12.6KiB                .text section size, the file size is 355.8KiB
target/release/gdbstub-nostd  :
section               size    addr
.interp                 28     680
.note.ABI-tag           32     708
.note.gnu.build-id      36     740
.dynsym                384     776
.gnu.version            32    1160
.gnu.version_r          64    1192
.gnu.hash               28    1256
.dynstr                215    1284
.rela.dyn              432    1504
.rela.plt               24    1936
.rodata                881    1968
.eh_frame_hdr          252    2852
.eh_frame             1256    3104
.text                12890    8464
.init                   27   21356
.fini                   13   21384
.plt                    32   21408
.fini_array              8   25536
.init_array              8   25544
.dynamic               432   25552
.got                   120   25984
.got.plt                32   26104
.relro_padding        2536   26136
.tm_clone_table          0   30232
.data                    8   30232
.bss                     1   30240
.comment               184       0
Total                19955
```

</details>
